### PR TITLE
cli improvements

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -2,6 +2,9 @@
 
 require('yargs')
   .options({
+    'rpc': {
+      default: {},
+    },
     'rpc.port': {
       alias: 'p',
       default: 8886,
@@ -16,4 +19,6 @@ require('yargs')
     },
   })
   .commandDir('../dist/cli/commands')
+  .demandCommand(1, '')
+  .strict()
   .argv; // we must read the argv property for the command line args to initialize properly

--- a/bin/xucli
+++ b/bin/xucli
@@ -3,7 +3,7 @@
 require('yargs')
   .options({
     rpc: {
-      default: {},
+      hidden: true,
     },
     'rpc.port': {
       alias: 'p',

--- a/bin/xucli
+++ b/bin/xucli
@@ -2,7 +2,7 @@
 
 require('yargs')
   .options({
-    'rpc': {
+    rpc: {
       default: {},
     },
     'rpc.port': {


### PR DESCRIPTION
This PR takes care of two things:


`xucli` demands one command which means that if none is specified help will be shown. 


If the specified is not found help and the error `Unknown argument: foo` will be shown. `.strict()` enforces that. But it doesn't play nicely with options containing dots (`Unknown argument: rpc`). I found two ways to handle that:

Adding
```
  "yargs": {
    "dot-notation": false
  }
```
to `package.json`. That means that nested object won't be possible. For example: `argv.rpc.host` would become `argv['rpc.host']`.

Or initializing `rpc` is an empty object in `bin/xucli`:
```
    rpc: {
      default: {},
    },
```
The disadvantage of this method is that the help of `xucli` would look like this:
```
xucli <command>

Commands:
  xucli connect <host> [port]               connect to an xu node
  xucli getinfo                             get general info from the xud node
  xucli getorders [pair_id] [max_results]   get orders from the orderbook
  xucli getpairs                            get orderbook's available pairs
  xucli placeorder <pair_id> <price>        place an order
  <quantity>
  xucli shutdown                            gracefully shutdown the xud node
  xucli tokenswap <identifier> <role>       perform a raiden token swap
  <sending_amount> <sending_token>
  <receiving_amount> <receiving_token>

Options:
  --help          Show help                                            [boolean]
  --version       Show version number                                  [boolean]
  --rpc                              [default: {"port":8886,"host":"localhost"}]
  --rpc.port, -p  RPC service port                      [number] [default: 8886]
  --rpc.host, -h  RPC service hostname           [string] [default: "localhost"]

```

I really don't like the inconsistency that comes with the second option. But I went for it for now because I wanted to hear your opinions on this subject before changing the way options are parsed.