### PR TITLE
Pool silent conn error

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import bootstrap from './bootstrap';
 import Logger from './Logger';
 import Config from './Config';
 import DB from './db/DB';
@@ -9,11 +9,9 @@ import GrpcServer from './grpc/GrpcServer';
 import GrpcWebProxyServer from './grpc/webproxy/GrpcWebProxyServer';
 import Pool from './p2p/Pool';
 import NodeKey from './nodekey/NodeKey';
-import dotenv from 'dotenv';
 import Service from './service/Service';
 
-/** Loads environment variables from the file .env */
-dotenv.config();
+bootstrap();
 
 /** Class representing a complete Exchange Union daemon. */
 class Xud {

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -4,7 +4,7 @@ export default () => {
   /** Loads environment variables from the file .env */
   dotenv.config();
 
-  /** rethrow unhandled promise rejection, to crash process of an unwrapped instance */
+  /** Rethrow unhandled promise rejection, to crash process of an unwrapped instance */
   process.on('unhandledRejection', (err) => {
     console.log(err);
     throw err;

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -5,8 +5,8 @@ export default () => {
   dotenv.config();
 
   /** rethrow unhandled promise rejection, to crash process of an unwrapped instance */
-  process.on('unhandledRejection', err => {
+  process.on('unhandledRejection', (err) => {
     console.log(err);
     throw err;
-  })
-}
+  });
+};

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -1,0 +1,12 @@
+import dotenv from 'dotenv';
+
+export default () => {
+  /** Loads environment variables from the file .env */
+  dotenv.config();
+
+  /** rethrow unhandled promise rejection, to crash process of an unwrapped instance */
+  process.on('unhandledRejection', err => {
+    console.log(err);
+    throw err;
+  })
+}

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -61,7 +61,7 @@ class Peer extends EventEmitter {
     return peer;
   }
 
-  public getStatus(): string {
+  public getStatus = (): string => {
     if (this.connected) {
       return `Connected to peer (${this.id})`;
     } else {

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -43,14 +43,6 @@ class Peer extends EventEmitter {
     return this.socketAddress.toString();
   }
 
-  get statusString(): string {
-    if (this.connected) {
-      return `Connected to peer (${this.id})`;
-    } else {
-      return 'Not connected';
-    }
-  }
-
   constructor() {
     super();
 
@@ -67,6 +59,14 @@ class Peer extends EventEmitter {
     const peer = new Peer();
     peer.accept(socket);
     return peer;
+  }
+
+  public getStatus(): string {
+    if (this.connected) {
+      return `Connected to peer (${this.id})`;
+    } else {
+      return 'Not connected';
+    }
   }
 
   public open = async (): Promise<void> => {
@@ -129,7 +129,7 @@ class Peer extends EventEmitter {
 
     if (this.connected) {
       assert(this.direction === ConnectionDirection.INBOUND);
-      this.logger.debug(this.statusString);
+      this.logger.debug(this.getStatus());
       return Promise.resolve();
     }
 
@@ -144,13 +144,14 @@ class Peer extends EventEmitter {
 
       const onError = (err) => {
         cleanup();
+        this.destroy();
         reject(err);
       };
 
       this.socket.once('connect', () => {
         this.connectTime = Date.now();
         this.connected = true;
-        this.logger.debug(this.statusString);
+        this.logger.debug(this.getStatus());
         this.emit('connect');
 
         cleanup();
@@ -162,6 +163,7 @@ class Peer extends EventEmitter {
       this.connectTimeout = setTimeout(() => {
         this.connectTimeout = undefined;
         cleanup();
+        this.destroy();
         reject(new Error('Connection timed out.'));
       }, 10000);
     });

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -73,7 +73,7 @@ class Pool extends EventEmitter {
     try {
       await this.connectPeer(peer);
     } catch (err) {
-      this.logger.warn(`connectPeer failed: ${err}`);
+      this.logger.info(`connectPeer failed: ${err}`);
     }
   }
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -65,8 +65,16 @@ class Pool extends EventEmitter {
     }
 
     const peer = Peer.fromOutbound(socketAddress);
-    await this.connectPeer(peer);
+    await this.tryConnectPeer(peer);
     return peer;
+  }
+
+  private tryConnectPeer = async (peer: Peer): Promise<void> => {
+    try {
+      return await this.connectPeer(peer);
+    } catch(err) {
+      this.logger.warn(`connectPeer failed: ${err}`);
+    }
   }
 
   private connectPeer = async (peer: Peer): Promise<void> => {
@@ -174,9 +182,7 @@ class Pool extends EventEmitter {
   }
 
   private destroyPeers = (): void => {
-    Object.keys(this.peers).map((key) => {
-      this.peers[key].destroy();
-    });
+    this.peers.forEach(peer => peer.destroy());
   }
 
   private listen = (): void => {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -71,7 +71,7 @@ class Pool extends EventEmitter {
 
   private tryConnectPeer = async (peer: Peer): Promise<void> => {
     try {
-      return await this.connectPeer(peer);
+      await this.connectPeer(peer);
     } catch (err) {
       this.logger.warn(`connectPeer failed: ${err}`);
     }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -72,7 +72,7 @@ class Pool extends EventEmitter {
   private tryConnectPeer = async (peer: Peer): Promise<void> => {
     try {
       return await this.connectPeer(peer);
-    } catch(err) {
+    } catch (err) {
       this.logger.warn(`connectPeer failed: ${err}`);
     }
   }

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -75,8 +75,8 @@ class Service {
    * Connect to an XU node on a given host and port.
    */
   public connect = async ({ host, port }: { host: string, port: number }) => {
-    await this.pool.addOutbound(host, port);
-    return 'connected';
+    const peer = await this.pool.addOutbound(host, port);
+    return peer.getStatus();
   }
 
   /**


### PR DESCRIPTION
Fixes #126 

Plus:
* crashing the process on `unhandledRejection`. there's no reason to swallow them. 
* creating a separate `bootstrap` function, to be accessible from different entry points (tests, etc.).
