### PR TITLE
Type safety for SocketAddress

### DIFF
--- a/lib/p2p/SocketAddress.ts
+++ b/lib/p2p/SocketAddress.ts
@@ -1,20 +1,26 @@
 import { Socket } from 'net';
+import assert from 'assert';
 
 /** Represents a network socketAddress */
 class SocketAddress {
-  constructor(public address, public port) {}
+  constructor(public address: string, public port: number) {}
 
-  public static fromSocket(socket: Socket) {
+  /**
+   * Create a `SocketAddress` using the remote host and port of a `Socket`
+   */
+  public static fromSocket = (socket: Socket) => {
     const { remoteAddress: address, remotePort: port } = socket;
-    return new SocketAddress(address, port);
+    assert(address, 'socket must have a remoteAddress value');
+    assert(port, 'socket must have a remotePort value');
+    return new SocketAddress(address!, port!);
   }
 
-  public static fromString(socketAddress: string) {
+  public static fromString = (socketAddress: string) => {
     const arr = socketAddress.split(':');
-    return new SocketAddress(arr[0], arr[1]);
+    return new SocketAddress(arr[0], parseInt(arr[1], 10));
   }
 
-  public toString(): string {
+  public toString = () => {
     return `${this.address}:${this.port}`;
   }
 }


### PR DESCRIPTION
This adds some type safety to the `SocketAddress` class and switches to arrow functions to follow the style of other classes.