### PR TITLE
Standardizing default rpcProtoPath

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -9,26 +9,24 @@ class Config {
   constructor(args) {
     this.args = args || null;
     const platform = os.platform();
+    let lndDatadir;
     switch (platform) {
       case 'win32': { // windows
         const homeDir = process.env.LOCALAPPDATA;
         this.xuDir = `${homeDir}/Xud/`;
-        this.lndDir = `${homeDir}/Lnd/`; // default lnd directory location
-        this.lndRpcProto = '../lndrpc.proto';
+        lndDatadir = `${homeDir}/Lnd/`; // default lnd directory location
         break;
       }
       case 'darwin': { // mac
         const homeDir = process.env.HOME;
         this.xuDir = `${homeDir}/.xud/`;
-        this.lndDir = `${homeDir}/Library/Application Support/Lnd/`;
-        this.lndRpcProto = 'lndrpc.proto';
+        lndDatadir = `${homeDir}/Library/Application Support/Lnd/`;
         break;
       }
       default: { // linux
         const homeDir = process.env.HOME;
         this.xuDir = `${homeDir}/.xud/`;
-        this.lndDir = `${homeDir}/.lnd/`;
-        this.lndRpcProto = 'lndrpc.proto';
+        lndDatadir = `${homeDir}/.lnd/`;
         break;
       }
     }
@@ -56,6 +54,10 @@ class Config {
       port: 5001,
     };
     this.rpcPort = 8886;
+    this.lnd = {
+      datadir: lndDatadir,
+      rpcProtoPath: 'lndrpc.proto',
+    };
     this.swapProtocols = {
       [enums.swapProtocols.LND]: {
         enable: true,

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -32,7 +32,7 @@ class Xud {
       this.db = new DB(this.config.db);
 
       if (this.config.isLndEnabled()) {
-        this.lndClient = new LndClient(this.config);
+        this.lndClient = new LndClient(this.config.lnd);
       }
       if (this.config.isRaidenEnabled()) {
         this.raidenClient = new RaidenClient(this.config.raiden);

--- a/lib/lndclient/LndClient.js
+++ b/lib/lndclient/LndClient.js
@@ -3,24 +3,24 @@
 const grpc = require('grpc');
 const fs = require('fs');
 const assert = require('assert');
-const Config = require('../Config');
 
 /** A class representing a client to interact with a running lnd instance. */
 class LndClient {
   /**
    * Create an lnd client.
-   * @param {Config} config - The XUD configuration
+   * @param {Object} options - The lnd configuration
    */
-  constructor(config) {
-    assert(config instanceof Config, 'config must be an instance of Config');
-    const { lndDir, lndRpcProto } = config;
+  constructor(options) {
+    const { datadir, rpcProtoPath } = options;
+    assert(typeof options.datadir === 'string', 'datadir must be a string');
+    assert(typeof options.rpcProtoPath === 'string', 'rpcProtoPath must be a string');
 
-    const lndCert = fs.readFileSync(`${lndDir}tls.cert`);
+    const lndCert = fs.readFileSync(`${datadir}tls.cert`);
     const credentials = grpc.credentials.createSsl(lndCert);
-    const lnrpcDescriptor = grpc.load(lndRpcProto);
+    const lnrpcDescriptor = grpc.load(rpcProtoPath);
     this.lightning = new lnrpcDescriptor.lnrpc.Lightning('127.0.0.1:10009', credentials);
 
-    const adminMacaroon = fs.readFileSync(`${lndDir}admin.macaroon`);
+    const adminMacaroon = fs.readFileSync(`${datadir}admin.macaroon`);
     this.meta = new grpc.Metadata();
     this.meta.add('macaroon', adminMacaroon.toString('hex'));
   }


### PR DESCRIPTION
This fixes the default path for the rpc.proto file included in the
source on windows, and also restructures the config parameters related
to lnd.