### PR TITLE
Define peer events interface

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -196,7 +196,7 @@ class Pool extends EventEmitter {
       console.log('err: ' + err);
     });
 
-    server.on('connection', (socket: Socket) => {
+    server.on('connection', (socket) => {
       this.handleSocket(socket);
     });
 
@@ -215,7 +215,7 @@ class Pool extends EventEmitter {
       this.logger.error('peer error', err);
     });
 
-    peer.once('open', (handshakeState: HandshakeState) => {
+    peer.once('open', (handshakeState) => {
       this.handleOpen(peer, handshakeState);
     });
 


### PR DESCRIPTION
This defines types of the `.on()`, `.once()`, and `.emit()` `EventEmitter` functions for the `Peer` class. If this looks good, I can use the same approach to our other classes that extend `EventEmitter`.