### PR TITLE
config and cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Xud uses [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/). You
 
 ## Command-Line Interface
 
-Spawning a new `xud` process
+Spawn a new `xud` process
 
 ```bash
 ~/xud/bin $ ./xud 
@@ -47,13 +47,13 @@ Options:
   -p, --p2p.port                                        [number] [default: 8885] 
 ```
 
-Interacting with an `xud` process, identified by his rpc port
+Interact with an `xud` process, identified by his `rpc` port
 ```bash
 ~/xud/bin $ ./xucli --help
 xucli [command]
 
 Commands:
-  xucli connect <p2p_host> [p2p_port]            connect to an xu node
+  xucli connect <host> [port]                    connect to an xu node
   xucli getinfo                                  get general info from the xud node
   xucli getorders                                get orders from the orderbook
   xucli getpairs                                 get orderbook's available pairs

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Interacting with an `xud` process, identified by his rpc port
 xucli [command]
 
 Commands:
-  xucli connect <p2p.host> [p2p.port]           connect to an xu node
-  xucli getinfo                                 get general info from the xud node
-  xucli getorders                               get orders from the orderbook
-  xucli getpairs                                get orderbook's available pairs
-  xucli placeorder <pairId> <price> <quantity>  place an order
-  xucli shutdown                                gracefully shutdown the xud node
-  xucli tokenswap <identifier> <role>           perform a raiden token swap
+  xucli connect <p2p_host> [p2p_port]            connect to an xu node
+  xucli getinfo                                  get general info from the xud node
+  xucli getorders                                get orders from the orderbook
+  xucli getpairs                                 get orderbook's available pairs
+  xucli placeorder <pair_id> <price> <quantity>  place an order
+  xucli shutdown                                 gracefully shutdown the xud node
+  xucli tokenswap <identifier> <role>            perform a raiden token swap
   <sending_amount> <sending_token>
   <receiving_amount> <receiving_token>
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,22 @@ Xud uses [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/). You
 
 ## Command-Line Interface
 
+Spawning a new `xud` process
+
+```bash
+~/xud/bin $ ./xud 
+Options:
+  -r, --rpc.port                                        [number] [default: 8886]
+  -p, --p2p.port                                        [number] [default: 8885] 
+```
+
+Interacting with an `xud` process, identified by his rpc port
 ```bash
 ~/xud/bin $ ./xucli --help
 xucli [command]
 
 Commands:
-  xucli connect <host> [port]                   connect to an xu node
+  xucli connect <p2p.host> [p2p.port]           connect to an xu node
   xucli getinfo                                 get general info from the xud node
   xucli getorders                               get orders from the orderbook
   xucli getpairs                                get orderbook's available pairs
@@ -56,7 +66,7 @@ Commands:
 Options:
   --version      Show version number                                   [boolean]
   --help         Show help                                             [boolean]
-  -r, --rpcport                                         [number] [default: 8886]
+  -r, --rpc.port                                        [number] [default: 8886]
 ```
 
 ## Configuration
@@ -64,12 +74,12 @@ Options:
 The configuration file uses [TOML](https://github.com/toml-lang/toml) and by default is located at  `~/.xud/xud.conf` on Linux or `AppData\Local\Xud\xud.conf` on Windows. Default settings which can be overridden are shown below.
 
 ```toml
-lndDir = "~/.lnd"
-rpcPort = 8886
+[rpc]
+port = 8886
 
 [db]
 username = "xud"
-password = ""
+password = null
 database = "xud"
 port = 3306
 host = "localhost"

--- a/bin/xucli
+++ b/bin/xucli
@@ -2,9 +2,9 @@
 /* eslint-disable no-unused-expressions */
 
 require('yargs')
-  .number('rpcport')
-  .alias('r', 'rpcport')
-  .default('rpcport', 8886)
+  .number('rpc.port')
+  .alias('r', 'rpc.port')
+  .default('rpc.port', 8886)
   .commandDir('../lib/cli/commands')
   .help()
   .argv; // we must read the argv property for the command line args to initialize properly

--- a/bin/xud
+++ b/bin/xud
@@ -2,12 +2,14 @@
 
 const Xud = require('../lib/Xud');
 const { argv } = require('yargs')
-  .number(['p2p.port', 'rpcPort', 'db.port', 'db.pool.max', 'raiden.port'])
+  .number(['p2p.port', 'rpc.port', 'db.port', 'raiden.port'])
   .boolean(['db.operatorsAliases', 'p2p.listen'])
   .default({
     'db.operatorsAliases': undefined,
     'p2p.listen': undefined,
-  });
+  })
+  .alias('r', 'rpc.port')
+  .alias('p', 'p2p.port');
 
 // delete non-config keys from argv
 delete argv._;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -47,7 +47,9 @@ class Config {
       ...this.db,
       database: 'xud_test',
     };
-    this.rpcPort = 8886;
+    this.rpc = {
+      port: 8886,
+    };
     this.lnd = {
       disable: false,
       datadir: lndDatadir,

--- a/lib/Xud.js
+++ b/lib/Xud.js
@@ -51,7 +51,7 @@ class Xud {
         p2p: this.p2p,
         shutdown: this.shutdown,
       });
-      await this.rpcServer.listen(this.config.rpcPort);
+      await this.rpcServer.listen(this.config.rpc.port);
     } catch (err) {
       this.logger.error(err);
     }

--- a/lib/cli/command.js
+++ b/lib/cli/command.js
@@ -7,7 +7,7 @@ const XUClient = require('../xuclient/XUClient');
  * @param {function} callback - The callback function to perform a command
  */
 module.exports = (argv, callback) => {
-  const xuClient = new XUClient(argv.rpcport);
+  const xuClient = new XUClient(argv.rpc.port);
 
   const promise = callback(xuClient, argv);
 

--- a/lib/cli/commands/connect.js
+++ b/lib/cli/commands/connect.js
@@ -1,21 +1,21 @@
 const command = require('../command');
 
-exports.command = 'connect <p2p.host> [p2p.port]';
+exports.command = 'connect <p2p_host> [p2p_port]';
 
 exports.describe = 'connect to an xu node';
 
 exports.builder = {
-  'p2p.host': {
-    type: 'number',
+  p2p_host: {
+    type: 'string',
   },
-  'p2p.port': {
+  p2p_port: {
     type: 'number',
     default: '8885',
   },
 };
 
 function callHandler(xuClient, argv) {
-  return xuClient.connect(argv.p2p.host, argv.p2p.port);
+  return xuClient.connect(argv.p2p_host, argv.p2p_port);
 }
 
 exports.handler = (argv) => {

--- a/lib/cli/commands/connect.js
+++ b/lib/cli/commands/connect.js
@@ -1,21 +1,21 @@
 const command = require('../command');
 
-exports.command = 'connect <host> [port]';
+exports.command = 'connect <p2p.host> [p2p.port]';
 
 exports.describe = 'connect to an xu node';
 
 exports.builder = {
-  host: {
+  'p2p.host': {
     type: 'number',
   },
-  port: {
+  'p2p.port': {
     type: 'number',
     default: '8885',
   },
 };
 
 function callHandler(xuClient, argv) {
-  return xuClient.connect(argv.host, argv.port);
+  return xuClient.connect(argv.p2p.host, argv.p2p.port);
 }
 
 exports.handler = (argv) => {

--- a/lib/cli/commands/connect.js
+++ b/lib/cli/commands/connect.js
@@ -1,21 +1,23 @@
 const command = require('../command');
 
-exports.command = 'connect <p2p_host> [p2p_port]';
+exports.command = 'connect <host> [port]';
 
 exports.describe = 'connect to an xu node';
 
 exports.builder = {
-  p2p_host: {
+  host: {
+    description: 'target p2p server host',
     type: 'string',
   },
-  p2p_port: {
+  port: {
+    description: 'target p2p server port',
     type: 'number',
     default: '8885',
   },
 };
 
 function callHandler(xuClient, argv) {
-  return xuClient.connect(argv.p2p_host, argv.p2p_port);
+  return xuClient.connect(argv.host, argv.port);
 }
 
 exports.handler = (argv) => {

--- a/lib/cli/commands/placeorder.js
+++ b/lib/cli/commands/placeorder.js
@@ -1,6 +1,6 @@
 const command = require('../command');
 
-exports.command = 'placeorder <pairId> <price> <quantity>';
+exports.command = 'placeorder <pair_id> <price> <quantity>';
 
 exports.describe = 'place an order';
 
@@ -11,7 +11,7 @@ exports.builder = {
   quantity: {
     type: 'number',
   },
-  pairId: {
+  pair_id: {
     type: 'string',
   },
 };
@@ -20,7 +20,7 @@ function callHandler(xuClient, argv) {
   const order = {
     price: argv.price,
     quantity: argv.quantity,
-    pairId: argv.pairId,
+    pairId: argv.pair_id,
   };
   return xuClient.placeOrder(order);
 }


### PR DESCRIPTION
* Fixing an existing issue with `rpcPort` (the name wasn't consistent, sometime it was `rpcport`), I ended up making it nested, as `rpc.port` (better approach since `rpc` will have more config, and this is our pattern anyway).
* Adding relevant description for the `./bin/xud` symlink (he's necessary if you want to create few `xud` instances). 
* Made it more clear that in the `connect` cli command, the args (host, port) are referring to the p2p server.