### PR TITLE
Rename nodeKey to nodePubKey

### DIFF
--- a/lib/nodekey/NodeKey.ts
+++ b/lib/nodekey/NodeKey.ts
@@ -15,6 +15,10 @@ class NodeKey {
     this.pubKeyStr = pubKey.toString('hex');
   }
 
+  public get nodePubKey(): string {
+    return this.pubKeyStr;
+  }
+
   /**
    * Generate a random NodeKey.
    */
@@ -71,13 +75,6 @@ class NodeKey {
    */
   public sign = (msg: Buffer): Buffer => {
     return secp256k1.sign(msg, this.privKey).signature;
-  }
-
-  /**
-   * Return the public key in hex format
-   */
-  public toString = (): string => {
-    return this.pubKeyStr;
   }
 
   /**

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -9,8 +9,6 @@ import Logger from '../Logger';
 import { ms } from '../utils/utils';
 import { orders } from '../types';
 
-const pubKey = `tempPK_${Math.floor(1000 + (Math.random() * 9000))}`;
-
 enum ConnectionDirection {
   INBOUND,
   OUTBOUND,
@@ -18,7 +16,7 @@ enum ConnectionDirection {
 
 type HandshakeState = {
   version?: string;
-  nodeKey?: string;
+  nodePubKey?: string;
   listenPort?: number;
   pairs?: string[];
 };
@@ -443,7 +441,7 @@ class Peer extends EventEmitter {
     // TODO: use real values
     const packet = new HelloPacket({
       version: '123',
-      nodeKey: '123',
+      nodePubKey: '123',
       listenPort: 20000,
       pairs: ['BTC/LTC'],
     });

--- a/lib/p2p/packets/types/HelloPacket.ts
+++ b/lib/p2p/packets/types/HelloPacket.ts
@@ -3,7 +3,7 @@ import PacketType from '../PacketType';
 
 type HelloPacketBody = {
   version: string;
-  nodeKey: string;
+  nodePubKey: string;
   listenPort: number;
   pairs: string[];
 };


### PR DESCRIPTION
Closes #160. I only renamed the instances where it's referring to the `string` form of the actual public key. The class representing the private/public keypair is still `NodeKey`. In a separate PR I'll implement putting this value into the HelloPacket.