### PR TITLE
utils - deepMerge

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const toml = require('toml');
-const util = require('./utils/utils');
+const utils = require('./utils/utils');
 const enums = require('./constants/enums');
 
 
@@ -74,8 +74,8 @@ class Config {
       try {
         const props = toml.parse(configText);
 
-        // copy parsed json properties from config file to this config object
-        util.copyObject(props, this);
+        // merge parsed json properties from config file to this config object
+        utils.deepMerge(this, props);
       } catch (e) {
         throw new Error(`Parsing error on line ${e.line}, column ${e.column
         }: ${e.message}`);
@@ -84,7 +84,7 @@ class Config {
 
     if (this.args) {
       // override our config file with command line arguments
-      util.copyObject(this.args, this);
+      utils.deepMerge(this, this.args);
       this.args = null;
     }
   }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,27 +1,41 @@
 const utils = exports;
 
 /**
- * Copy the defined properties of one object to another, overriding any
- * existing properties. Object properties are copied recursively.
- * @param {object} source - The source object to copy from.
- * @param {object} dest - The destination object to copy to.
+ * isObject
+ * @returns {boolean}
  */
-utils.copyObject = (source, dest) => {
-  const sourceKeys = Object.keys(source);
-  for (let n = 0; n < sourceKeys.length; n += 1) {
-    const key = sourceKeys[n];
-    if (typeof dest[key] === 'object' && !Array.isArray(dest[key])) {
-      utils.copyObject(source[key], dest[key]);
-    } else if (source[key] !== undefined) {
-      dest[key] = source[key]; // eslint-disable-line no-param-reassign
-    }
-  }
-};
+function isObject(val) {
+  return (val && typeof val === 'object' && !Array.isArray(val));
+}
 
 /** Get the current date in the LocaleString format.
  * @returns {string}
-*/
+ */
 utils.getTsString = () => (new Date()).toLocaleString();
+
+/**
+ * recursively merge properties from different sources into a target object, overriding any
+ * existing properties.
+ * @param {object} target - The destination object to merge into.
+ * @param {object} sources - The sources objects to copy from.
+ */
+utils.deepMerge = (target, ...sources) => {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        utils.deepMerge(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    });
+  }
+
+  return utils.deepMerge(target, ...sources);
+};
 
 /** Get all methods from an object whose name doesn't start with an underscore.
  * @returns {object}

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -14,7 +14,7 @@ function isObject(val) {
 utils.getTsString = () => (new Date()).toLocaleString();
 
 /**
- * recursively merge properties from different sources into a target object, overriding any
+ * Recursively merge properties from different sources into a target object, overriding any
  * existing properties.
  * @param {object} target - The destination object to merge into.
  * @param {object} sources - The sources objects to copy from.
@@ -28,7 +28,7 @@ utils.deepMerge = (target, ...sources) => {
       if (isObject(source[key])) {
         if (!target[key]) Object.assign(target, { [key]: {} });
         utils.deepMerge(target[key], source[key]);
-      } else {
+      } else if (source[key] !== undefined) {
         Object.assign(target, { [key]: source[key] });
       }
     });


### PR DESCRIPTION
`utils.copyObject` had some issues with null & string properties.
Trying to fix it made the code too clumsy, so I used a different implementation instead.

I change its name to `deepMerge` because that's the standard name for this kind of util.