### PR TITLE
Database fixes

### DIFF
--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -112,7 +112,7 @@ class DB {
     try {
       this.sequelize = new Sequelize('', this.sequelize.options.username, this.sequelize.options.password, this.sequelize.options);
       await this.sequelize.authenticate();
-      await this.sequelize.query(`CREATE DATABASE ${this.sequelize.options.database};`);
+      await this.sequelize.query(`CREATE DATABASE ${this.sequelize.options.database} CHARACTER SET utf8 COLLATE utf8_general_ci;`);
       await this.sequelize.query(`USE ${this.sequelize.options.database}`);
     } catch (err) {
       this.logger.error('unable to create the database', err);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
     "compile:watch": "tsc -w",
     "nodemon:watch": "nodemon --watch dist -e js dist/lib/Xud.js",
-    "lint": "tslint ./lib/**/*.ts ./bin/*",
+    "lint": "tslint ./lib/**/*.ts ./bin/* ./tasks/**/*.ts",
     "db:init": "gulp db.init",
     "docs": "typedoc --out typedoc --module commonjs --target es6 lib",
     "test": "npm run test:unit && npm run test:int",

--- a/tasks/db/dropTables.ts
+++ b/tasks/db/dropTables.ts
@@ -14,4 +14,3 @@ gulp.task('db.dropTables', async () => {
   await db.dropTables();
   db.close();
 });
-

--- a/tasks/db/init.ts
+++ b/tasks/db/init.ts
@@ -58,7 +58,5 @@ gulp.task('db.init', async () => {
     },
   ]);
 
-
   db.close();
 });
-

--- a/tasks/db/restart.ts
+++ b/tasks/db/restart.ts
@@ -4,4 +4,3 @@ import runSequence from 'run-sequence';
 gulp.task('db.restart', (done) => {
   runSequence('db.dropTables', 'db.init', done);
 });
-


### PR DESCRIPTION
This pr fixes 

- the integration test failing if the database does not exist before running
- the error `Specified key was too long; max key length is 767 bytes` by enforcing the database charset `utf8`

and adds the TypeScript files in the tasks folder to `npm run lint`.

Edit: this fixes also the issues with Travis and the integration tests in #75 