### PR TITLE
Restore mysql2 dependecy, hardcode mysql dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Launch a new `xud` process
 ~/xud $ cd bin
 ~/xud/bin $ ./xud
 2018-6-3 15:14:27 [GLOBAL] info: config loaded
-2018-6-3 15:14:27 [DB] info: connected to database. host:localhost port:3306 database:xud dialect:mysql
+2018-6-3 15:14:27 [DB] info: connected to database. host:localhost port:3306 database:xud
 2018-6-3 15:14:28 [LND] info: LndClient status: CONNECTION_VERIFIED
 2018-6-3 15:14:28 [P2P] info: pool server listening on 0.0.0.0:8885
 2018-6-3 15:14:28 [RPC] info: GRPC server listening on port 8886
@@ -82,7 +82,6 @@ Options:
   --version                     Show version number                    [boolean]
   --xudir, -x                   Data directory for xud                  [string]
   --db.database                 SQL database name                       [string]
-  --db.dialect                  SQL database dialect                    [string]
   --db.host                     Hostname for SQL database               [string]
   --db.port                     Port for SQL database                   [number]
   --db.username                 User for SQL database                   [string]

--- a/bin/xud
+++ b/bin/xud
@@ -13,10 +13,6 @@ const { argv } = require('yargs')
       describe: 'SQL database name',
       type: 'string',
     },
-    'db.dialect': {
-      describe: 'SQL database dialect',
-      type: 'string',
-    },
     'db.host': {
       describe: 'Hostname for SQL database',
       type: 'string',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -54,7 +54,6 @@ class Config {
       port: 3306,
       username: 'xud',
       database: 'xud',
-      dialect: 'mysql',
     };
     this.testDb = {
       ...this.db,

--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -13,7 +13,6 @@ type SequelizeConfig = {
   username: string;
   password?: string;
   database?: string;
-  dialect: string;
 };
 
 type DBConfig = SequelizeConfig & {
@@ -47,8 +46,8 @@ class DB {
   public init = async (): Promise<void> => {
     try {
       await this.sequelize.authenticate();
-      const { host, port, database, dialect } = this.config;
-      this.logger.info(`connected to database. host:${host} port:${port} database:${database} dialect:${dialect}`);
+      const { host, port, database } = this.config;
+      this.logger.info(`connected to database. host:${host} port:${port} database:${database}`);
     } catch (err) {
       if (DB.isDbDoesNotExistError(err)) {
         await this.createDatabase();
@@ -98,6 +97,7 @@ class DB {
   private createSequelizeInstance = (config: SequelizeConfig): Sequelize.Sequelize => {
     return new Sequelize({
       ...config,
+      dialect: 'mysql',
       operatorsAliases: false,
       dialectOptions: {
         multipleStatements: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,6 +303,11 @@
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -879,6 +884,15 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
+    },
+    "cardinal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -1704,6 +1718,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
+    },
+    "denque": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.2.3.tgz",
+      "integrity": "sha512-BOjyD1zPf7gqgXlXBCnCsz84cbRNfqpQNvWOUiw3Onu9s7a2afW2LyHzctoie/2KELfUoZkNHTnW02C3hCU20w=="
     },
     "depd": {
       "version": "1.1.2",
@@ -3152,6 +3171,11 @@
           }
         }
       }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
     },
     "generic-pool": {
       "version": "3.4.2",
@@ -5230,6 +5254,11 @@
         }
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -5516,6 +5545,56 @@
       "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.0.tgz",
       "integrity": "sha1-WzLqB+tDyd7WEwQ0z5JvRrKn/U0="
     },
+    "mysql2": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-1.5.3.tgz",
+      "integrity": "sha512-Oov36YQSeciNP9SeqE7je4eWgeGADOorXLmsqhtxOJmPGUOJSNJT0s6/eq1Byy4nhXTRQUvlMHsI4Q/eMEs88Q==",
+      "requires": {
+        "cardinal": "1.0.0",
+        "denque": "1.2.3",
+        "generate-function": "^2.0.0",
+        "iconv-lite": "^0.4.18",
+        "long": "^4.0.0",
+        "lru-cache": "4.1.1",
+        "named-placeholders": "1.1.1",
+        "object-assign": "^4.1.1",
+        "readable-stream": "2.3.5",
+        "safe-buffer": "^5.0.1",
+        "seq-queue": "0.0.5",
+        "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
+      "integrity": "sha1-O3oNJiA910s6nfTJz7gnsvuQfmQ=",
+      "requires": {
+        "lru-cache": "2.5.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+          "integrity": "sha1-2COIrpyWC+y+oMc7uet5tsbOmus="
+        }
+      }
+    },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
@@ -5686,8 +5765,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6334,6 +6412,21 @@
         "resolve": "^1.1.6"
       }
     },
+    "redeyed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+      "requires": {
+        "esprima": "~3.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
+        }
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
@@ -6693,6 +6786,11 @@
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
+    },
+    "seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "sequelize": {
       "version": "4.37.3",
@@ -7057,6 +7155,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sqlstring": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
     },
     "sshpk": {
       "version": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "fastpriorityqueue": "^0.3.1",
     "grpc": "^1.12.2",
     "gulp": "^4.0.0",
+    "mysql2": "^1.5.3",
     "protocol-buffers-schema": "^3.3.2",
     "secp256k1": "^3.5.0",
     "sequelize": "^4.37.3",


### PR DESCRIPTION
This PR restores the `mysql2` dependency removed in #140 because it is required when Sequelize is using the mysql dialect. This also removes sql dialect as one of the configurable db options, thereby enforcing the use of a mysql-compatible database via the code.