### PR TITLE
Add cross-platform scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1082,6 +1082,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-os": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cross-os/-/cross-os-1.3.0.tgz",
+      "integrity": "sha512-9kViqCcAwlPLTeSDPlyC2FdMQ5UVPtGZUnGV8vYDcBA3olJ/hDR7H6IfrNJft2DlKONleHf8CMhD+7Uv2tBnEw==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "postinstall": "npm run compile",
     "start": "npm run compile && npm run run",
-    "compile": "rm -rf ./dist && tsc",
+    "compile": "cross-os compile",
     "run": "node dist/lib/Xud.js",
     "dev": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
     "compile:watch": "tsc -w",
@@ -23,6 +23,13 @@
     "test:unit:watch": "mocha -r ts-node/register test/unit/*  --watch --watch-extensions ts",
     "test:int": "mocha -r ts-node/register test/integration/*",
     "test:int:watch": "mocha -r ts-node/register test/integration/*  --watch --watch-extensions ts"
+  },
+  "cross-os": {
+    "compile": {
+      "linux": "rm -rf ./dist && tsc",
+      "darwin": "rm -rf ./dist && tsc",
+      "win32": "rd /q /s dist && tsc"
+    }
   },
   "repository": {
     "type": "git",
@@ -75,6 +82,7 @@
     "@types/yargs": "^11.0.0",
     "chai": "^4.1.2",
     "concurrently": "^3.5.1",
+    "cross-os": "^1.3.0",
     "gulp-runner": "^1.1.0",
     "mocha": "^5.0.5",
     "nodemon": "^1.17.2",


### PR DESCRIPTION
This commit uses the `cross-os` package to enable separate npm scripts based on OS platform. Currently the only script affected is `compile`.