### PR TITLE
Use __dirname to load lndrpc.proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [Exchange Union](https://www.exchangeunion.com/) (XU) is a decentralized exchange layer built on the [Lightning](http://lightning.network/) and [Raiden](https://raiden.network/) networks to enable trustless and instant cryptocurrency swaps and order fulfillment between exchanges.
 
-
 This repo contains the early stages of the Exchange Union Daemon ("xud") which encompasses the following components:
 
 * Integration with [lnd](https://github.com/lightningnetwork/lnd) and [raiden](https://github.com/raiden-network/raiden) nodes.
@@ -50,7 +49,6 @@ port = 8885
 [lnd]
 disable = false
 datadir = "~/.lnd"
-rpcprotopath = "lndrpc.proto"
 host = "localhost"
 
 [raiden]
@@ -90,7 +88,6 @@ Options:
   --db.dialect        SQL database dialect                              [string]
   --lnd.disable       Disable lnd integration                          [boolean]
   --lnd.datadir       Data directory for lnd                            [string]
-  --lnd.rpcprotopath  Path to lndrpc.proto file                         [string]
   --raiden.disable    Disable raiden integration                       [boolean]
   --raiden.port       Port for raiden REST service                      [number]
 ```

--- a/bin/xud
+++ b/bin/xud
@@ -69,10 +69,6 @@ const { argv } = require('yargs')
       describe: 'Path of the admin macaroon for lnd',
       type: 'string',
     },
-    'lnd.rpcprotopath': {
-      describe: 'Path to lndrpc.proto file',
-      type: 'string',
-    },
     'raiden.disable': {
       describe: 'Disable raiden integration',
       type: 'boolean',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -69,7 +69,6 @@ class Config {
       macaroonpath: path.join(lndDatadir, 'admin.macaroon'),
       host: 'localhost',
       port: 10009,
-      rpcprotopath: 'lndrpc.proto',
     };
     this.raiden = {
       disable: false,

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -1,5 +1,6 @@
 import grpc, { Metadata, ChannelCredentials, StatusObject } from 'grpc';
 import fs from 'fs';
+import path from 'path';
 
 import Logger from '../Logger';
 import BaseClient, { ClientStatus } from '../BaseClient';
@@ -16,7 +17,6 @@ type LndClientConfig = {
   macaroonpath: string;
   host: string;
   port: number;
-  rpcprotopath: string;
 };
 
 /** A class representing a client to interact with lnd. */
@@ -30,7 +30,7 @@ class LndClient extends BaseClient{
    */
   constructor(config: LndClientConfig) {
     super();
-    const { disable, datadir, certpath, host, port, macaroonpath, rpcprotopath } = config;
+    const { disable, datadir, certpath, host, port, macaroonpath } = config;
 
     this.logger = Logger.global;
 
@@ -42,6 +42,7 @@ class LndClient extends BaseClient{
     } else {
       const lndCert: Buffer = fs.readFileSync(certpath);
       const credentials: ChannelCredentials = grpc.credentials.createSsl(lndCert);
+      const rpcprotopath = path.join(__dirname, '..', '..', '..', 'lndrpc.proto');
       const lnrpcDescriptor: any = grpc.load(rpcprotopath);
       this.lightning = new lnrpcDescriptor.lnrpc.Lightning(`${host}:${port}`, credentials);
 


### PR DESCRIPTION
This solves the bug from #80, allowing `xud` to be run from any working directory without interfering with the default path to `lndrpc.proto`. I don't think there's any need to keep this configurable, as even multiple instances of `xud` should be using the same version of `lnd`.