### PR TITLE
lnd/raiden config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ host = "localhost"
 listen = true
 port = 8885
 
-[swapProtocols.LND]
+[lnd]
 disable = false
 rpcProtoPath = "lndrpc.proto"
 
-[swapProtocols.RAIDEN]
+[raiden]
 disable = false
 port = 5001
 ```

--- a/README.md
+++ b/README.md
@@ -76,4 +76,12 @@ host = "localhost"
 [p2p]
 listen = true
 port = 8885
+
+[swapProtocols.LND]
+disable = false
+rpcProtoPath = "lndrpc.proto"
+
+[swapProtocols.RAIDEN]
+disable = false
+port = 5001
 ```

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -2,8 +2,6 @@ const fs = require('fs');
 const os = require('os');
 const toml = require('toml');
 const util = require('./utils/utils');
-const enums = require('./constants/enums');
-
 
 class Config {
   constructor(args) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -88,14 +88,6 @@ class Config {
   get(key) {
     return this.props[key];
   }
-
-  isLndEnabled() {
-    return this.swapProtocols[enums.swapProtocols.LND].enable;
-  }
-
-  isRaidenEnabled() {
-    return this.swapProtocols[enums.swapProtocols.RAIDEN].enable;
-  }
 }
 
 module.exports = Config;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -51,16 +51,14 @@ class Config {
       database: 'xud_test',
     };
     this.rpcPort = 8886;
-    this.swapProtocols = {
-      [enums.swapProtocols.LND]: {
-        disable: false,
-        datadir: lndDatadir,
-        rpcProtoPath: 'lndrpc.proto',
-      },
-      [enums.swapProtocols.RAIDEN]: {
-        disable: false,
-        port: 5001,
-      },
+    this.lnd = {
+      disable: false,
+      datadir: lndDatadir,
+      rpcProtoPath: 'lndrpc.proto',
+    };
+    this.raiden = {
+      disable: false,
+      port: 5001,
     };
   }
 

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -50,20 +50,16 @@ class Config {
       ...this.db,
       database: 'xud_test',
     };
-    this.raiden = {
-      port: 5001,
-    };
     this.rpcPort = 8886;
-    this.lnd = {
-      datadir: lndDatadir,
-      rpcProtoPath: 'lndrpc.proto',
-    };
     this.swapProtocols = {
       [enums.swapProtocols.LND]: {
-        enable: true,
+        disable: false,
+        datadir: lndDatadir,
+        rpcProtoPath: 'lndrpc.proto',
       },
       [enums.swapProtocols.RAIDEN]: {
-        enable: true,
+        disable: false,
+        port: 5001,
       },
     };
   }

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -30,14 +30,8 @@ class Xud {
 
     try {
       this.db = new DB(this.config.db);
-
-      if (this.config.isLndEnabled()) {
-        this.lndClient = new LndClient(this.config.lnd);
-      }
-      if (this.config.isRaidenEnabled()) {
-        this.raidenClient = new RaidenClient(this.config.raiden);
-      }
-
+      this.lndClient = new LndClient(this.config.swapProtocols.LND);
+      this.raidenClient = new RaidenClient(this.config.swapProtocols.RAIDEN);
       this.p2p = new P2P();
       if (this.config.p2p.listen) {
         this.p2pServer = new P2PServer(this.p2p);

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -30,8 +30,8 @@ class Xud {
 
     try {
       this.db = new DB(this.config.db);
-      this.lndClient = new LndClient(this.config.swapProtocols.LND);
-      this.raidenClient = new RaidenClient(this.config.swapProtocols.RAIDEN);
+      this.lndClient = new LndClient(this.config.lnd);
+      this.raidenClient = new RaidenClient(this.config.raiden);
       this.p2p = new P2P();
       if (this.config.p2p.listen) {
         this.p2pServer = new P2PServer(this.p2p);

--- a/lib/constants/enums.js
+++ b/lib/constants/enums.js
@@ -1,10 +1,5 @@
 const enums = exports;
 
-enums.swapProtocols = {
-  LND: 'LND',
-  RAIDEN: 'RAIDEN',
-};
-
 enums.orderingDirections = {
   DESC: 'DESC',
   ASC: 'ASC',

--- a/lib/constants/errors.js
+++ b/lib/constants/errors.js
@@ -1,6 +1,0 @@
-const errors = exports;
-
-errors.LND_NOT_CONNECTED = {
-  message: 'not connected to lnd',
-  code: -10,
-};

--- a/lib/lndclient/LndClient.js
+++ b/lib/lndclient/LndClient.js
@@ -3,6 +3,9 @@
 const grpc = require('grpc');
 const fs = require('fs');
 const assert = require('assert');
+const Logger = require('../Logger');
+const errors = require('./errors');
+
 
 /** A class representing a client to interact with a running lnd instance. */
 class LndClient {
@@ -11,18 +14,35 @@ class LndClient {
    * @param {Object} options - The lnd configuration
    */
   constructor(options) {
-    const { datadir, rpcProtoPath } = options;
-    assert(typeof options.datadir === 'string', 'datadir must be a string');
-    assert(typeof options.rpcProtoPath === 'string', 'rpcProtoPath must be a string');
+    const { disable, datadir, rpcProtoPath } = options;
+    assert(typeof disable === 'boolean', 'disable must be a boolean');
+    assert(typeof datadir === 'string', 'datadir must be a string');
+    assert(typeof rpcProtoPath === 'string', 'rpcProtoPath must be a string');
 
-    const lndCert = fs.readFileSync(`${datadir}tls.cert`);
-    const credentials = grpc.credentials.createSsl(lndCert);
-    const lnrpcDescriptor = grpc.load(rpcProtoPath);
-    this.lightning = new lnrpcDescriptor.lnrpc.Lightning('127.0.0.1:10009', credentials);
+    this.logger = Logger.global;
+    if (disable) {
+      this.setStatus(LndClient.statuses.DISABLED);
+    } else {
+      const lndCert = fs.readFileSync(`${datadir}tls.cert`);
+      const credentials = grpc.credentials.createSsl(lndCert);
+      const lnrpcDescriptor = grpc.load(rpcProtoPath);
+      this.lightning = new lnrpcDescriptor.lnrpc.Lightning('127.0.0.1:10009', credentials);
 
-    const adminMacaroon = fs.readFileSync(`${datadir}admin.macaroon`);
-    this.meta = new grpc.Metadata();
-    this.meta.add('macaroon', adminMacaroon.toString('hex'));
+      const adminMacaroon = fs.readFileSync(`${datadir}admin.macaroon`);
+      this.meta = new grpc.Metadata();
+      this.meta.add('macaroon', adminMacaroon.toString('hex'));
+
+      this.setStatus(LndClient.statuses.CONNECTION_VERIFIED); // TODO: verify connection
+    }
+  }
+
+  isDisabled() {
+    return this.status === LndClient.statuses.DISABLED;
+  }
+
+  setStatus(val) {
+    this.logger.info(`lndClient status: ${val}`);
+    this.status = val;
   }
 
   /**
@@ -32,6 +52,10 @@ class LndClient {
    */
   getInfo() {
     return new Promise((resolve, reject) => {
+      if (this.isDisabled()) {
+        reject(errors.LND_IS_DISABLED);
+        return;
+      }
       this.lightning.getInfo({}, this.meta, (err, response) => {
         if (err) {
           reject(err.details);
@@ -48,6 +72,10 @@ class LndClient {
    */
   addInvoice(value) {
     return new Promise((resolve, reject) => {
+      if (this.isDisabled()) {
+        reject(errors.LND_IS_DISABLED);
+        return;
+      }
       this.lightning.addInvoice({
         value,
         memo: 'XU',
@@ -67,6 +95,10 @@ class LndClient {
    */
   payInvoice(payment_request) {
     return new Promise((resolve, reject) => {
+      if (this.isDisabled()) {
+        reject(errors.LND_IS_DISABLED);
+        return;
+      }
       this.lightning.sendPaymentSync({ payment_request }, this.meta, (err, response) => {
         if (err) {
           reject(err.details);
@@ -77,5 +109,10 @@ class LndClient {
     });
   }
 }
+
+LndClient.statuses = {
+  DISABLED: 'DISABLED',
+  CONNECTION_VERIFIED: 'CONNECTION_VERIFIED', // assuming connection does not remain open
+};
 
 module.exports = LndClient;

--- a/lib/lndclient/errors.js
+++ b/lib/lndclient/errors.js
@@ -1,0 +1,6 @@
+const errors = exports;
+
+errors.LND_IS_DISABLED = {
+  message: 'lnd is disabled',
+  code: 100,
+};

--- a/lib/raidenclient/RaidenClient.js
+++ b/lib/raidenclient/RaidenClient.js
@@ -2,15 +2,35 @@
 
 const http = require('http');
 const assert = require('assert');
+const errors = require('./errors');
 const Logger = require('../Logger');
 
 class RaidenClient {
   constructor(options) {
-    this.port = options.port;
+    const { disable, port } = options;
+    assert(typeof disable === 'boolean', 'disable must be a boolean');
+    assert(typeof port === 'number', 'port must be a number');
+
     this.logger = Logger.global;
+    this.port = port;
+    if (disable) {
+      this.setStatus(RaidenClient.statuses.DISABLED);
+    }
+  }
+
+  setStatus(val) {
+    this.logger.info(`raidenClient status: ${val}`);
+    this.status = val;
+  }
+
+  isDisabled() {
+    return this.status === RaidenClient.statuses.DISABLED;
   }
 
   sendRequest(endpoint, method, payload) {
+    if (this.isDisabled()) {
+      throw errors.RAIDEN_IS_DISABLED;
+    }
     const options = {
       hostname: '127.0.0.1',
       port: this.port,
@@ -100,5 +120,10 @@ class RaidenClient {
     });
   }
 }
+
+RaidenClient.statuses = {
+  DISABLED: 'DISABLED',
+  CONNECTION_VERIFIED: 'CONNECTION_VERIFIED', // assuming connection does not remain open
+};
 
 module.exports = RaidenClient;

--- a/lib/raidenclient/errors.js
+++ b/lib/raidenclient/errors.js
@@ -1,0 +1,6 @@
+const errors = exports;
+
+errors.RAIDEN_IS_DISABLED = {
+  message: 'raiden is disabled',
+  code: 200,
+};

--- a/lib/rpcserver/RpcMethods.js
+++ b/lib/rpcserver/RpcMethods.js
@@ -1,5 +1,4 @@
 const Logger = require('../Logger');
-const errors = require('../constants/errors');
 
 /** Class containing the available RPC methods for Exchange Union */
 class RpcMethods {
@@ -31,11 +30,7 @@ class RpcMethods {
    * @returns {object}
    */
   getInfo() {
-    if (this.lndClient) {
-      return this.lndClient.getInfo();
-    } else {
-      return errors.LND_NOT_CONNECTED;
-    }
+    return this.lndClient.getInfo();
   }
 
   /**


### PR DESCRIPTION
* removed `swapProtocols` object
* changed `enable` to `disable`
* handling the `status` state within lnd/raiden client. the previous approach of not constructing an object was not good. state can change during object's lifetime. error handling was more difficult
* splitting the `errors` constant files to different domain. He should contain common errors only, which none exists at the moment, so he was deleted for now

Open task: make `http-jsonrpc-server` return the full object returned/throwed from the method. if throwed, http status code should be set by the `code` property. 

fixes #20 
fixes #23 


