### PR TITLE
DB repository layer

### DIFF
--- a/lib/db/DB.js
+++ b/lib/db/DB.js
@@ -1,9 +1,9 @@
-const Sequelize = require('sequelize');
+const fs = require('fs');
+const path = require('path');
 const assert = require('assert');
+const Sequelize = require('sequelize');
 const Logger = require('../Logger');
-const enums = require('../constants/enums');
 
-const { DataTypes } = Sequelize;
 
 class DB {
   constructor(options) {
@@ -12,65 +12,26 @@ class DB {
     assert(typeof options.host === 'string', 'host name must be a string');
     assert(Number.isInteger(options.port) && options.port > 1023 && options.port < 65536, 'port must be an integer between 1024 and 65535');
 
-    this.sequelize = new Sequelize(options);
-    this.define();
-
     this.logger = Logger.global;
+    this.sequelize = new Sequelize(options);
+    this.importModels();
   }
 
-  define() {
-    // P2P
+  importModels() {
+    this.models = {};
+    const modelsFolder = path.join(__dirname, 'models');
+    fs.readdirSync(modelsFolder)
+      .filter(file => (file.indexOf('.') !== 0) && (file !== path.basename(__filename)) && (file.slice(-3) === '.js'))
+      .forEach((file) => {
+        const model = this.sequelize.import(path.join(modelsFolder, file));
+        this.models[model.name] = model;
+      });
 
-    this.Peer = this.sequelize.define('peer', {
-      id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-      nodeKey: { type: DataTypes.STRING, unique: true },
-      ipv4: DataTypes.STRING(15),
-      port: DataTypes.SMALLINT,
-    });
-
-    // DOB
-
-    this.Currency = this.sequelize.define('currency', {
-      id: { type: DataTypes.STRING, primaryKey: true },
-    });
-
-    //
-
-    this.Pair = this.sequelize.define('pair', {
-      id: { type: DataTypes.STRING, primaryKey: true },
-      baseCurrency: { type: DataTypes.STRING, allowNull: false },
-      quoteCurrency: { type: DataTypes.STRING, allowNull: false },
-      swapProtocol: {
-        type: DataTypes.ENUM, values: Object.values(enums.swapProtocols), allowNull: true,
-      },
-    });
-
-    this.Pair.belongsTo(this.Currency, {
-      foreignKey: 'baseCurrency',
-    });
-    this.Pair.belongsTo(this.Currency, {
-      foreignKey: 'quoteCurrency',
-    });
-    const derivePairId = (pair) => {
-      pair.id = `${pair.baseCurrency}/${pair.quoteCurrency}`; // eslint-disable-line no-param-reassign
-    };
-    this.Pair.beforeBulkCreate(pairs => pairs.forEach(pair => derivePairId(pair)));
-    this.Pair.beforeCreate(pair => derivePairId(pair));
-
-    //
-
-    this.Order = this.sequelize.define('order', {
-      id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-      pairId: { type: DataTypes.STRING, allowNull: false },
-      peerId: { type: DataTypes.INTEGER, allowNull: true },
-      quantity: DataTypes.DECIMAL(14, 8),
-      price: DataTypes.DECIMAL(14, 8),
-    });
-    this.Order.belongsTo(this.Pair, {
-      foreignKey: 'pairId',
-    });
-    this.Order.belongsTo(this.Peer, {
-      foreignKey: 'peerId',
+    Object.keys(this.models).forEach((modelName) => {
+      const model = this.models[modelName];
+      if (model.defineAssociations) {
+        model.defineAssociations(this.models);
+      }
     });
   }
 
@@ -85,17 +46,25 @@ class DB {
       throw err;
     }
 
+    const {
+      Peer, Currency, Pair, Order,
+    } = this.models;
+
     // sync schemas with the database
     const options = { logging: this.logger.info };
     await Promise.all([
-      this.Peer.sync(options),
-      this.Currency.sync(options),
+      Peer.sync(options),
+      Currency.sync(options),
     ]);
 
     await Promise.all([
-      this.Pair.sync(options),
-      this.Order.sync(options),
+      Pair.sync(options),
+      Order.sync(options),
     ]);
+  }
+
+  getModels() {
+    return this.models;
   }
 
   close() {

--- a/lib/db/baseRepository.js
+++ b/lib/db/baseRepository.js
@@ -1,0 +1,11 @@
+const baseRepository = exports;
+
+baseRepository.addOne = async (model, payload) => {
+  const result = await model.create(payload);
+  return result.id;
+};
+
+baseRepository.addMany = async (model, payload) => {
+  const results = await model.bulkCreate(payload);
+  return results.map(record => record.id);
+};

--- a/lib/db/models/Currency.js
+++ b/lib/db/models/Currency.js
@@ -1,0 +1,9 @@
+module.exports = (sequelize, DataTypes) => {
+  const Currency = this.Currency = sequelize.define('Currency', {
+    id: { type: DataTypes.STRING, primaryKey: true },
+  }, {
+    tableName: 'currencies',
+  });
+
+  return Currency;
+};

--- a/lib/db/models/Currency.js
+++ b/lib/db/models/Currency.js
@@ -1,5 +1,5 @@
 module.exports = (sequelize, DataTypes) => {
-  const Currency = this.Currency = sequelize.define('Currency', {
+  const Currency = sequelize.define('Currency', {
     id: { type: DataTypes.STRING, primaryKey: true },
   }, {
     tableName: 'currencies',

--- a/lib/db/models/Order.js
+++ b/lib/db/models/Order.js
@@ -1,0 +1,23 @@
+module.exports = (sequelize, DataTypes) => {
+  const Order = sequelize.define('Order', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    pairId: { type: DataTypes.STRING, allowNull: false },
+    peerId: { type: DataTypes.INTEGER, allowNull: true },
+    quantity: DataTypes.DECIMAL(14, 8),
+    price: DataTypes.DECIMAL(14, 8),
+  }, {
+    tableName: 'orders',
+  });
+
+  Order.defineAssociations = (models) => {
+    models.Order.belongsTo(models.Pair, {
+      foreignKey: 'pairId',
+    });
+    models.Order.belongsTo(models.Peer, {
+      foreignKey: 'peerId',
+    });
+  };
+
+  return Order;
+};
+

--- a/lib/db/models/Pair.js
+++ b/lib/db/models/Pair.js
@@ -1,0 +1,33 @@
+const enums = require('../../constants/enums');
+
+module.exports = (sequelize, DataTypes) => {
+  const Pair = sequelize.define('Pair', {
+    id: { type: DataTypes.STRING, primaryKey: true },
+    baseCurrency: { type: DataTypes.STRING, allowNull: false },
+    quoteCurrency: { type: DataTypes.STRING, allowNull: false },
+    swapProtocol: {
+      type: DataTypes.ENUM, values: Object.values(enums.swapProtocols), allowNull: true,
+    },
+  }, {
+    tableName: 'pairs',
+  });
+
+  Pair.defineAssociations = (models) => {
+    models.Pair.belongsTo(models.Currency, {
+      foreignKey: 'baseCurrency',
+    });
+
+    models.Pair.belongsTo(models.Currency, {
+      foreignKey: 'quoteCurrency',
+    });
+
+    const derivePairId = (pair) => {
+      pair.id = `${pair.baseCurrency}/${pair.quoteCurrency}`; // eslint-disable-line no-param-reassign
+    };
+    models.Pair.beforeBulkCreate(pairs => pairs.forEach(pair => derivePairId(pair)));
+    models.Pair.beforeCreate(pair => derivePairId(pair));
+  };
+
+  return Pair;
+};
+

--- a/lib/db/models/Peer.js
+++ b/lib/db/models/Peer.js
@@ -1,0 +1,12 @@
+module.exports = (sequelize, DataTypes) => {
+  const Peer = sequelize.define('Peer', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    nodeKey: { type: DataTypes.STRING, unique: true },
+    ipv4: DataTypes.STRING(15),
+    port: DataTypes.SMALLINT,
+  }, {
+    tableName: 'peers',
+  });
+
+  return Peer;
+};

--- a/lib/orderbook/OrderBook.js
+++ b/lib/orderbook/OrderBook.js
@@ -1,36 +1,23 @@
 const Logger = require('../Logger');
-const { Op } = require('sequelize');
+const OrderBookRepository = require('./OrderBookRepository');
 
 class OrderBook {
   constructor(db) {
-    this.db = db;
     this.logger = Logger.global;
+    this.repository = new OrderBookRepository(db);
 
     this.getOrders = this.getOrders.bind(this);
     this.addOrder = this.addOrder.bind(this);
   }
 
-  async getOrders() {
-    const [bids, asks] = await Promise.all([
-      this.db.Order.findAll({
-        where: { quantity: { [Op.gt]: 0 } },
-        order: [['price', 'DESC']],
-      }),
-      this.db.Order.findAll({
-        where: { quantity: { [Op.lt]: 0 } },
-        order: [['price', 'ASC']],
-      }),
-    ]);
-    return {
-      bids,
-      asks,
-    };
+  getOrders() {
+    return this.repository.getOrders();
   }
 
   async addOrder(order) {
-    const result = await this.db.Order.create(order);
+    const id = await this.repository.addOrder(order);
     this.logger.debug(`added order: ${JSON.stringify(order)}`);
-    return result.id;
+    return id;
   }
 }
 

--- a/lib/orderbook/OrderBookRepository.js
+++ b/lib/orderbook/OrderBookRepository.js
@@ -1,0 +1,45 @@
+const Logger = require('../Logger');
+const { Op } = require('sequelize');
+const baseRepository = require('../db/baseRepository');
+
+class OrderbookRepository {
+  constructor(db) {
+    this.logger = Logger.global;
+    this.models = db.getModels();
+  }
+
+  async getOrders() {
+    const [bids, asks] = await Promise.all([
+      this.models.Order.findAll({
+        where: { quantity: { [Op.gt]: 0 } },
+        order: [['price', 'DESC']],
+      }),
+      this.models.Order.findAll({
+        where: { quantity: { [Op.lt]: 0 } },
+        order: [['price', 'ASC']],
+      }),
+    ]);
+    return {
+      bids,
+      asks,
+    };
+  }
+
+  addOrder(order) {
+    return baseRepository.addOne(this.models.Order, order);
+  }
+
+  addOrders(orders) {
+    return baseRepository.addMany(this.models.Order, orders);
+  }
+
+  addCurrencies(currencies) {
+    return baseRepository.addMany(this.models.Currency, currencies);
+  }
+
+  addPairs(pairs) {
+    return baseRepository.addMany(this.models.Pair, pairs);
+  }
+}
+
+module.exports = OrderbookRepository;

--- a/lib/p2p/P2PRepository.js
+++ b/lib/p2p/P2PRepository.js
@@ -1,0 +1,19 @@
+const Logger = require('../Logger');
+const baseRepository = require('../db/baseRepository');
+
+class P2PRepository {
+  constructor(db) {
+    this.logger = Logger.global;
+    this.models = db.getModels();
+  }
+
+  addPeer(peer) {
+    return baseRepository.addOne(this.models.Peer, peer);
+  }
+
+  addPeers(peers) {
+    return baseRepository.addMany(this.models.Peer, peers);
+  }
+}
+
+module.exports = P2PRepository;


### PR DESCRIPTION
Don't mind the previous commits. I accidentally used an existing remote branch name.

* Seperated DB models to multiple files
* in the end I did used `tableName` for sequelize models, because of how `sequelize.import` works.
* Adding the repository layer. Currently it makes the service layer merely a proxy, but soon it will change. 
* adding `baseRepository` for generic db interfaces. I didn't use class inheritance because it wasn't appropriate since a repository can span multiple models.

