### PR TITLE
Fixed SSL issue with LND

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -6,6 +6,9 @@ import BaseClient, { ClientStatus } from'../BaseClient';
 import errors from './errors';
 import * as lndrpc from './lndrpc_pb';
 
+/** Fixes a SSL issue with newer versions of LND */
+process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA';
+
 /**
  * The configurable options for the lnd client.
  */


### PR DESCRIPTION
This fixes the SSL issue `ssl_transport_security.cc:989] Handshake failed with fatal error SSL_ERROR_SSL: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure.` with newer versions of LND. 