### PR TITLE
Update npm scripts & tsconfig compiler options

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -15,5 +15,5 @@ require('yargs')
       type: 'string',
     },
   })
-  .commandDir('../dist/lib/cli/commands')
+  .commandDir('../dist/cli/commands')
   .argv; // we must read the argv property for the command line args to initialize properly

--- a/bin/xud
+++ b/bin/xud
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const Xud = require('../dist/lib/Xud').default;
+const Xud = require('../dist/Xud').default;
 
 const { argv } = require('yargs')
   .options({

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -42,7 +42,7 @@ class LndClient extends BaseClient{
     } else {
       const lndCert = fs.readFileSync(certpath);
       const credentials = grpc.credentials.createSsl(lndCert);
-      const rpcprotopath = path.join(__dirname, '..', '..', '..', 'lndrpc.proto');
+      const rpcprotopath = path.join(__dirname, '..', '..', 'lndrpc.proto');
       const lnrpcDescriptor: any = grpc.load(rpcprotopath);
       this.lightning = new lnrpcDescriptor.lnrpc.Lightning(`${host}:${port}`, credentials);
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "npm run compile && npm start",
     "dev:watch": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
     "compile:watch": "tsc -w",
-    "nodemon:watch": "nodemon --watch dist -e js dist/lib/Xud.js",
+    "nodemon:watch": "nodemon --watch dist -e js dist/Xud.js",
     "lint": "tslint --project tsconfig.json && tslint --config tslint-alt.json 'bin/*' 'test/**/*.ts' 'tasks/**/*.ts'",
     "db:init": "gulp db.init",
     "docs": "typedoc --out typedoc --module commonjs --target es6 lib",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   },
   "scripts": {
     "postinstall": "npm run compile",
-    "start": "npm run compile && npm run run",
+    "start": "node dist/Xud.js",
+    "stop": "cross-os stop",
     "compile": "cross-os compile",
-    "run": "node dist/lib/Xud.js",
-    "dev": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
+    "dev": "npm run compile && npm start",
+    "dev:watch": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
     "compile:watch": "tsc -w",
     "nodemon:watch": "nodemon --watch dist -e js dist/lib/Xud.js",
-    "lint": "tslint --project tsconfig.json 'lib/**/*.ts' 'bin/*' 'test/**/*.ts' 'tasks/**/*.ts'",
+    "lint": "tslint --project tsconfig.json && tslint --config tslint-alt.json 'bin/*' 'test/**/*.ts' 'tasks/**/*.ts'",
     "db:init": "gulp db.init",
     "docs": "typedoc --out typedoc --module commonjs --target es6 lib",
     "test": "npm run test:unit && npm run test:int",
@@ -25,6 +26,11 @@
     "test:int:watch": "mocha -r ts-node/register test/integration/*  --watch --watch-extensions ts"
   },
   "cross-os": {
+    "stop": {
+      "linux": "./bin/xucli shutdown",
+      "darwin": "./bin/xucli shutdown",
+      "win32": "node bin\\xucli shutdown"
+    },
     "compile": {
       "linux": "rm -rf ./dist && tsc",
       "darwin": "rm -rf ./dist && tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,12 @@
 {
+  "include": [
+    "lib",
+  ],
   "compilerOptions": {
     "target": "ES2016",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "allowJs": true,                          /* Allow javascript files to be compiled. */
-    "outDir": "./dist",                   /* Redirect output structure to the directory. */
+    "allowJs": false,                         /* Allow javascript files to be compiled. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noEmitOnError": false,
     "noImplicitAny": false,                   /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -11,7 +14,7 @@
     "strictNullChecks": true,                 /* Enable strict null checks. */
     "strictFunctionTypes": true,              /* Enable strict checking of function types. */
     "strictPropertyInitialization": true,     /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": false,                  /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": true,                   /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true,                     /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */

--- a/tslint-alt.json
+++ b/tslint-alt.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tslint.json",
+  "rules": {
+    "no-boolean-literal-compare": false
+  }
+}


### PR DESCRIPTION
This PR does the following:

- Adds an `npm stop` script,
- Skips compiling each time `npm start` is called, and splits the `dev` script into `dev` - which compiles and starts - and `dev:watch` - which watches for changes to the code while running. 
- Fixes the lint script by combining two `tslint` commands, one according to the tsconfig.json project file (which only inspects files/folders that are being compiled) and one according to specified folders with a modified config to avoid warnings for required type information.

- Only compiles the `lib` folder. As a result, no `lib` folder is created within `dist` and therefore
all references to `dist/lib` have been adjusted. 
- Disables javascript compiling (not currently used).
- Enables the `noImplicitThis` rule, which the project currently satisfies. 