### PR TITLE
improving p2p robustness

### DIFF
--- a/lib/p2p/P2P.js
+++ b/lib/p2p/P2P.js
@@ -2,6 +2,7 @@ const net = require('net');
 const Logger = require('../Logger');
 const assert = require('assert');
 const OrderBook = require('../orderbook/OrderBook');
+const dns = require('dns');
 
 class P2P {
   constructor(orderBook) {
@@ -24,18 +25,27 @@ class P2P {
     }
   }
 
-  async connect(host, port) {
+  connect(host, port) {
     return new Promise((resolve, reject) => {
-      const peer = net.connect({
-        host,
-        port,
-      }, () => {
-        this.addPeer(peer);
-        this.logger.debug(`connected to peer ${peer.remoteAddress}:${peer.remotePort}`);
-        resolve();
-      });
-      peer.once('error', (err) => {
-        reject(err);
+      dns.lookup(host, (dnsErr, ipAddr) => {
+        if (dnsErr) {
+          resolve(`could not resolve ${host}`);
+        }
+        if (this.peers[`${ipAddr}:${port}`]) {
+          resolve(`peer ${host}:${port} is already connected`);
+        }
+        const peer = net.connect({
+          host,
+          port,
+        }, () => {
+          this.addPeer(peer);
+          const msg = `connected to peer ${peer.remoteAddress}:${peer.remotePort}`;
+          this.logger.debug(msg);
+          resolve(msg);
+        });
+        peer.once('error', (err) => {
+          reject(err);
+        });
       });
     });
   }
@@ -53,7 +63,7 @@ class P2P {
   addPeer(peer) {
     assert(!this.peers[peer.remoteAddress], `peer ${peer.remoteAddress} is already connected`);
 
-    this.peers[peer.remoteAddress] = peer;
+    this.peers[`${peer.remoteAddress}:${peer.remotePort}`] = peer;
 
     peer.on('end', () => {
       this.peers[peer.remoteAddress] = null;
@@ -64,20 +74,26 @@ class P2P {
       const dataStr = data.toString();
       this.logger.debug(`received data from ${peer.remoteAddress}: ${dataStr}`);
       const type = dataStr.split(' ', 1)[0];
-      const obj = JSON.parse(dataStr.substring(type.length + 1));
+      try {
+        const obj = JSON.parse(dataStr.substring(type.length + 1));
 
-      switch (type) {
-        case 'neworder':
-          this.orderBook.addOrder(obj);
-          break;
-        default:
-          this.logger.error(`unknown p2p message type: ${type}`);
+        switch (type) {
+          case 'neworder':
+            this.orderBook.addOrder(obj);
+            break;
+          default:
+            // TODO ban peers for repeated bad p2p messages
+            this.logger.warn(`unknown p2p message type: ${type}`);
+        }
+      } catch (err) {
+        // TODO ban peers for repeated bad p2p messages
+        this.logger.warn(`could not parse p2p emssage: ${dataStr}`);
       }
     });
 
     peer.on('error', (err) => {
       this.peers[peer.remoteAddress] = null;
-      this.logger.debug(`error with connection to peer ${peer.remoteAddress}: ${err}`);
+      this.logger.debug(`error with connection to peer ${peer.remoteAddress}:${peer.remotePort} - ${err}`);
     });
   }
 }

--- a/lib/rpcserver/RpcMethods.js
+++ b/lib/rpcserver/RpcMethods.js
@@ -42,8 +42,8 @@ class RpcMethods {
     this.p2p.broadcast('neworder', params);
   }
 
-  async connect(params) {
-    await this.p2p.connect(params.host, params.port);
+  connect(params) {
+    return this.p2p.connect(params.host, params.port);
   }
 
   shutdown() {


### PR DESCRIPTION
This is a set of changes to improve peer to peer functionality.
Connecting to a peer first attempts to resolve the hostname. If a
connection attempt is made to an ip address and port that is already
connected, the connection attempt is aborted. Bad data received from a
peer no longer crashes the daemon, instead a warning is logged.