### PR TITLE
Refactor lndclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ port = 8885
 
 [lnd]
 disable = false
-datadir = "~/.lnd"
 host = "localhost"
 
 [raiden]
@@ -88,7 +87,6 @@ Options:
   --db.port                     Port for SQL database                   [number]
   --db.username                 User for SQL database                   [string]
   --lnd.certpath                Path to the SSL certificate for lnd     [string]
-  --lnd.datadir                 Data directory for lnd                  [string]
   --lnd.disable                 Disable lnd integration                [boolean]
   --lnd.host                    Host of the lnd gRPC interface          [string]
   --lnd.macaroonpath            Path of the admin macaroon for lnd      [string]

--- a/bin/xud
+++ b/bin/xud
@@ -33,10 +33,6 @@ const { argv } = require('yargs')
       describe: 'Path to the SSL certificate for lnd',
       type: 'string',
     },
-    'lnd.datadir': {
-      describe: 'Data directory for lnd',
-      type: 'string',
-    },
     'lnd.disable': {
       describe: 'Disable lnd integration',
       type: 'boolean',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -22,24 +22,24 @@ class Config {
 
   constructor(private args?: object) {
     const platform = os.platform();
-    let lndDatadir;
+    let lndDefaultDatadir;
     switch (platform) {
       case 'win32': { // windows
         const homeDir = process.env.LOCALAPPDATA;
         this.xudir = `${homeDir}/Xud/`;
-        lndDatadir = `${homeDir}/Lnd/`; // default lnd directory location
+        lndDefaultDatadir = `${homeDir}/Lnd/`;
         break;
       }
       case 'darwin': { // mac
         const homeDir = process.env.HOME;
         this.xudir = `${homeDir}/.xud/`;
-        lndDatadir = `${homeDir}/Library/Application Support/Lnd/`;
+        lndDefaultDatadir = `${homeDir}/Library/Application Support/Lnd/`;
         break;
       }
       default: { // linux
         const homeDir = process.env.HOME;
         this.xudir = `${homeDir}/.xud/`;
-        lndDatadir = `${homeDir}/.lnd/`;
+        lndDefaultDatadir = `${homeDir}/.lnd/`;
         break;
       }
     }
@@ -70,9 +70,8 @@ class Config {
     };
     this.lnd = {
       disable: false,
-      datadir: lndDatadir,
-      certpath: path.join(lndDatadir, 'tls.cert'),
-      macaroonpath: path.join(lndDatadir, 'admin.macaroon'),
+      certpath: path.join(lndDefaultDatadir, 'tls.cert'),
+      macaroonpath: path.join(lndDefaultDatadir, 'admin.macaroon'),
       host: 'localhost',
       port: 10009,
     };
@@ -97,8 +96,7 @@ class Config {
         // merge parsed json properties from config file to this config object
         deepMerge(this, props);
       } catch (e) {
-        throw new Error(`Parsing error on line ${e.line}, column ${e.column
-        }: ${e.message}`);
+        throw new Error(`Parsing error on line ${e.line}, column ${e.column}: ${e.message}`);
       }
     }
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -43,6 +43,8 @@ class Service {
    */
   public getInfo = async () => {
     const lnd = await this.lndClient.getInfo();
+    delete lnd.chainsList;
+    delete lnd.urisList;
     return { lnd };
   }
 


### PR DESCRIPTION
This is similar to the changes in #129 except applied to the LND client. Now all LND calls use the generated request/response types, and the main purpose of LNDClient.ts is to establish the grpc connection and to wrap calls with promises.

I did the bare minimum to make the `getinfo` cli call working, as it is being reworked in #131.