### PR TITLE
Hosts and Get_Hosts Packets

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -53,7 +53,7 @@ class Xud {
       this.raidenClient = new RaidenClient(this.config.raiden);
 
       this.pool = new Pool(this.config.p2p, this.db);
-      this.pool.connect();
+      this.pool.init();
 
       this.orderBook = new OrderBook(this.db.models, this.pool, this.lndClient);
       await this.orderBook.init();

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 import Host from './Host';
 import SocketAddress from './SocketAddress';
 import Parser, { ParserError, ParserErrorType } from './Parser';
-import { Packet, PacketDirection, PacketType, HelloPacket, PingPacket, PongPacket, GetOrdersPacket, OrdersPacket } from './packets';
+import { Packet, PacketDirection, PacketType, HelloPacket, PingPacket, PongPacket, HostsPacket, OrdersPacket } from './packets';
 import Logger from '../Logger';
 import { ms } from '../utils/utils';
 import { orders } from '../types';
@@ -152,16 +152,19 @@ class Peer extends EventEmitter {
     this.sendRaw(packet.type, packet.toRaw());
 
     if (packet.direction === PacketDirection.REQUEST) {
-      this.addResponseTimeout(packet.header.hash!, Peer.RESPONSE_TIMEOUT);
+      this.addResponseTimeout(packet.header.hash, Peer.RESPONSE_TIMEOUT);
     }
   }
 
-  public sendOrders = (orders: orders.OutgoingOrder[]): OrdersPacket => {
+  public sendOrders = (orders: orders.OutgoingOrder[]): void => {
     const packet = new OrdersPacket({ orders });
 
     this.sendPacket(packet);
+  }
 
-    return packet;
+  public sendHosts = (hosts: Host[], reqHash: string): void => {
+    const packet = new HostsPacket({ hosts }, reqHash);
+    this.sendPacket(packet);
   }
 
   private sendRaw = (type, body) => {

--- a/lib/p2p/packets/PacketType.ts
+++ b/lib/p2p/packets/PacketType.ts
@@ -5,6 +5,8 @@ enum PacketType  {
   ORDER = 'ORDER',
   GET_ORDERS = 'GET_ORDERS',
   ORDERS = 'ORDERS',
+  GET_HOSTS = 'GET_HOSTS',
+  HOSTS = 'HOSTS',
 }
 
 export default PacketType;

--- a/lib/p2p/packets/PacketType.ts
+++ b/lib/p2p/packets/PacketType.ts
@@ -3,7 +3,7 @@ enum PacketType  {
   PING = 'PING',
   PONG = 'PONG',
   ORDER = 'ORDER',
-  GETORDERS = 'GETORDERS',
+  GET_ORDERS = 'GET_ORDERS',
   ORDERS = 'ORDERS',
 }
 

--- a/lib/p2p/packets/index.ts
+++ b/lib/p2p/packets/index.ts
@@ -1,4 +1,4 @@
 export { default as packetUtils } from './packetUtils';
 export { default as PacketType } from './PacketType';
 export { default as Packet, PacketDirection } from './Packet';
-export { OrderPacket, HelloPacket, PingPacket, PongPacket, GetOrdersPacket, OrdersPacket } from './types';
+export * from './types';

--- a/lib/p2p/packets/packetUtils.ts
+++ b/lib/p2p/packets/packetUtils.ts
@@ -12,7 +12,7 @@ const fromRaw = (type: string, packet: string): Packet | void => {
       return new packetTypes.PongPacket(packet);
     case PacketType.ORDER:
       return new packetTypes.OrderPacket(packet);
-    case PacketType.GETORDERS:
+    case PacketType.GET_ORDERS:
       return new packetTypes.GetOrdersPacket(packet);
     case PacketType.ORDERS:
       return new packetTypes.OrdersPacket(packet);

--- a/lib/p2p/packets/packetUtils.ts
+++ b/lib/p2p/packets/packetUtils.ts
@@ -16,6 +16,10 @@ const fromRaw = (type: string, packet: string): Packet | void => {
       return new packetTypes.GetOrdersPacket(packet);
     case PacketType.ORDERS:
       return new packetTypes.OrdersPacket(packet);
+    case PacketType.GET_HOSTS:
+      return new packetTypes.GetHostsPacket(packet);
+    case PacketType.HOSTS:
+      return new packetTypes.HostsPacket(packet);
     default:
       return;
   }

--- a/lib/p2p/packets/types/GetHostsPacket.ts
+++ b/lib/p2p/packets/types/GetHostsPacket.ts
@@ -1,0 +1,18 @@
+import Packet, { PacketDirection } from '../Packet';
+import PacketType from '../PacketType';
+
+type GetHostsPacketBody = {
+  ts: number;
+};
+
+class GetHostsPacket extends Packet<GetHostsPacketBody> {
+  public get type() {
+    return PacketType.GET_HOSTS;
+  }
+
+  public get direction() {
+    return PacketDirection.REQUEST;
+  }
+}
+
+export default GetHostsPacket;

--- a/lib/p2p/packets/types/GetOrdersPacket.ts
+++ b/lib/p2p/packets/types/GetOrdersPacket.ts
@@ -3,7 +3,7 @@ import PacketType from '../PacketType';
 
 class GetOrdersPacket extends Packet<{}> {
   public get type() {
-    return PacketType.GETORDERS;
+    return PacketType.GET_ORDERS;
   }
 
   public get direction() {

--- a/lib/p2p/packets/types/HostsPacket.ts
+++ b/lib/p2p/packets/types/HostsPacket.ts
@@ -1,0 +1,19 @@
+import Packet, { PacketDirection } from '../Packet';
+import PacketType from '../PacketType';
+import Host from '../../Host';
+
+type HostsPacketBody = {
+  hosts: Host[],
+};
+
+class HostsPacket extends Packet<HostsPacketBody> {
+  public get type() {
+    return PacketType.HOSTS;
+  }
+
+  public get direction() {
+    return PacketDirection.RESPONSE;
+  }
+}
+
+export default HostsPacket;

--- a/lib/p2p/packets/types/index.ts
+++ b/lib/p2p/packets/types/index.ts
@@ -4,3 +4,5 @@ export { default as PingPacket } from './PingPacket';
 export { default as PongPacket } from './PongPacket';
 export { default as GetOrdersPacket } from './GetOrdersPacket';
 export { default as OrdersPacket } from './OrdersPacket';
+export { default as GetHostsPacket } from './GetHostsPacket';
+export { default as HostsPacket } from './HostsPacket';

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -8,6 +8,7 @@ import { OwnOrder } from '../types/orders';
 import Config from '../Config';
 import { EventEmitter } from 'events';
 import { orders } from '../types';
+import SocketAddress from '../p2p/SocketAddress';
 
 const packageJson = require('../../package.json');
 
@@ -164,7 +165,7 @@ class Service extends EventEmitter {
    * Connect to an XU node on a given host and port.
    */
   public connect = async ({ host, port }: { host: string, port: number }) => {
-    const peer = await this.pool.addOutbound(host, port);
+    const peer = await this.pool.addOutbound(new SocketAddress(host, port));
     return peer.getStatus();
   }
 


### PR DESCRIPTION
Resolves #147. I split this into two commits, the first is an attempt at some general cleanup, refactoring, and code documentation around the p2p module. The second implements the new packets. Currently the `GetHostsPacket` is empty, but we can modify this in the future to specify some criteria for which hosts should be returned. When we successfully establish an outbound connection to a peer, we send a `GetHostsPacket` which kicks off recursion of connecting to new hosts as long as we keep finding out about new ones. 