### PR TITLE
verify that address is not already connected

### DIFF
--- a/lib/p2p/PeerList.ts
+++ b/lib/p2p/PeerList.ts
@@ -1,0 +1,28 @@
+import Peer from './Peer';
+import SocketAddress from './SocketAddress';
+
+class PeerList {
+  private peers: { [ key: string ]: Peer } = {};
+
+  public add(peer: Peer): boolean {
+    if (this.has(peer.address)) {
+      return false;
+    } else {
+      const key = peer.address.toString();
+      this.peers[key] = peer;
+      return true;
+    }
+  }
+
+  public remove(peer:Peer): void {
+    const key = peer.address.toString();
+    delete this.peers[key];
+  }
+
+  public has(address: SocketAddress): boolean {
+    const key = address.toString();
+    return !!this.peers[key];
+  }
+}
+
+export default PeerList;

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -1,0 +1,7 @@
+class P2PError {
+  constructor(public message: string) {}
+}
+
+export default {
+  ADDRESS_ALREADY_CONNECTED: (address: string) => new P2PError(`Address (${address}) already connected`),
+};

--- a/lib/rpc/RpcMethods.ts
+++ b/lib/rpc/RpcMethods.ts
@@ -78,8 +78,12 @@ class RpcMethods implements RpcComponents {
    * Connect to an XU node on a given host and port. See [[Pool.addOutbound]]
    */
   async connect(params) {
-    const peer = await this.pool.addOutbound(params.host, params.port);
-    return peer.statusString;
+    try {
+      const peer = await this.pool.addOutbound(params.host, params.port);
+      return peer.statusString;
+    } catch (err) {
+      return err;
+    }
   }
 
   /**


### PR DESCRIPTION
Small PR for supporting some unit tests.

I'm checking for existing peer only for outbound connections, because getting an existing one as an  inbound is technically impossible (TCP/IP-wise).

I also created a new basic error scheme, which we should expand and apply to other domains as well (instead of the old, pre-TS one). I'm not extending the `Error` class there, because these are operational errors (known, pre-defined error scenarios), so the stacktrace is irrelevant. 