### PR TITLE
Fix MatchingEngine unit test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,12 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
       "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA=="
     },
+    "@types/chai": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.3.tgz",
+      "integrity": "sha512-f5dXGzOJycyzSMdaXVhiBhauL4dYydXwVpavfQ1mVCaGjR56a9QfklXObUxlIY9bGTmCPHEEZ04I16BZ/8w5ww==",
+      "dev": true
+    },
     "@types/continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "yargs": "^11.0.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.1.3",
     "@types/mocha": "^5.2.0",
     "@types/yargs": "^11.0.0",
     "chai": "^4.1.2",

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -25,7 +25,7 @@ describe('MatchingEngine.getMatchingQuantity', () => {
       createOrder(5, 10),
       createOrder(5.5, -10),
     );
-    expect(res).to.be.equal(0);
+    expect(res).to.equal(0);
   });
 
   it('should match buy order with a higher then a sell order', () => {
@@ -33,7 +33,7 @@ describe('MatchingEngine.getMatchingQuantity', () => {
       createOrder(5.5, 10),
       createOrder(5, -10),
     );
-    expect(res).to.be.equal(10);
+    expect(res).to.equal(10);
   });
 
   it('should match buy order with an equal price to a sell order', () => {
@@ -41,7 +41,7 @@ describe('MatchingEngine.getMatchingQuantity', () => {
       createOrder(5, 10),
       createOrder(5, -10),
     );
-    expect(res).to.be.equal(10);
+    expect(res).to.equal(10);
   });
 
   it('should match with lowest quantity of both orders', () => {
@@ -49,7 +49,7 @@ describe('MatchingEngine.getMatchingQuantity', () => {
       createOrder(5, 5),
       createOrder(5, -10),
     );
-    expect(res).to.be.equal(5);
+    expect(res).to.equal(5);
   });
 });
 
@@ -117,8 +117,8 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
       createOrder(5, orderQuantity),
       targetQuantity,
     );
-    expect(target.quantity).to.be.equal(targetQuantity);
-    expect(remaining.quantity).to.be.equal(orderQuantity - targetQuantity);
+    expect(target.quantity).to.equal(targetQuantity);
+    expect(remaining.quantity).to.equal(orderQuantity - targetQuantity);
   });
 
   it('should split sell orders properly', () => {
@@ -128,8 +128,8 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
       createOrder(5, orderQuantity),
       targetQuantity,
     );
-    expect(target.quantity).to.be.equal(targetQuantity * -1);
-    expect(remaining.quantity).to.be.equal(orderQuantity + targetQuantity);
+    expect(target.quantity).to.equal(targetQuantity * -1);
+    expect(remaining.quantity).to.equal(orderQuantity + targetQuantity);
   });
 
   it('should not work when targetQuantity higher than quantity of order', () => {
@@ -164,7 +164,7 @@ describe('MatchingEngine.match', () => {
       createOrder(5, 10),
       matchAgainst,
     );
-    expect(remainingOrder.quantity).to.be.equal(1);
+    expect(remainingOrder.quantity).to.equal(1);
   });
 
   it('should split one maker order when taker is insufficient', () => {
@@ -179,7 +179,7 @@ describe('MatchingEngine.match', () => {
     );
     expect(remainingOrder).to.be.null;
     matches.forEach((match) => {
-      expect(match.maker.quantity).to.be.equal(-5);
+      expect(match.maker.quantity).to.equal(-5);
     });
     expect(engine.priorityQueues.peerSellOrders.peek().quantity).to.equal(-1);
   });

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import uuidv1 from 'uuid/v1';
 import MatchingEngine from '../../lib/orderbook/MatchingEngine';
-import { orders } from '../../lib/types';
+import { orders, db } from '../../lib/types';
 import enums from '../../lib/constants/enums';
 
 const PAIR_ID = 'BTC/LTC';
@@ -15,8 +15,8 @@ const createOrder = (price: number, quantity: number, createdAt?: Date): orders.
   createdAt: createdAt || new Date(),
 });
 
-const createDbOrder = (price: number, quantity: number) => {
-  return createOrder(price, quantity) as orders.dbOrder;
+const createOrderInstance = (price: number, quantity: number) => {
+  return createOrder(price, quantity) as db.OrderInstance;
 };
 
 describe('MatchingEngine.getMatchingQuantity', () => {
@@ -143,8 +143,8 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
 describe('MatchingEngine.match', () => {
   it('should fully match with two maker orders', () => {
     const engine = new MatchingEngine(PAIR_ID, true, [], [
-      createDbOrder(5, -5),
-      createDbOrder(5, -5),
+      createOrderInstance(5, -5),
+      createOrderInstance(5, -5),
     ], [], []);
     const matchAgainst = [engine.priorityQueues.peerSellOrders];
     const { remainingOrder } = MatchingEngine.match(
@@ -156,8 +156,8 @@ describe('MatchingEngine.match', () => {
 
   it('should split taker order when makers are insufficient', () => {
     const engine = new MatchingEngine(PAIR_ID, true, [], [
-      createDbOrder(5, -5),
-      createDbOrder(5, -4),
+      createOrderInstance(5, -5),
+      createOrderInstance(5, -4),
     ], [], []);
     const matchAgainst = [engine.priorityQueues.peerSellOrders];
     const { remainingOrder } = MatchingEngine.match(
@@ -169,8 +169,8 @@ describe('MatchingEngine.match', () => {
 
   it('should split one maker order when taker is insufficient', () => {
     const engine = new MatchingEngine(PAIR_ID, true, [], [
-      createDbOrder(5, -5),
-      createDbOrder(5, -6),
+      createOrderInstance(5, -5),
+      createOrderInstance(5, -6),
     ], [], []);
     const matchAgainst = [engine.priorityQueues.peerSellOrders];
     const { matches, remainingOrder } = MatchingEngine.match(
@@ -181,6 +181,6 @@ describe('MatchingEngine.match', () => {
     matches.forEach((match) => {
       expect(match.maker.quantity).to.be.equal(-5);
     });
-    expect(engine.priorityQueues.peerSellOrders.peek().quantity).to.be.equal(-1);
+    expect(engine.priorityQueues.peerSellOrders.peek().quantity).to.equal(-1);
   });
 });


### PR DESCRIPTION
It looks like #89 and #88 crossed wires and, thanks partly to Travis-CI not being able to build NodeJS 10.2.1, we missed a resulting compilation error. I've fixed that here plus made a few minor legibility changes.

On a related note, it looks like NodeJS does weekly releases so 10.2.2 should be out in a few days. I'm hoping that resolves the issues with Travis, otherwise I'm thinking we should only test against Node v8 until it's all working again. 