### PR TITLE
Market Order task - consolidation

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -69,7 +69,7 @@ class OrderBook {
     return this.repository.getPeerOrders(pairId, maxResults);
   }
 
-  public addFillOrder = async (order: orders.OwnOrder): Promise<matchingEngine.MatchingResult>  => {
+  public addLimitOrder = async (order: orders.OwnOrder): Promise<matchingEngine.MatchingResult>  => {
     return this.addOwnOrder(order);
   }
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -69,7 +69,15 @@ class OrderBook {
     return this.repository.getPeerOrders(pairId, maxResults);
   }
 
-  public addOwnOrder = async (order: orders.OwnOrder): Promise<matchingEngine.MatchingResult>  => {
+  public addFillOrder = async (order: orders.OwnOrder): Promise<matchingEngine.MatchingResult>  => {
+    return this.addOwnOrder(order);
+  }
+
+  public addMarketOrder = async (_order: orders.OwnOrder) => {
+    // TODO: implement
+  }
+
+  private addOwnOrder = async (order: orders.OwnOrder): Promise<matchingEngine.MatchingResult>  => {
     const matchingEngine = this.matchingEngines[order.pairId];
     if (!matchingEngine) {
       throw errors.INVALID_PAIR_ID(order.pairId);
@@ -99,7 +107,7 @@ class OrderBook {
     return matchingResult;
   }
 
-  public addPeerOrder = async (order: orders.PeerOrder): Promise<void> => {
+  private addPeerOrder = async (order: orders.PeerOrder): Promise<void> => {
     const matchingEngine = this.matchingEngines[order.pairId];
     if (!matchingEngine) {
       this.logger.debug(`incoming peer order invalid pairId: ${order.pairId}`);

--- a/lib/rpc/RpcMethods.ts
+++ b/lib/rpc/RpcMethods.ts
@@ -76,7 +76,7 @@ class RpcMethods {
     assert(order.quantity !== 0, 'quantity must not equal 0');
     assert(typeof order.pairId === 'string', 'pairId name must be a string');
 
-    return this.orderBook.addOwnOrder(order);
+    return this.orderBook.addFillOrder(order);
   }
 
   /**

--- a/lib/rpc/RpcMethods.ts
+++ b/lib/rpc/RpcMethods.ts
@@ -76,7 +76,7 @@ class RpcMethods {
     assert(order.quantity !== 0, 'quantity must not equal 0');
     assert(typeof order.pairId === 'string', 'pairId name must be a string');
 
-    return this.orderBook.addFillOrder(order);
+    return this.orderBook.addLimitOrder(order);
   }
 
   /**

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -55,19 +55,16 @@ describe('OrderBook', () => {
     });
   });
 
-  it('should append new ownOrder', async () => {
+  it('should append two new ownOrder', async () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC',  quantity: 5, price: 55 };
-    await orderBook.addOwnOrder(order);
+    await orderBook.addFillOrder(order);
+    await orderBook.addFillOrder(order);
   });
 
-  it('should append new peerOrder', async () => {
-    const order: orders.PeerOrder = { id: uuidv1(), pairId: 'BTC/LTC',  quantity: 5, price: 55, hostId: 1, invoice: 'dummyInvoice' };
-    await orderBook.addPeerOrder(order);
-  });
 
   it('should match new ownOrder and update matches', async () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC', quantity: -6, price: 55 };
-    const matches = await orderBook.addOwnOrder(order);
+    const matches = await orderBook.addFillOrder(order);
     expect(matches.remainingOrder).to.be.null;
     const firstMakerLeft = await getOrderQuantity(matches.matches[0].maker.id);
     expect(firstMakerLeft).to.be.equal(0);

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -61,7 +61,6 @@ describe('OrderBook', () => {
     await orderBook.addFillOrder(order);
   });
 
-
   it('should match new ownOrder and update matches', async () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC', quantity: -6, price: 55 };
     const matches = await orderBook.addFillOrder(order);

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -57,13 +57,13 @@ describe('OrderBook', () => {
 
   it('should append two new ownOrder', async () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC',  quantity: 5, price: 55 };
-    await orderBook.addFillOrder(order);
-    await orderBook.addFillOrder(order);
+    await orderBook.addLimitOrder(order);
+    await orderBook.addLimitOrder(order);
   });
 
   it('should match new ownOrder and update matches', async () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC', quantity: -6, price: 55 };
-    const matches = await orderBook.addFillOrder(order);
+    const matches = await orderBook.addLimitOrder(order);
     expect(matches.remainingOrder).to.be.null;
     const firstMakerLeft = await getOrderQuantity(matches.matches[0].maker.id);
     expect(firstMakerLeft).to.be.equal(0);


### PR DESCRIPTION
A small PR for just defining the order book high-level API.

* making `addPeerOrder` a private method, because it won't be consumed directly by exchanged, but rather by the P2P layer. 
* defining two public methods, to be directly consumed by exchanged: `addFillOrder` & `addMarketOrder`. both are implicitly referring to an `OwnOrder`.

The idea of how to implement a Market Order: 
* Buy orders `price` will be set to `Number.MAX_VALUE`.
* Sell order `price` will set to 0.
* After matching, the remaining order won't become a maker order: it won't be added to the queues (for internal matching), and won't be broadcasted to peers. 

@kilrau 

#105 