### PR TITLE
Refactoring Logger for TypeScript

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -28,7 +28,7 @@ class LndClient extends BaseClient{
     if (disable) {
       this.setStatus(ClientStatus.DISABLED);
     } else if (!fs.existsSync(`${datadir}tls.cert`)) {
-      this.logger.error('could not find tls.cert in the lnd datadir, is lnd installed?', undefined);
+      this.logger.error('could not find tls.cert in the lnd datadir, is lnd installed?');
       this.setStatus(ClientStatus.DISABLED);
     } else {
       const lndCert = fs.readFileSync(`${datadir}tls.cert`);

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -56,7 +56,7 @@ class RaidenClient extends BaseClient {
       });
 
       req.on('error', (err) => {
-        this.logger.error(err, undefined);
+        this.logger.error(err);
         reject(err);
       });
 


### PR DESCRIPTION
Just some refactoring around the typescript migration for our `Logger` module. `@types/winston` is not up to date with version 3.0 which we're using, but it looks like it will be by the end of the month, so we can incorporate that then.