### PR TITLE
Updating xud command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,72 +25,9 @@ npm install
 
 Xud uses [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/). You will have to install one of those and create a user and database grant all permissions for the new database to the new user.
 
-## Starting the Daemon
-
-Launch a new `xud` process
-
-```bash
-~/xud $ cd bin
-~/xud/bin $ ./xud
-2018-3-2 11:36:06 - info: config loaded
-2018-3-2 11:36:06 - info: connected to database
-2018-3-2 11:36:06 - info: P2P server listening on port 8885
-2018-3-2 11:36:06 - info: RPC server listening on port 8886
-```
-
-Optional command line arguments
-
-```bash
-~/xud/bin $ ./xud --help
-Options:
-  --help              Show help                                        [boolean]
-  --version           Show version number                              [boolean]
-  --rpc.port, -r      RPC service port                                  [number]
-  --p2p.port, -p      Port to listen for incoming peers                 [number]
-  --p2p.listen        Listen for incoming peers                        [boolean]
-  --xudir, -x         Data directory for xud                            [string]
-  --db.host           Hostname for SQL database                         [string]
-  --db.port           Port for SQL database                             [number]
-  --db.username       User for SQL database                             [string]
-  --db.database       SQL database name                                 [string]
-  --db.dialect        SQL database dialect                              [string]
-  --lnd.disable       Disable lnd integration                          [boolean]
-  --lnd.datadir       Data directory for lnd                            [string]
-  --lnd.rpcprotopath  Path to lndrpc.proto file                         [string]
-  --raiden.disable    Disable raiden integration                       [boolean]
-  --raiden.port       Port for raiden REST service                      [number]
-```
-
-## Command-Line Interface
-
-Interact with an `xud` process, identified by its `rpc` port
-
-```bash
-~/xud/bin $ ./xucli --help
-xucli [command]
-
-Commands:
-  xucli connect <host> [port]               connect to an xu node
-  xucli getinfo                             get general info from the xud node
-  xucli getorders                           get orders from the orderbook
-  xucli getpairs                            get orderbook's available pairs
-  xucli placeorder <pair_id> <price>        place an order
-  <quantity>
-  xucli shutdown                            gracefully shutdown the xud node
-  xucli tokenswap <identifier> <role>       perform a raiden token swap
-  <sending_amount> <sending_token>
-  <receiving_amount> <receiving_token>
-
-Options:
-  --help          Show help                                            [boolean]
-  --version       Show version number                                  [boolean]
-  --rpc.port, -p  The RPC service port                  [number] [default: 8886]
-  --rpc.host, -h  The RPC service hostname       [string] [default: "localhost"]
-```
-
 ## Configuration
 
-The configuration file uses [TOML](https://github.com/toml-lang/toml) and by default is located at  `~/.xud/xud.conf` on Linux or `AppData\Local\Xud\xud.conf` on Windows. Default settings which can be overridden are shown below.
+An optional configuration file uses [TOML](https://github.com/toml-lang/toml) and by default should be saved at  `~/.xud/xud.conf` on Linux or `AppData\Local\Xud\xud.conf` on Windows. Default settings which can be overridden are shown below.
 
 ```toml
 [rpc]
@@ -115,6 +52,69 @@ rpcprotopath = "lndrpc.proto"
 [raiden]
 disable = false
 port = 5001
+```
+
+## Starting the Daemon
+
+Launch a new `xud` process
+
+```bash
+~/xud $ cd bin
+~/xud/bin $ ./xud
+2018-3-2 11:36:06 - info: config loaded
+2018-3-2 11:36:06 - info: connected to database
+2018-3-2 11:36:06 - info: P2P server listening on port 8885
+2018-3-2 11:36:06 - info: RPC server listening on port 8886
+```
+
+Optional command line arguments to override defaults and settings in the [Configuration](#configuration) file for a specific `xud` instance
+
+```bash
+~/xud/bin $ ./xud --help
+Options:
+  --help              Show help                                        [boolean]
+  --version           Show version number                              [boolean]
+  --rpc.port, -r      RPC service port                                  [number]
+  --p2p.port, -p      Port to listen for incoming peers                 [number]
+  --p2p.listen        Listen for incoming peers                        [boolean]
+  --xudir, -x         Data directory for xud                            [string]
+  --db.host           Hostname for SQL database                         [string]
+  --db.port           Port for SQL database                             [number]
+  --db.username       User for SQL database                             [string]
+  --db.database       SQL database name                                 [string]
+  --db.dialect        SQL database dialect                              [string]
+  --lnd.disable       Disable lnd integration                          [boolean]
+  --lnd.datadir       Data directory for lnd                            [string]
+  --lnd.rpcprotopath  Path to lndrpc.proto file                         [string]
+  --raiden.disable    Disable raiden integration                       [boolean]
+  --raiden.port       Port for raiden REST service                      [number]
+```
+
+## Command-Line Interface
+
+Interact with an `xud` process, identified by its `rpc` host and port
+
+```bash
+~/xud/bin $ ./xucli --help
+xucli [command]
+
+Commands:
+  xucli connect <host> [port]               connect to an xu node
+  xucli getinfo                             get general info from the xud node
+  xucli getorders                           get orders from the orderbook
+  xucli getpairs                            get orderbook's available pairs
+  xucli placeorder <pair_id> <price>        place an order
+  <quantity>
+  xucli shutdown                            gracefully shutdown the xud node
+  xucli tokenswap <identifier> <role>       perform a raiden token swap
+  <sending_amount> <sending_token>
+  <receiving_amount> <receiving_token>
+
+Options:
+  --help          Show help                                            [boolean]
+  --version       Show version number                                  [boolean]
+  --rpc.port, -p  The RPC service port                  [number] [default: 8886]
+  --rpc.host, -h  The RPC service hostname       [string] [default: "localhost"]
 ```
 
 ## Database Initialization

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Xud uses [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/). You
 
 ## Starting the Daemon
 
+Launch a new `xud` process
+
 ```bash
 ~/xud $ cd bin
 ~/xud/bin $ ./xud
@@ -36,16 +38,30 @@ Xud uses [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/). You
 2018-3-2 11:36:06 - info: RPC server listening on port 8886
 ```
 
-## Command-Line Interface
-
-Spawn a new `xud` process
+Optional command line arguments
 
 ```bash
-~/xud/bin $ ./xud
+~/xud/bin $ ./xud --help
 Options:
-  -r, --rpc.port                                        [number] [default: 8886]
-  -p, --p2p.port                                        [number] [default: 8885]
+  --help              Show help                                        [boolean]
+  --version           Show version number                              [boolean]
+  --rpc.port, -r      RPC service port                                  [number]
+  --p2p.port, -p      Port to listen for incoming peers                 [number]
+  --p2p.listen        Listen for incoming peers                        [boolean]
+  --xudir, -x         Data directory for xud                            [string]
+  --db.host           Hostname for SQL database                         [string]
+  --db.port           Port for SQL database                             [number]
+  --db.username       User for SQL database                             [string]
+  --db.database       SQL database name                                 [string]
+  --db.dialect        SQL database dialect                              [string]
+  --lnd.disable       Disable lnd integration                          [boolean]
+  --lnd.datadir       Data directory for lnd                            [string]
+  --lnd.rpcprotopath  Path to lndrpc.proto file                         [string]
+  --raiden.disable    Disable raiden integration                       [boolean]
+  --raiden.port       Port for raiden REST service                      [number]
 ```
+
+## Command-Line Interface
 
 Interact with an `xud` process, identified by its `rpc` port
 
@@ -79,7 +95,6 @@ The configuration file uses [TOML](https://github.com/toml-lang/toml) and by def
 ```toml
 [rpc]
 port = 8886
-host = "localhost"
 
 [db]
 username = "xud"
@@ -94,6 +109,7 @@ port = 8885
 
 [lnd]
 disable = false
+datadir = "~/.lnd"
 rpcprotopath = "lndrpc.proto"
 
 [raiden]

--- a/bin/xucli
+++ b/bin/xucli
@@ -5,13 +5,13 @@ require('yargs')
     'rpc.port': {
       alias: 'p',
       default: 8886,
-      describe: 'The RPC service port',
+      describe: 'RPC service port',
       type: 'number',
     },
     'rpc.host': {
       alias: 'h',
       default: 'localhost',
-      describe: 'The RPC service hostname',
+      describe: 'RPC service hostname',
       type: 'string',
     },
   })

--- a/bin/xud
+++ b/bin/xud
@@ -3,14 +3,70 @@
 const Xud = require('../dist/lib/Xud').default;
 
 const { argv } = require('yargs')
-  .number(['p2p.port', 'rpc.port', 'db.port', 'raiden.port'])
-  .boolean(['db.operatorsAliases', 'p2p.listen'])
-  .default({
-    'db.operatorsAliases': undefined,
-    'p2p.listen': undefined,
-  })
-  .alias('r', 'rpc.port')
-  .alias('p', 'p2p.port');
+  .options({
+    'rpc.port': {
+      describe: 'RPC service port',
+      type: 'number',
+      alias: 'r',
+    },
+    'p2p.port': {
+      describe: 'Port to listen for incoming peers',
+      type: 'number',
+      alias: 'p',
+    },
+    'p2p.listen': {
+      describe: 'Listen for incoming peers',
+      type: 'boolean',
+      default: undefined,
+    },
+    xudir: {
+      describe: 'Data directory for xud',
+      type: 'string',
+      alias: 'x',
+    },
+    'db.host': {
+      describe: 'Hostname for SQL database',
+      type: 'string',
+    },
+    'db.port': {
+      describe: 'Port for SQL database',
+      type: 'number',
+    },
+    'db.username': {
+      describe: 'User for SQL database ',
+      type: 'string',
+    },
+    'db.database': {
+      describe: 'SQL database name',
+      type: 'string',
+    },
+    'db.dialect': {
+      describe: 'SQL database dialect',
+      type: 'string',
+    },
+    'lnd.disable': {
+      describe: 'Disable lnd integration',
+      type: 'boolean',
+      default: undefined,
+    },
+    'lnd.datadir': {
+      describe: 'Data directory for lnd',
+      type: 'string',
+    },
+    'lnd.rpcprotopath': {
+      describe: 'Path to lndrpc.proto file',
+      type: 'string',
+    },
+    'raiden.disable': {
+      describe: 'Disable raiden integration',
+      type: 'boolean',
+      default: undefined,
+    },
+    'raiden.port': {
+      describe: 'Port for raiden REST service',
+      type: 'number',
+    },
+  });
 
 // delete non-config keys from argv
 delete argv._;

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -9,8 +9,8 @@ import { DBConfig } from './db/DB';
 
 class Config {
   args?: object;
-  xuDir: string;
   p2p: PoolConfig;
+  xudir: string;
   db: DBConfig;
   testDb: any;
   rpc: any;
@@ -24,19 +24,19 @@ class Config {
     switch (platform) {
       case 'win32': { // windows
         const homeDir = process.env.LOCALAPPDATA;
-        this.xuDir = `${homeDir}/Xud/`;
+        this.xudir = `${homeDir}/Xud/`;
         lndDatadir = `${homeDir}/Lnd/`; // default lnd directory location
         break;
       }
       case 'darwin': { // mac
         const homeDir = process.env.HOME;
-        this.xuDir = `${homeDir}/.xud/`;
+        this.xudir = `${homeDir}/.xud/`;
         lndDatadir = `${homeDir}/Library/Application Support/Lnd/`;
         break;
       }
       default: { // linux
         const homeDir = process.env.HOME;
-        this.xuDir = `${homeDir}/.xud/`;
+        this.xudir = `${homeDir}/.xud/`;
         lndDatadir = `${homeDir}/.lnd/`;
         break;
       }
@@ -51,7 +51,6 @@ class Config {
       host: 'localhost',
       port: 3306,
       username: 'xud',
-      password: undefined,
       database: 'xud',
       dialect: 'mysql',
     };
@@ -74,10 +73,10 @@ class Config {
   }
 
   async load() {
-    if (!fs.existsSync(this.xuDir)) {
-      fs.mkdirSync(this.xuDir);
-    } else if (fs.existsSync(`${this.xuDir}xud.conf`)) {
-      const configText: any = fs.readFileSync(`${this.xuDir}xud.conf`);
+    if (!fs.existsSync(this.xudir)) {
+      fs.mkdirSync(this.xudir);
+    } else if (fs.existsSync(`${this.xudir}xud.conf`)) {
+      const configText: any = fs.readFileSync(`${this.xudir}xud.conf`);
       try {
         const props = toml.parse(configText);
 


### PR DESCRIPTION
This updates the `xud` command line arguments along with the readme. I renamed `xuDir` to `xudir` to be consistent with the lower case config/arg names.