### PR TITLE
Add host arg to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,22 @@ Interact with an `xud` process, identified by its `rpc` port
 xucli [command]
 
 Commands:
-  xucli connect <host> [port]                    connect to an xu node
-  xucli getinfo                                  get general info from the xud node
-  xucli getorders                                get orders from the orderbook
-  xucli getpairs                                 get orderbook's available pairs
-  xucli placeorder <pair_id> <price> <quantity>  place an order
-  xucli shutdown                                 gracefully shutdown the xud node
-  xucli tokenswap <identifier> <role>            perform a raiden token swap
+  xucli connect <host> [port]               connect to an xu node
+  xucli getinfo                             get general info from the xud node
+  xucli getorders                           get orders from the orderbook
+  xucli getpairs                            get orderbook's available pairs
+  xucli placeorder <pair_id> <price>        place an order
+  <quantity>
+  xucli shutdown                            gracefully shutdown the xud node
+  xucli tokenswap <identifier> <role>       perform a raiden token swap
   <sending_amount> <sending_token>
   <receiving_amount> <receiving_token>
 
 Options:
-  --version      Show version number                                   [boolean]
-  --help         Show help                                             [boolean]
-  -r, --rpc.port                                        [number] [default: 8886]
+  --help          Show help                                            [boolean]
+  --version       Show version number                                  [boolean]
+  --rpc.port, -p  The RPC service port                  [number] [default: 8886]
+  --rpc.host, -h  The RPC service hostname       [string] [default: "localhost"]
 ```
 
 ## Configuration
@@ -77,6 +79,7 @@ The configuration file uses [TOML](https://github.com/toml-lang/toml) and by def
 ```toml
 [rpc]
 port = 8886
+host = "localhost"
 
 [db]
 username = "xud"

--- a/bin/xucli
+++ b/bin/xucli
@@ -1,9 +1,19 @@
 #!/usr/bin/env node
 
 require('yargs')
-  .number('rpc.port')
-  .alias('r', 'rpc.port')
-  .default('rpc.port', 8886)
+  .options({
+    'rpc.port': {
+      alias: 'p',
+      default: 8886,
+      describe: 'The RPC service port',
+      type: 'number',
+    },
+    'rpc.host': {
+      alias: 'h',
+      default: 'localhost',
+      describe: 'The RPC service hostname',
+      type: 'string',
+    },
+  })
   .commandDir('../dist/lib/cli/commands')
-  .help()
   .argv; // we must read the argv property for the command line args to initialize properly

--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -8,7 +8,7 @@ import { Arguments } from 'yargs';
  * @param callback The callback function to perform a command
  */
 export default (argv: Arguments, callback: (XUClient, Arguments) => Promise<any>) => {
-  const xuClient = new XUClient(argv.rpc.port);
+  const xuClient = new XUClient(argv.rpc.port, argv.rpc.host);
 
   const promise = callback(xuClient, argv);
 

--- a/lib/xuclient/XUClient.ts
+++ b/lib/xuclient/XUClient.ts
@@ -2,21 +2,22 @@ import http from 'http';
 import assert from 'assert';
 
 class XUClient {
-  port: number;
-  id: number;
+  port: number = 8886;
+  id: number = 1;
+  host: string = 'localhost';
 
-  constructor(port) {
+  constructor(port: number, host?: string) {
     if (port) {
-      assert(typeof port === 'number', 'port must be a number');
       assert(port > 1023 && port < 65536, 'port must be between 1024 and 65535');
+      this.port = port;
     }
-    this.port = port || 8886;
-
-    this.id = 1;
+    if (host) {
+      this.host = host;
+    }
   }
 
   callRpc(method, params) {
-    const { port, id } = this;
+    const { port, id, host } = this;
     this.id += 1;
     return new Promise((resolve, reject) => {
       const postData = JSON.stringify({
@@ -25,6 +26,7 @@ class XUClient {
         id,
         jsonrpc: '2.0',
       });
+
       const req = http.request({
         port,
         headers: {
@@ -33,6 +35,7 @@ class XUClient {
           'Content-Length': postData.length,
         },
         method: 'POST',
+        hostname: host,
       }, (res) => {
         res.setEncoding('utf8');
         let body = '';


### PR DESCRIPTION
This adds the option to specify a host besides `localhost` for `xucli` commands.