### PR TITLE
adding graceful shutdown rpc call

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -38,6 +38,10 @@ switch (args.call) {
     promise = xuClient.connect(args.host, args.port);
     break;
   }
+  case 'shutdown': {
+    promise = xuClient.shutdown();
+    break;
+  }
   default:
     console.error(`${args.call} not recognized as a call`);
 }

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -11,6 +11,8 @@ class Xud {
   constructor(args) {
     this.logger = Logger.global;
     this.config = new Config(args);
+
+    this.shutdown = this.shutdown.bind(this);
   }
 
   async start() {
@@ -26,16 +28,42 @@ class Xud {
       }
 
       this.p2p = new P2P(this.orderBook);
-      this.rpcServer = new RpcServer(this.orderBook, this.lndClient, this.p2p);
       if (this.config.p2p.listen) {
         this.p2pServer = new P2PServer(this.p2p);
         await this.p2pServer.listen(this.config.p2p.port);
       }
+      this.rpcServer = new RpcServer({
+        orderBook: this.orderBook,
+        lndClient: this.lndClient,
+        p2p: this.p2p,
+        shutdown: this.shutdown,
+      });
       await this.db.init();
       await this.rpcServer.listen(this.config.rpcPort);
     } catch (err) {
       this.logger.error(err);
     }
+  }
+
+  async shutdown() {
+    // ensure we stop listening for new peers before disconnecting from peers
+    if (this.p2pServer) {
+      this.p2pServer.close();
+    }
+    this.p2p.closeAllConnections();
+
+    // TODO: ensure we are not in the middle of executing any trades
+
+    const msg = 'XUD shutdown gracefully';
+    (async () => {
+      // we use an immediately invoked function here to close rpcServer and exit process AFTER the
+      // shutdown method returns a response.
+      await this.rpcServer.close();
+      this.logger.info(msg);
+      process.exit();
+    })();
+
+    return msg;
   }
 }
 

--- a/lib/p2p/P2P.js
+++ b/lib/p2p/P2P.js
@@ -40,6 +40,16 @@ class P2P {
     });
   }
 
+  closeAllConnections() {
+    const peerKeys = Object.keys(this.peers);
+    for (let n = 0; n < peerKeys.length; n += 1) {
+      const peer = this.peers[peerKeys[n]];
+      if (peer) {
+        peer.destroy();
+      }
+    }
+  }
+
   addPeer(peer) {
     assert(!this.peers[peer.remoteAddress], `peer ${peer.remoteAddress} is already connected`);
 

--- a/lib/p2p/P2PServer.js
+++ b/lib/p2p/P2PServer.js
@@ -26,6 +26,13 @@ class P2PServer {
       });
     });
   }
+
+  close() {
+    this.server.close(() => { this.logger.info('P2P server closed'); }).once('error', (err) => {
+      throw (err);
+    });
+    this.logger.info('P2P server stopped listening');
+  }
 }
 
 module.exports = P2PServer;

--- a/lib/rpcserver/RpcMethods.js
+++ b/lib/rpcserver/RpcMethods.js
@@ -1,15 +1,24 @@
+const Logger = require('../Logger');
 const errors = require('../constants/errors');
 
 class RpcMethods {
-  constructor(orderbook, lndClient, p2p) {
+  constructor({
+    orderbook,
+    lndClient,
+    p2p,
+    shutdown,
+  }) {
     this.orderbook = orderbook;
     this.lndClient = lndClient;
     this.p2p = p2p;
+    this.shutdown = shutdown;
+    this.logger = Logger.global;
 
     this.getInfo = this.getInfo.bind(this);
     this.getOrders = this.getOrders.bind(this);
     this.placeOrder = this.placeOrder.bind(this);
     this.connect = this.connect.bind(this);
+    this.shutdown = this.shutdown.bind(this);
   }
 
   getInfo() {
@@ -35,6 +44,13 @@ class RpcMethods {
 
   async connect(params) {
     await this.p2p.connect(params.host, params.port);
+  }
+
+  shutdown() {
+    if (this.shutdown) {
+      return this.shutdown();
+    }
+    return 'nothing to shutdown';
   }
 }
 

--- a/lib/rpcserver/RpcServer.js
+++ b/lib/rpcserver/RpcServer.js
@@ -5,8 +5,18 @@ const RpcMethods = require('./RpcMethods');
 const utils = require('../utils/utils');
 
 class RpcServer {
-  constructor(orderBook, lndClient, p2p) {
-    const rpcMethods = new RpcMethods(orderBook, lndClient, p2p);
+  constructor({
+    orderBook,
+    lndClient,
+    p2p,
+    shutdown,
+  }) {
+    const rpcMethods = new RpcMethods({
+      orderBook,
+      lndClient,
+      p2p,
+      shutdown,
+    });
     this.server = new HttpJsonRpcServer({
       onRequest: (request) => {
         this.logger.debug(`RPC server request: ${JSON.stringify(request)}`);
@@ -26,6 +36,11 @@ class RpcServer {
     assert(port && Number.isInteger(port) && port > 1023 && port < 65536, 'port must be an integer between 1024 and 65535');
     await this.server.listen(port);
     this.logger.info(`RPC server listening on port ${port}`);
+  }
+
+  async close() {
+    await this.server.close();
+    this.logger.info('RPC server stopped listening');
   }
 }
 

--- a/lib/xuclient/XUClient.js
+++ b/lib/xuclient/XUClient.js
@@ -58,25 +58,29 @@ class XUClient {
     });
   }
 
-  async getInfo() {
+  getInfo() {
     return this.callRpc('getInfo');
   }
 
-  async getOrders() {
+  getOrders() {
     return this.callRpc('getOrders');
   }
 
-  async placeOrder(order) {
+  aplaceOrder(order) {
     return this.callRpc('placeOrder', {
       order,
     });
   }
 
-  async connect(host, port) {
+  connect(host, port) {
     return this.callRpc('connect', {
       host,
       port,
     });
+  }
+
+  shutdown() {
+    return this.callRpc('shutdown');
   }
 }
 


### PR DESCRIPTION
The graceful shutdown call disconnects from all peers and stops all servers.
Later, this method can be used to ensure we don't close xud while in the
middle of trades or any other important activity.