### PR TITLE
Added contexts for logger

### DIFF
--- a/lib/BaseClient.ts
+++ b/lib/BaseClient.ts
@@ -9,8 +9,8 @@ abstract class BaseClient {
   protected logger: Logger;
   protected status!: ClientStatus;
 
-  constructor() {
-    this.logger = Logger.global;
+  constructor(logger: Logger) {
+    this.logger = logger;
   }
 
   protected setStatus(val: ClientStatus): void {

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -13,7 +13,13 @@ enum Level {
 }
 
 enum Context {
-  GLOBAL,
+  GLOBAL = 'GLOBAL',
+  DB = 'DB',
+  RPC = 'RPC',
+  P2P = 'P2P',
+  ORDERBOOK = 'ORDERBOOK',
+  LND = 'LND',
+  RAIDEN = 'RAIDEN',
 }
 
 const contextFileMap = {
@@ -33,6 +39,12 @@ class Logger {
   : Level.DEBUG;
 
   public static global = new Logger({ context: Context.GLOBAL, logDir: undefined, level: undefined });
+  public static db = new Logger({ context: Context.DB, logDir: undefined, level: undefined });
+  public static rpc = new Logger({ context: Context.RPC, logDir: undefined, level: undefined });
+  public static p2p = new Logger({ context: Context.P2P, logDir: undefined, level: undefined });
+  public static orderbook = new Logger({ context: Context.ORDERBOOK, logDir: undefined, level: undefined });
+  public static lnd = new Logger({ context: Context.LND, logDir: undefined, level: undefined });
+  public static raiden = new Logger({ context: Context.RAIDEN, logDir: undefined, level: undefined });
 
   constructor({ level, logDir, context }: { level?: string, logDir?: string, context: Context}) {
     this.level = level || Logger.defaultLevel;
@@ -41,7 +53,7 @@ class Logger {
 
     const { format } = winston;
     const logFormat = format.printf(
-        info => `${getTsString()} ${info.level}: ${info.message}`);
+        info => `${getTsString()} [${this.context}] ${info.level}: ${info.message}`);
 
     if (!fs.existsSync(this.logDir)) {
       fs.mkdirSync(this.logDir);
@@ -52,7 +64,7 @@ class Logger {
       transports: [
         new winston.transports.Console({ format: format.combine(format.colorize(), logFormat) }),
         new winston.transports.File({
-          filename: path.join(this.logDir, contextFileMap[this.context]),
+          filename: path.join(this.logDir, contextFileMap[Context.GLOBAL]),
         }),
       ],
     });

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -24,6 +24,12 @@ enum Context {
 
 const contextFileMap = {
   [Context.GLOBAL]: 'xud.log',
+  [Context.DB]: 'xud.log',
+  [Context.RPC]: 'xud.log',
+  [Context.P2P]: 'xud.log',
+  [Context.ORDERBOOK]: 'xud.log',
+  [Context.LND]: 'xud.log',
+  [Context.RAIDEN]: 'xud.log',
 };
 
 class Logger {
@@ -64,7 +70,7 @@ class Logger {
       transports: [
         new winston.transports.Console({ format: format.combine(format.colorize(), logFormat) }),
         new winston.transports.File({
-          filename: path.join(this.logDir, contextFileMap[Context.GLOBAL]),
+          filename: path.join(this.logDir, contextFileMap[this.context]),
         }),
       ],
     });

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -44,13 +44,13 @@ class Logger {
   ? Level.INFO
   : Level.DEBUG;
 
-  public static global = new Logger({ context: Context.GLOBAL, logDir: undefined, level: undefined });
-  public static db = new Logger({ context: Context.DB, logDir: undefined, level: undefined });
-  public static rpc = new Logger({ context: Context.RPC, logDir: undefined, level: undefined });
-  public static p2p = new Logger({ context: Context.P2P, logDir: undefined, level: undefined });
-  public static orderbook = new Logger({ context: Context.ORDERBOOK, logDir: undefined, level: undefined });
-  public static lnd = new Logger({ context: Context.LND, logDir: undefined, level: undefined });
-  public static raiden = new Logger({ context: Context.RAIDEN, logDir: undefined, level: undefined });
+  public static global = new Logger({ context: Context.GLOBAL });
+  public static db = new Logger({ context: Context.DB });
+  public static rpc = new Logger({ context: Context.RPC });
+  public static p2p = new Logger({ context: Context.P2P });
+  public static orderbook = new Logger({ context: Context.ORDERBOOK  });
+  public static lnd = new Logger({ context: Context.LND });
+  public static raiden = new Logger({ context: Context.RAIDEN });
 
   constructor({ level, logDir, context }: { level?: string, logDir?: string, context: Context}) {
     this.level = level || Logger.defaultLevel;

--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -30,7 +30,7 @@ type Models = {
 class DB {
   public sequelize!: Sequelize.Sequelize;
   public models!: Models;
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.db;
 
   constructor(private config: DBConfig) {
     assert(Number.isInteger(config.port) && config.port > 1023 && config.port < 65536, 'port must be an integer between 1024 and 65535');

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -29,10 +29,8 @@ class LndClient extends BaseClient{
    * @param config The lnd configuration
    */
   constructor(config: LndClientConfig) {
-    super();
+    super(Logger.lnd);
     const { disable, datadir, certpath, host, port, macaroonpath } = config;
-
-    this.logger = Logger.global;
 
     if (disable) {
       this.setStatus(ClientStatus.DISABLED);

--- a/lib/orderbook/MatchesProcessor.ts
+++ b/lib/orderbook/MatchesProcessor.ts
@@ -6,7 +6,7 @@ class MatchesProcessor {
 
   constructor() {
     this.buffer = [];
-    this.logger = Logger.global;
+    this.logger = Logger.orderbook;
   }
 
   public add(match) {

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -29,7 +29,7 @@ type SplitOrder = {
 
 class MatchingEngine {
   public priorityQueues: PriorityQueues;
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.orderbook;
 
   constructor(public pairId: string,
               private internalMatching: boolean,

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -16,7 +16,7 @@ type OrderBookConfig = {
 };
 
 class OrderBook {
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.orderbook;
   private repository: OrderBookRepository;
   private matchesProcessor: MatchesProcessor = new MatchesProcessor();
   public pairs: db.PairInstance[] = [];

--- a/lib/orderbook/OrderBookRepository.ts
+++ b/lib/orderbook/OrderBookRepository.ts
@@ -11,7 +11,7 @@ type Orders = {
 };
 
 class OrderbookRepository {
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.orderbook;
   private models: Models;
 
   constructor(db: DB) {

--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -3,7 +3,7 @@ import DB, { Models } from '../db/DB';
 import { db } from '../types';
 
 class P2PRepository {
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.p2p;
   private models: Models;
 
   constructor(private db: DB) {

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -16,7 +16,7 @@ enum ConnectionDirection {
 /** Represents a remote XU peer */
 class Peer extends EventEmitter {
   public address!: SocketAddress;
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.p2p;
   private connected: boolean = false;
   private opened: boolean = false;
   private direction?: ConnectionDirection;

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -19,7 +19,7 @@ type PoolConfig = {
 class Pool extends EventEmitter {
   private peers: PeerList = new PeerList();
   private server: Server = net.createServer();
-  private logger: Logger = Logger.global;
+  private logger: Logger = Logger.p2p;
   private connected: boolean = false;
   private hosts: Hosts = new Hosts();
 

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 
-import BaseClient, { ClientStatus } from'../BaseClient';
+import Logger from '../Logger';
+import BaseClient, { ClientStatus } from '../BaseClient';
 import * as errors from './errors';
 
 /**
@@ -76,7 +77,7 @@ class RaidenClient extends BaseClient {
    * Create a raiden client.
    */
   constructor(config: RaidenClientConfig) {
-    super();
+    super(Logger.raiden);
     const { disable, host, port } = config;
 
     this.port = port;

--- a/lib/rpc/RpcMethods.ts
+++ b/lib/rpc/RpcMethods.ts
@@ -24,7 +24,7 @@ class RpcMethods {
     this.pool = components.pool;
     this.shutdown = components.shutdown;
 
-    this.logger = Logger.global;
+    this.logger = Logger.rpc;
 
     this.getInfo = this.getInfo.bind(this);
     this.getPairs = this.getPairs.bind(this);

--- a/lib/rpc/RpcServer.ts
+++ b/lib/rpc/RpcServer.ts
@@ -24,7 +24,7 @@ type RpcComponents = {
 /** Class representing an Exchange Union RPC Server. */
 class RpcServer {
   private server: HttpJsonRpcServer;
-  private logger: Logger;
+  private logger: Logger = Logger.rpc;
 
   /**
    * Create an RPC server.
@@ -44,7 +44,6 @@ class RpcServer {
       },
       methods: getPublicMethods(rpcMethods),
     });
-    this.logger = Logger.global;
   }
 
   /**


### PR DESCRIPTION
This pr adds contexts to the logger as in #99.

But I am not sure about the fact that every context has its own static instance in the `Logger` class. What about a constructor that takes only the context as argument? `logDir` and `level` are the same anyway. 