### PR TITLE
Raiden Integration

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -13,6 +13,13 @@ const argDefinitions = [
   { name: 'price', type: Number },
   { name: 'host', type: String },
   { name: 'port', type: Number },
+  { name: 'target_address', type: String },
+  { name: 'role', type: String },
+  { name: 'sending_amount', type: Number },
+  { name: 'sending_token', type: String },
+  { name: 'receiving_amount', type: Number },
+  { name: 'receiving_token', type: String },
+  { name: 'identifier', type: String },
 ];
 const args = commandLineArgs(argDefinitions);
 
@@ -36,6 +43,17 @@ switch (args.call) {
   }
   case 'connect': {
     promise = xuClient.connect(args.host, args.port);
+    break;
+  }
+  case 'tokenswap': {
+    const payload = {
+      role: args.role,
+      sending_amount: args.sending_amount,
+      sending_token: args.sending_token,
+      receiving_amount: args.receiving_amount,
+      receiving_token: args.receiving_token,
+    };
+    promise = xuClient.tokenSwap(args.target_address, payload, args.identifier);
     break;
   }
   case 'shutdown': {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -48,6 +48,9 @@ class Config {
       pool: { max: 100 },
       operatorsAliases: false,
     };
+    this.raiden = {
+      port: 5001,
+    };
     this.rpcPort = 8886;
     this.swapProtocols = {
       [enums.swapProtocols.LND]: {
@@ -88,6 +91,10 @@ class Config {
 
   isLndEnabled() {
     return this.swapProtocols[enums.swapProtocols.LND].enable;
+  }
+
+  isRaidenEnabled() {
+    return this.swapProtocols[enums.swapProtocols.RAIDEN].enable;
   }
 }
 

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -39,6 +39,7 @@ class Xud {
       this.rpcServer = new RpcServer({
         orderBook: this.orderBook,
         lndClient: this.lndClient,
+        raidenClient: this.raidenClient,
         p2p: this.p2p,
         shutdown: this.shutdown,
       });

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -3,6 +3,7 @@ const Config = require('./Config');
 const DB = require('./db/DB');
 const OrderBook = require('./orderbook/OrderBook');
 const LndClient = require('./lndclient/LndClient');
+const RaidenClient = require('./raidenclient/RaidenClient');
 const RpcServer = require('./rpcserver/RpcServer');
 const P2P = require('./p2p/P2P');
 const P2PServer = require('./p2p/P2PServer');
@@ -25,6 +26,9 @@ class Xud {
 
       if (this.config.isLndEnabled()) {
         this.lndClient = new LndClient(this.config);
+      }
+      if (this.config.isRaidenEnabled()) {
+        this.raidenClient = new RaidenClient(this.config.raiden);
       }
 
       this.p2p = new P2P(this.orderBook);

--- a/lib/raidenclient/RaidenClient.js
+++ b/lib/raidenclient/RaidenClient.js
@@ -1,0 +1,78 @@
+/* eslint-disable camelcase */
+
+const http = require('http');
+const assert = require('assert');
+
+class RaidenClient {
+  constructor(options) {
+    this.port = options.port;
+  }
+
+  sendRequest(endpoint, method, payload) {
+    const options = {
+      hostname: '127.0.0.1',
+      port: this.port,
+      path: `/api/1/${endpoint}`,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    };
+
+    return new Promise((resolve, reject) => {
+      const req = http.request(options, (res) => {
+        resolve(res);
+      });
+
+      req.on('error', (err) => {
+        reject(err);
+      });
+
+      if (payload) {
+        req.write(payload);
+      }
+      req.end();
+    });
+  }
+
+  async tokenSwap(target_address, payload, identifier) {
+    assert(typeof target_address === 'string', 'target_address must be a string');
+
+    let endpoint = `token_swaps/${target_address}`;
+    if (identifier) {
+      endpoint += `/${identifier}`;
+    }
+
+    const res = await this.sendRequest(endpoint, 'PUT', payload);
+    if (res.statusCode === 201) {
+      return 'swap created';
+    } else {
+      throw res.statusMessage;
+    }
+  }
+
+  async getChannelInfo(channel_address) {
+    assert(typeof channel_address === 'string', 'channel_address must be a string');
+
+    const endpoint = `channels/${channel_address}`;
+    const res = await this.sendRequest(endpoint, 'GET');
+
+    res.setEncoding('utf8');
+
+    return new Promise((resolve, reject) => {
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        resolve(JSON.stringify(body));
+      });
+      res.on('error', (err) => {
+        reject(err);
+      });
+    });
+  }
+}
+
+module.exports = RaidenClient;

--- a/lib/raidenclient/RaidenClient.js
+++ b/lib/raidenclient/RaidenClient.js
@@ -2,10 +2,12 @@
 
 const http = require('http');
 const assert = require('assert');
+const Logger = require('../Logger');
 
 class RaidenClient {
   constructor(options) {
     this.port = options.port;
+    this.logger = Logger.global;
   }
 
   sendRequest(endpoint, method, payload) {
@@ -14,11 +16,16 @@ class RaidenClient {
       port: this.port,
       path: `/api/1/${endpoint}`,
       method,
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(payload),
-      },
     };
+
+    let payloadStr;
+    if (payload) {
+      payloadStr = JSON.stringify(payload);
+      options.headers = {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payloadStr),
+      };
+    }
 
     return new Promise((resolve, reject) => {
       const req = http.request(options, (res) => {
@@ -26,11 +33,12 @@ class RaidenClient {
       });
 
       req.on('error', (err) => {
+        this.logger.error(err);
         reject(err);
       });
 
-      if (payload) {
-        req.write(payload);
+      if (payloadStr) {
+        req.write(payloadStr);
       }
       req.end();
     });
@@ -45,10 +53,17 @@ class RaidenClient {
    * @param {string} payload.sending_token - The identifier for the token being sent
    * @param {number} payload.receiving_amount - The amount being received
    * @param {string} payload.receiving_token - The identifier for the token being received
-   * @param {string} identifier
+   * @param {number} identifier -An identification number for this swap
    */
   async tokenSwap(target_address, payload, identifier) {
     assert(typeof target_address === 'string', 'target_address must be a string');
+    assert(typeof identifier === 'number', 'identifier must be a string');
+    assert(typeof payload === 'object', 'object must be an object');
+    assert(typeof payload.role === 'string', 'role must be an object');
+    assert(typeof payload.sending_amount === 'number', 'sending_amount must be a number');
+    assert(typeof payload.sending_token === 'string', 'sending_token must be a string');
+    assert(typeof payload.receiving_amount === 'number', 'receiving_amount must be a number');
+    assert(typeof payload.receiving_token === 'string', 'receiving_token must be a string');
 
     let endpoint = `token_swaps/${target_address}`;
     if (identifier) {
@@ -59,7 +74,7 @@ class RaidenClient {
     if (res.statusCode === 201) {
       return 'swap created';
     } else {
-      throw res.statusMessage;
+      throw new Error(`${res.statusCode}: ${res.statusMessage}`);
     }
   }
 

--- a/lib/raidenclient/RaidenClient.js
+++ b/lib/raidenclient/RaidenClient.js
@@ -36,6 +36,17 @@ class RaidenClient {
     });
   }
 
+  /**
+   * Initiates or completes a Raiden token swap
+   * @param {string} target_address - The address of the intended swap counterparty
+   * @param {Object} payload
+   * @param {string} payload.role - Either "maker" for initiating a swap or "taker" for filling one
+   * @param {number} payload.sending_amount - The amount being sent
+   * @param {string} payload.sending_token - The identifier for the token being sent
+   * @param {number} payload.receiving_amount - The amount being received
+   * @param {string} payload.receiving_token - The identifier for the token being received
+   * @param {string} identifier
+   */
   async tokenSwap(target_address, payload, identifier) {
     assert(typeof target_address === 'string', 'target_address must be a string');
 

--- a/lib/rpcserver/RpcMethods.js
+++ b/lib/rpcserver/RpcMethods.js
@@ -5,11 +5,13 @@ class RpcMethods {
   constructor({
     orderbook,
     lndClient,
+    raidenClient,
     p2p,
     shutdown,
   }) {
     this.orderbook = orderbook;
     this.lndClient = lndClient;
+    this.raidenClient = raidenClient;
     this.p2p = p2p;
     this.shutdown = shutdown;
     this.logger = Logger.global;
@@ -18,6 +20,7 @@ class RpcMethods {
     this.getOrders = this.getOrders.bind(this);
     this.placeOrder = this.placeOrder.bind(this);
     this.connect = this.connect.bind(this);
+    this.tokenswap = this.tokenSwap.bind(this);
     this.shutdown = this.shutdown.bind(this);
   }
 
@@ -44,6 +47,10 @@ class RpcMethods {
 
   async connect(params) {
     await this.p2p.connect(params.host, params.port);
+  }
+
+  tokenSwap(params) {
+    return this.raidenClient.tokenSwap(params.target_address, params.payload, params.identifier);
   }
 
   shutdown() {

--- a/lib/rpcserver/RpcMethods.js
+++ b/lib/rpcserver/RpcMethods.js
@@ -20,7 +20,7 @@ class RpcMethods {
     this.getOrders = this.getOrders.bind(this);
     this.placeOrder = this.placeOrder.bind(this);
     this.connect = this.connect.bind(this);
-    this.tokenswap = this.tokenSwap.bind(this);
+    this.tokenSwap = this.tokenSwap.bind(this);
     this.shutdown = this.shutdown.bind(this);
   }
 

--- a/lib/rpcserver/RpcServer.js
+++ b/lib/rpcserver/RpcServer.js
@@ -8,12 +8,14 @@ class RpcServer {
   constructor({
     orderBook,
     lndClient,
+    raidenClient,
     p2p,
     shutdown,
   }) {
     const rpcMethods = new RpcMethods({
       orderBook,
       lndClient,
+      raidenClient,
       p2p,
       shutdown,
     });

--- a/lib/xuclient/XUClient.js
+++ b/lib/xuclient/XUClient.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 const http = require('http');
 const assert = require('assert');
 
@@ -76,6 +78,14 @@ class XUClient {
     return this.callRpc('connect', {
       host,
       port,
+    });
+  }
+
+  tokenSwap(target_address, payload, identifier) {
+    return this.callRpc('tokenSwap', {
+      target_address,
+      payload,
+      identifier,
     });
   }
 


### PR DESCRIPTION
This adds basic integration with the Raiden REST API and specifically the `token_swaps` endpoint which is used to swap one token for another. I've tested this manually and verified that the calls work and get back the successful response from Raiden, but the channels aren't being updated as expected. This is something we can revisit when Raiden is in a more stable state, but for now I thought we could merge the framework for interacting with it.

The command line `tokenswap` call is probably only temporary for demo/testing purposes, as in the future this will be called as part of an order being matched and not manually.