### PR TITLE
Refactor packets

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -93,7 +93,7 @@ class Pool extends EventEmitter {
   }
 
   public broadcastOrder = (order: orders.OutgoingOrder) => {
-    const orderPacket = new OrderPacket().fromOutgoingOrder(order);
+    const orderPacket = new OrderPacket(order);
     this.peers.forEach(peer => peer.sendPacket(orderPacket));
   }
 

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -3,41 +3,56 @@ import CryptoJS from 'crypto-js';
 import MD5 from 'crypto-js/md5';
 
 type PacketHeader = {
+  /** The Base64 encoded MD5 hash of the body of this packet. This is used for error checking and as a key to identify packets.*/
   hash: string;
+  /** The hash of the body of the received packet which this packet is responding to. */
   reqHash?: string;
 };
 
-enum MessageType {
+enum PacketDirection {
+  /** A packet that is pushed to a peer without expecting any response. */
   UNILATERAL,
+  /** A packet that is sent to a peer requesting a particular response. */
   REQUEST,
+  /** A packet that is sent in response to an incoming packet. */
   RESPONSE,
 }
 
-abstract class Packet {
-  public header!: PacketHeader;
-  public abstract type: PacketType;
-  public abstract messageType: MessageType;
-  public abstract body: any;
+abstract class Packet<T = any> {
+  public abstract get type(): PacketType;
+  public abstract get direction(): PacketDirection;
+  public body: T;
+  public header: PacketHeader;
 
-  public fromRaw(raw: string): Packet {
-    const { header, body } = JSON.parse(raw);
-    this.body = body;
-    this.header = header;
-    return this;
+  /**
+   * Create a packet from a packet body or from a raw, serialized packet.
+   * @param body
+   * @param reqHash The requesting packet hash to set on the header if this packet is a response
+   */
+  constructor(body: T | string, reqHash?: string) {
+    if (typeof body === 'string') {
+      // we are deserializing a received packet from a raw JSON string
+      const packet = JSON.parse(body);
+      this.body = packet.body;
+      this.header = packet.header;
+    } else {
+      // we are creating a new outgoing packet from a body
+      this.body = body;
+      this.header = {
+        reqHash,
+        hash: MD5(JSON.stringify(body)).toString(CryptoJS.enc.Base64),
+      };
+    }
   }
 
+  /**
+   * Serialize this packet to JSON
+   */
   public toRaw(): string {
     const { header, body } = this;
     return JSON.stringify({ header, body });
   }
-
-  public createHeader(body: any, reqHash?: string): PacketHeader {
-    return {
-      reqHash,
-      hash: MD5(JSON.stringify(body)).toString(CryptoJS.enc.Base64),
-    };
-  }
 }
 
 export default Packet;
-export { PacketHeader, MessageType };
+export { PacketHeader, PacketDirection };

--- a/lib/p2p/packets/index.ts
+++ b/lib/p2p/packets/index.ts
@@ -1,4 +1,4 @@
 export { default as packetUtils } from './packetUtils';
 export { default as PacketType } from './PacketType';
-export { default as Packet, MessageType } from './Packet';
+export { default as Packet, PacketDirection } from './Packet';
 export { OrderPacket, HelloPacket, PingPacket, PongPacket } from './types';

--- a/lib/p2p/packets/packetUtils.ts
+++ b/lib/p2p/packets/packetUtils.ts
@@ -5,13 +5,13 @@ import * as packetTypes from './types';
 const fromRaw = (type: string, packet: string): Packet | void => {
   switch (type) {
     case PacketType.HELLO:
-      return new packetTypes.HelloPacket().fromRaw(packet);
+      return new packetTypes.HelloPacket(packet);
     case PacketType.PING:
-      return new packetTypes.PingPacket().fromRaw(packet);
+      return new packetTypes.PingPacket(packet);
     case PacketType.PONG:
-      return new packetTypes.PongPacket().fromRaw(packet);
+      return new packetTypes.PongPacket(packet);
     case PacketType.ORDER:
-      return new packetTypes.OrderPacket().fromRaw(packet);
+      return new packetTypes.OrderPacket(packet);
     default:
       return;
   }

--- a/lib/p2p/packets/types/HelloPacket.ts
+++ b/lib/p2p/packets/types/HelloPacket.ts
@@ -1,4 +1,4 @@
-import Packet, { MessageType } from '../Packet';
+import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 
 type HelloPacketBody = {
@@ -8,15 +8,13 @@ type HelloPacketBody = {
   pairs: string[];
 };
 
-class HelloPacket extends Packet {
-  public type: PacketType = PacketType.HELLO;
-  public messageType: MessageType = MessageType.UNILATERAL;
-  public body!: HelloPacketBody;
+class HelloPacket extends Packet<HelloPacketBody> {
+  public get type() {
+    return PacketType.HELLO;
+  }
 
-  public init(args: HelloPacketBody): HelloPacket {
-    this.body = args;
-    this.header = this.createHeader(this.body);
-    return this;
+  public get direction() {
+    return PacketDirection.UNILATERAL;
   }
 }
 

--- a/lib/p2p/packets/types/OrderPacket.ts
+++ b/lib/p2p/packets/types/OrderPacket.ts
@@ -1,4 +1,4 @@
-import Packet, { MessageType } from '../Packet';
+import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 import { orders } from '../../../types/index';
 
@@ -10,19 +10,13 @@ type OrderPacketBody = {
   invoice: string;
 };
 
-class OrderPacket extends Packet {
-  public type: PacketType = PacketType.ORDER;
-  public messageType: MessageType = MessageType.UNILATERAL;
-  public body!: OrderPacketBody;
-
-  public init(args: OrderPacketBody): OrderPacket {
-    this.body = args;
-    this.header = this.createHeader(this.body);
-    return this;
+class OrderPacket extends Packet<OrderPacketBody> {
+  public get type() {
+    return PacketType.HELLO;
   }
 
-  public fromOutgoingOrder(order: orders.OutgoingOrder): OrderPacket {
-    return this.init(order);
+  public get direction() {
+    return PacketDirection.UNILATERAL;
   }
 }
 

--- a/lib/p2p/packets/types/PingPacket.ts
+++ b/lib/p2p/packets/types/PingPacket.ts
@@ -1,20 +1,17 @@
-import Packet, { MessageType } from '../Packet';
+import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
-import { ms } from '../../../utils/utils';
 
 type PingPacketBody = {
   ts: number;
 };
 
-class PingPacket extends Packet {
-  public type: PacketType = PacketType.PING;
-  public messageType: MessageType = MessageType.REQUEST;
-  public body!: PingPacketBody;
+class PingPacket extends Packet<PingPacketBody> {
+  public get type() {
+    return PacketType.PING;
+  }
 
-  public init(): PingPacket {
-    this.body = { ts: ms() };
-    this.header = this.createHeader(this.body);
-    return this;
+  public get direction() {
+    return PacketDirection.REQUEST;
   }
 }
 

--- a/lib/p2p/packets/types/PongPacket.ts
+++ b/lib/p2p/packets/types/PongPacket.ts
@@ -1,22 +1,18 @@
-import Packet, { MessageType } from '../Packet';
+import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
-import { ms } from '../../../utils/utils';
 
 type PongPacketBody = {
   ts: number;
 };
 
-class PongPacket extends Packet {
-  public type: PacketType = PacketType.PONG;
-  public messageType: MessageType = MessageType.RESPONSE;
-  public body!: PongPacketBody;
-
-  public init(args: { reqHash: string }): PongPacket {
-    this.body = { ts: ms() };
-    this.header = this.createHeader(this.body, args.reqHash);
-    return this;
+class PongPacket extends Packet<PongPacketBody> {
+  public get type() {
+    return PacketType.PONG;
   }
 
+  public get direction() {
+    return PacketDirection.RESPONSE;
+  }
 }
 
 export default PongPacket;


### PR DESCRIPTION
This is a followup to #189. I think I found a reasonable approach to the packet classes using generics. The body property itself is generic, and all classes extended `Packet` share a single constructor which itself is overloaded in that it accepts either a packet body type and an optional request hash (for creating outgoing packets) or a string (for deserializing incoming packets).

This refactors the Packet class and its derivations in the following ways:

- Adding a generic type parameter to Packet which is used for a generic constructor and to define the `body` type.
- Generic constructor that accepts either a packet body type or a string. If passed a string, it attempts to deserialize it into a packet.
- Renaming `MessageType` to `PacketDirection` to differentiate itself from `PacketType`
- Change the `type` and `messageType`/`direction` parameters to getter functions that return fixed values, since we don't want these values to be overwritten.