### PR TITLE
Fixed travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ script:
   - cd docker/xud && docker build -t exchangeunion/xud .
 
 before_install:
+  - sudo apt-get install -y rsync
   - mysql -e 'CREATE USER 'xud'@'localhost'';
   - mysql -e 'GRANT ALL PRIVILEGES ON `xud\_%`.* TO `xud`@`%`;'


### PR DESCRIPTION
This PR will Travis make install `rsync` before compiling the Docker image and cause the build to succeed.