### PR TITLE
Fix lint script issues on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
     "compile:watch": "tsc -w",
     "nodemon:watch": "nodemon --watch dist -e js dist/lib/Xud.js",
-    "lint": "tslint ./lib/**/*.ts ./bin/*",
+    "lint": "tslint 'lib/**/*.ts' 'bin/*'",
     "db:init": "gulp db.init",
     "docs": "typedoc --out typedoc --module commonjs --target es6 lib",
     "test": "npm run test:unit && npm run test:int",


### PR DESCRIPTION
This addresses the mysterious recent issue of `npm run lint` not working on linux/mac. I've tested the new script on both windows and linux and it works as expected. @moshababo could you just sanity test this on mac?