### PR TITLE
generate nodekey and persist to disk

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import Logger from './Logger';
 import Config from './Config';
 import DB from './db/DB';
@@ -6,6 +7,7 @@ import LndClient from './lndclient/LndClient';
 import RaidenClient from './raidenclient/RaidenClient';
 import RpcServer from './rpc/RpcServer';
 import Pool from './p2p/Pool';
+import NodeKey from './nodekey/NodeKey';
 import dotenv from 'dotenv';
 
 /** Loads environment variables from the file .env */
@@ -14,17 +16,18 @@ dotenv.config();
 /** Class representing a complete Exchange Union daemon. */
 class Xud {
   logger: any;
-  config: any;
+  config: Config;
   db: any;
   lndClient: any;
   raidenClient: any;
   pool?: Pool;
   orderBook: any;
   rpcServer: any;
+  nodeKey!: NodeKey;
 
   /**
    * Create an Exchange Union daemon.
-   * @param {Object} args - Optional command line arguments to override configuration parameters.
+   * @param args Optional command line arguments to override configuration parameters.
    */
   constructor(args) {
     this.logger = Logger.global;
@@ -41,6 +44,9 @@ class Xud {
     this.logger.info('config loaded');
 
     try {
+      // TODO: wait for decryption of existing key or encryption of new key, config option to disable encryption
+      this.nodeKey = NodeKey.load(`${this.config.xudir}/nodekey.dat`);
+
       this.db = new DB(this.config.db);
       await this.db.init();
 

--- a/lib/nodekey/NodeKey.ts
+++ b/lib/nodekey/NodeKey.ts
@@ -1,0 +1,100 @@
+import CryptoJS from 'crypto-js';
+import { randomBytes } from 'crypto';
+import secp256k1 from 'secp256k1';
+import fs from 'fs';
+
+/**
+ * A class representing an ECDSA public/private key pair that identifies an XU node on the network
+ * and can sign messages to prove their veracity.
+ */
+class NodeKey {
+  private pubKeyStr: string;
+
+  constructor(private privKey: Buffer) {
+    const pubKey = secp256k1.publicKeyCreate(privKey);
+    this.pubKeyStr = pubKey.toString('hex');
+  }
+
+  /**
+   * Generate a random NodeKey.
+   */
+  static generate = (): NodeKey => {
+    let privKey: Buffer;
+    do {
+      privKey = randomBytes(32);
+    } while (!secp256k1.privateKeyVerify(privKey));
+
+    return new NodeKey(privKey);
+  }
+
+  /**
+   * Load a NodeKey from a file.
+   * @param path The path to the file
+   * @param password An optional password to decrypt the file
+   * @returns A NodeKey if a file containing a valid ECDSA private key exists at the given path
+   */
+  static fromFile = (path: string, password?: string): NodeKey => {
+    let buf: Buffer;
+    if (password) {
+      const encryptedString: string = fs.readFileSync(path, 'utf8');
+      const decryptedString: string = CryptoJS.AES.decrypt(encryptedString, password).toString(CryptoJS.enc.Hex);
+      buf = Buffer.from(decryptedString, 'hex');
+    } else {
+      buf = fs.readFileSync(path);
+    }
+
+    if (secp256k1.privateKeyVerify(buf)) {
+      return new NodeKey(buf);
+    } else {
+      throw new Error(`${path} does not contain a valid ECDSA private key`);
+    }
+  }
+
+  /**
+   * Load a node key from a file or create one if none exists. See [[fromFile]] and [[generate]].
+   */
+  static load = (path: string): NodeKey => {
+    let nodeKey: NodeKey;
+    if (fs.existsSync(path)) {
+      nodeKey = NodeKey.fromFile(path);
+    } else {
+      nodeKey = NodeKey.generate();
+      nodeKey.toFile(path);
+    }
+    return nodeKey;
+  }
+
+  /**
+   * Sign a message with the private key.
+   * @param msg The data to sign
+   * @returns The signature
+   */
+  sign = (msg: Buffer): Buffer => {
+    return secp256k1.sign(msg, this.privKey).signature;
+  }
+
+  /**
+   * Return the public key in hex format
+   */
+  toString = (): string => {
+    return this.pubKeyStr;
+  }
+
+  /**
+   * Save the private key to a file, optionally encrypted by a password
+   * @param path The path at which to save the file
+   * @param password An optional password parameter for encrypting the private key
+   */
+  toFile = (path, password?: string): void => {
+    let buf: Buffer;
+    if (password) {
+      const wa = CryptoJS.lib.WordArray.create(this.privKey.buffer);
+      buf = CryptoJS.AES.encrypt(wa, password);
+    } else {
+      buf = this.privKey;
+    }
+    fs.writeFileSync(path, buf);
+  }
+}
+
+export default NodeKey;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1092,6 +1092,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "homepage": "https://github.com/ExchangeUnion/xud#readme",
   "dependencies": {
     "dotenv": "^5.0.1",
+    "crypto-js": "^3.1.9-1",
     "fastpriorityqueue": "^0.3.1",
     "grpc": "^1.9.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
This allows for creation of an ECDSA key pair (node key) for establishing node identity and signing messages. A node key is generated randomly and automatically if none exists. Generated node keys are saved to disk in the xu data folder and read on future starts. Methods to encrypt and decrypt stored keys on disk are included but currently are not used.

I didn't replace the placeholder node key in P2P.ts because the file is being replaced in a separate PR, but eventually we'll want to use this there.

This addresses #39.