### PR TITLE
Add tslint rules

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -74,7 +74,7 @@ class Config {
     if (!fs.existsSync(this.xuDir)) {
       fs.mkdirSync(this.xuDir);
     } else if (fs.existsSync(`${this.xuDir}xud.conf`)) {
-      const configText : any = fs.readFileSync(`${this.xuDir}xud.conf`);
+      const configText: any = fs.readFileSync(`${this.xuDir}xud.conf`);
       try {
         const props = toml.parse(configText);
 

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -1,4 +1,4 @@
-const enums : any = {};
+const enums: any = {};
 
 enums.swapProtocols = {
   LND: 'LND',

--- a/lib/constants/errorCodesPrefix.ts
+++ b/lib/constants/errorCodesPrefix.ts
@@ -5,4 +5,3 @@ export default {
   LND: '4',
   RAIDEN: '5',
 };
-

--- a/lib/db/baseRepository.ts
+++ b/lib/db/baseRepository.ts
@@ -1,4 +1,4 @@
-const baseRepository : any = {};
+const baseRepository: any = {};
 
 baseRepository.addOne = async (model, payload) => model.create(payload);
 

--- a/lib/db/models/Order.ts
+++ b/lib/db/models/Order.ts
@@ -22,4 +22,3 @@ module.exports = (sequelize, DataTypes) => {
 
   return Order;
 };
-

--- a/lib/db/models/Pair.ts
+++ b/lib/db/models/Pair.ts
@@ -31,4 +31,3 @@ export default (sequelize, DataTypes) => {
 
   return Pair;
 };
-

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -37,7 +37,7 @@ class LndClient {
     } else {
       const lndCert = fs.readFileSync(`${datadir}tls.cert`);
       const credentials = grpc.credentials.createSsl(lndCert);
-      const lnrpcDescriptor : any = grpc.load(rpcprotopath);
+      const lnrpcDescriptor: any = grpc.load(rpcprotopath);
       this.lightning = new lnrpcDescriptor.lnrpc.Lightning('127.0.0.1:10009', credentials);
 
       const adminMacaroon = fs.readFileSync(`${datadir}admin.macaroon`);
@@ -121,6 +121,5 @@ class LndClient {
     });
   }
 }
-
 
 export default LndClient;

--- a/lib/lndclient/errors.ts
+++ b/lib/lndclient/errors.ts
@@ -1,7 +1,7 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
 
 const codesPrefix = errorCodesPrefix.LND;
-const errors : any = {};
+const errors: any = {};
 
 errors.LND_IS_DISABLED = {
   message: 'lnd is disabled',

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -79,7 +79,6 @@ class MatchingEngine {
     }
   }
 
-
   addPeerBuyOrder(order) {
     return this.getMatchesOrAdd({
       order,
@@ -136,6 +135,5 @@ class MatchingEngine {
     });
   }
 }
-
 
 export default MatchingEngine;

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -5,16 +5,16 @@ function Peer({
   this.address = address;
   this.port = port;
 }
-  
+
 Peer.prototype.getKey = function getKey() {
   return `${this.address}:${this.port}`;
 };
-  
+
 Peer.prototype.toString = function toString() {
   const { host, address, port } = this;
   return !host || address === host
       ? `${address}:${port}`
       : `${host}[${address}]:${port}`;
 };
-  
+
 export default Peer;

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -39,7 +39,7 @@ class RaidenClient {
     if (this.isDisabled()) {
       throw errors.RAIDEN_IS_DISABLED;
     }
-    const options : any = {
+    const options: any = {
       method,
       hostname: '127.0.0.1',
       port: this.port,
@@ -98,7 +98,7 @@ class RaidenClient {
       endpoint += `/${identifier}`;
     }
 
-    const res : any = await this.sendRequest(endpoint, 'PUT', payload);
+    const res: any = await this.sendRequest(endpoint, 'PUT', payload);
     if (res.statusCode === 201) {
       return 'swap created';
     } else {
@@ -110,7 +110,7 @@ class RaidenClient {
     assert(typeof channel_address === 'string', 'channel_address must be a string');
 
     const endpoint = `channels/${channel_address}`;
-    const res : any = await this.sendRequest(endpoint, 'GET', null);
+    const res: any = await this.sendRequest(endpoint, 'GET', null);
 
     res.setEncoding('utf8');
 

--- a/lib/raidenclient/errors.ts
+++ b/lib/raidenclient/errors.ts
@@ -1,7 +1,7 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
 
 const codesPrefix = errorCodesPrefix.RAIDEN;
-const errors : any = {};
+const errors: any = {};
 
 errors.RAIDEN_IS_DISABLED = {
   message: 'raiden is disabled',

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,17 +1,17 @@
-const utils : any = {};
+const utils: any = {};
 
 /**
  * Check whether a variable is a non-array object
  * @returns {boolean}
  */
-function isObject(val: any) : boolean {
+function isObject(val: any): boolean {
   return (val && typeof val === 'object' && !Array.isArray(val));
 }
 
 /** Get the current date in the LocaleString format.
  * @returns {string}
  */
-utils.getTsString = () : string => (new Date()).toLocaleString();
+utils.getTsString = (): string => (new Date()).toLocaleString();
 
 /**
  * Recursively merge properties from different sources into a target object, overriding any
@@ -19,7 +19,7 @@ utils.getTsString = () : string => (new Date()).toLocaleString();
  * @param {object} target - The destination object to merge into.
  * @param {object} sources - The sources objects to copy from.
  */
-utils.deepMerge = (target: any, ...sources : any[]) : object => {
+utils.deepMerge = (target: any, ...sources: any[]): object => {
   if (!sources.length) return target;
   const source = sources.shift();
 
@@ -40,7 +40,7 @@ utils.deepMerge = (target: any, ...sources : any[]) : object => {
 /** Get all methods from an object whose name doesn't start with an underscore.
  * @returns {object}
 */
-utils.getPublicMethods = (obj: any) : object => {
+utils.getPublicMethods = (obj: any): object => {
   const ret: any = {};
   Object.getOwnPropertyNames(Object.getPrototypeOf(obj)).forEach((name) => {
     const func = obj[name];
@@ -51,8 +51,8 @@ utils.getPublicMethods = (obj: any) : object => {
   return ret;
 };
 
-utils.groupBy = (arr: object[], keyGetter: (item: object) => string | number) : object => {
-  const ret : any = {};
+utils.groupBy = (arr: object[], keyGetter: (item: object) => string | number): object => {
+  const ret: any = {};
   arr.forEach((item) => {
     const key = keyGetter(item);
     const group = ret[key];

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,18 @@
     "no-else-after-return": false,
     "function-name": false,
     "no-this-assignment": [true, {"allow-destructuring": true}],
-    "align": false
+    "align": false,
+    "no-consecutive-blank-lines": true,
+    "no-trailing-whitespace": true,
+    "whitespace": [true, "check-separator", "check-branch", "check-decl", "check-operator", "check-preblock"],
+    "typedef-whitespace": [
+      true, {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This adds tslint rules to match the airbnb javascript style guide (`no-consecutive-blank-lines` & `no-trailing-whitespace`) and typescript documentation convention (`typedef-whitespace`). I'm going to open a PR to add the first two rules directly to the style guide we are using, because they really should be included there I figure.