### PR TITLE
check if lnd tls.cert file exists

### DIFF
--- a/lib/lndclient/LndClient.js
+++ b/lib/lndclient/LndClient.js
@@ -22,6 +22,9 @@ class LndClient {
     this.logger = Logger.global;
     if (disable) {
       this.setStatus(LndClient.statuses.DISABLED);
+    } else if (!fs.existsSync(`${datadir}tls.cert`)) {
+      this.logger.error('could not find tls.cert in the lnd datadir, is lnd installed?');
+      this.setStatus(LndClient.statuses.DISABLED);
     } else {
       const lndCert = fs.readFileSync(`${datadir}tls.cert`);
       const credentials = grpc.credentials.createSsl(lndCert);


### PR DESCRIPTION
This improves the error handling around issues #20 and #27 when lnd is not installed.