### PR TITLE
RPC error handling fixes

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -67,7 +67,11 @@ class Xud {
         shutdown: this.shutdown,
       });
       this.rpcServer = new GrpcServer(this.service);
-      await this.rpcServer.listen(this.config.rpc.port, this.config.rpc.host);
+      if (!await this.rpcServer.listen(this.config.rpc.port, this.config.rpc.host)) {
+        this.logger.error('Could not start RPC server, exiting...');
+        this.shutdown();
+        return;
+      }
 
       if (!this.config.webproxy.disable) {
         this.grpcAPIProxy = new GrpcWebProxyServer();

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -37,21 +37,21 @@ class GrpcServer {
   /**
    * Start the server and begin listening on the provided port
    * @param port
+   * @returns true if the server started listening successfully, false otherwise
    */
   public listen = (port: number, host: string) => {
     assert(Number.isInteger(port) && port > 1023 && port < 65536, 'port must be an integer between 1024 and 65535');
-    try {
-      const bindCode = this.server.bind(`${host}:${port}`, grpc.ServerCredentials.createInsecure());
-      if (bindCode !== port) {
-        const error = errors.COULDNOT_BIND(port.toString());
-        this.logger.error(error.message);
-        throw error;
-      }
-      this.server.start();
-      this.logger.info(`gRPC server listening on ${host}:${port}`);
-    } catch (error) {
-      throw error;
+
+    const bindCode = this.server.bind(`${host}:${port}`, grpc.ServerCredentials.createInsecure());
+    if (bindCode !== port) {
+      const error = errors.COULD_NOT_BIND(port.toString());
+      this.logger.error(error.message);
+      return false;
     }
+
+    this.server.start();
+    this.logger.info(`gRPC server listening on ${host}:${port}`);
+    return true;
   }
 
   /**
@@ -60,7 +60,7 @@ class GrpcServer {
   public close = (): Promise<void> => {
     return new Promise((resolve) => {
       this.server.tryShutdown(() => {
-        this.logger.info('GRPC server stopped listening');
+        this.logger.info('GRPC server completed shutdown');
         resolve();
       });
     });

--- a/lib/grpc/errors.ts
+++ b/lib/grpc/errors.ts
@@ -3,5 +3,5 @@ class GRPCError {
 }
 
 export default {
-  COULDNOT_BIND: (port: string) => new GRPCError(`gRPC couldn't bind on port: ${port}`),
+  COULD_NOT_BIND: (port: string) => new GRPCError(`gRPC couldn't bind on port: ${port}`),
 };

--- a/lib/grpc/webproxy/GrpcWebProxyServer.ts
+++ b/lib/grpc/webproxy/GrpcWebProxyServer.ts
@@ -33,6 +33,9 @@ class GrpcWebProxyServer {
         this.logger.info(`gRPC Web API proxy listening on port ${proxyPort}`);
         resolve();
       });
+      this.server.on('error', (err) => {
+        this.logger.error('WebProxyServer Error: ' + err.message);
+      });
     });
   }
 
@@ -41,7 +44,7 @@ class GrpcWebProxyServer {
    */
   public close = (): Promise<void> => {
     return new Promise((resolve, reject) => {
-      if (this.server) {
+      if (this.server && this.server.listening) {
         this.server.close(() => {
           this.logger.info('gRPC Web API proxy stopped listening');
           resolve();

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -202,7 +202,7 @@ class Pool extends EventEmitter {
 
     server.on('listening', () => {
       const { address, port } = this.server.address();
-      this.logger.info(`pool server listening on ${address}:${port}`);
+      this.logger.info(`p2p server listening on ${address}:${port}`);
     });
   }
 


### PR DESCRIPTION
This commit addresses a few issues with handling rpc-related exceptions.

- Errors raised by the web proxy server are now caught and logged, including `EADDRINUSE` on startup if the designated port is in use.
- If the gGRPC server fails to initialize and begin listening, the XUD process is gracefully terminated.
- Other minor changes related to variable naming, comments, and log messages.