### PR TITLE
Split order IDs

### DIFF
--- a/lib/cli/commands/cancelorder.ts
+++ b/lib/cli/commands/cancelorder.ts
@@ -2,22 +2,22 @@ import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { CancelOrderRequest } from '../../proto/xudrpc_pb';
 
-export const command = 'cancelorder <order_id> <pair_id>';
+export const command = 'cancelorder <pair_id> <order_id>';
 
 export const describe = 'cancel an order';
 
 export const builder = {
-  order_id: {
+  pair_id: {
     type: 'string',
   },
-  pair_id: {
+  order_id: {
     type: 'string',
   },
 };
 
 export const handler = (argv: Arguments) => {
   const request = new CancelOrderRequest();
-  request.setOrderId(argv.order_id);
   request.setPairId(argv.pair_id);
+  request.setOrderId(argv.order_id);
   loadXudClient(argv).cancelOrder(request, callback);
 };

--- a/lib/cli/commands/placeorder.ts
+++ b/lib/cli/commands/placeorder.ts
@@ -2,7 +2,7 @@ import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { PlaceOrderRequest, Order } from '../../proto/xudrpc_pb';
 
-export const command = 'placeorder <pair_id> <order_id> <price> [quantity]';
+export const command = 'placeorder <pair_id> <order_id> <quantity> [price]';
 
 export const describe = 'place an order';
 

--- a/lib/cli/commands/placeorder.ts
+++ b/lib/cli/commands/placeorder.ts
@@ -2,19 +2,22 @@ import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { PlaceOrderRequest, Order } from '../../proto/xudrpc_pb';
 
-export const command = 'placeorder <pair_id> <quantity> [price]';
+export const command = 'placeorder <pair_id> <order_id> <price> [quantity]';
 
 export const describe = 'place an order';
 
 export const builder = {
+  pair_id: {
+    type: 'string',
+  },
+  order_id: {
+    type: 'string',
+  },
   price: {
     type: 'number',
   },
   quantity: {
     type: 'number',
-  },
-  pair_id: {
-    type: 'string',
   },
 };
 
@@ -22,9 +25,10 @@ export const handler = (argv: Arguments) => {
   const request = new PlaceOrderRequest();
 
   const order = new Order();
-  order.setPrice(argv.price);
-  order.setQuantity(argv.quantity);
   order.setPairId(argv.pair_id);
+  order.setLocalId(argv.order_id);
+  order.setQuantity(argv.quantity);
+  order.setPrice(argv.price);
   request.setOrder(order);
 
   loadXudClient(argv).placeOrder(request, callback);

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -77,10 +77,10 @@ class MatchingEngine {
     };
   }
 
-  public static match(order: orders.StampedOrder, matchAgainst: PriorityQueue[]): matchingEngine.MatchingResult {
+  public static match(order: orders.StampedOwnOrder, matchAgainst: PriorityQueue[]): matchingEngine.MatchingResult {
     const isBuyOrder = order.quantity > 0;
     const matches: matchingEngine.OrderMatch[] = [];
-    let remainingOrder: orders.StampedOrder | null = { ...order };
+    let remainingOrder: orders.StampedOwnOrder | null = { ...order };
 
     const getMatchingQuantity = (remainingOrder, oppositeOrder) => isBuyOrder
       ? MatchingEngine.getMatchingQuantity(remainingOrder, oppositeOrder)
@@ -110,7 +110,7 @@ class MatchingEngine {
           } else if (oppositeOrderAbsQuantity === matchingQuantity) { // taker order quantity is not sufficient. maker order will split
             const splitOrder = this.splitOrderByQuantity(remainingOrder, matchingQuantity);
             matches.push({ maker: oppositeOrder, taker: splitOrder.target });
-            remainingOrder = splitOrder.remaining;
+            remainingOrder = splitOrder.remaining as orders.StampedOwnOrder;
           } else {
             assert(false, 'matchingQuantity should not be lower than both orders quantity values');
           }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -76,29 +76,29 @@ class OrderBook extends EventEmitter {
   /**
    * Returns lists of buy and sell orders of peers
    */
-  public getPeerOrders = (pairId: string, maxResults: number): Map<String, orders.StampedPeerOrder[]> => {
-    return this.getOrders(maxResults, this.peerOrders[pairId]) as Map<String, orders.StampedPeerOrder[]>;
+  public getPeerOrders = (pairId: string, maxResults: number): { [ type: string ]: orders.StampedPeerOrder[] } => {
+    return this.getOrders(maxResults, this.peerOrders[pairId]) as { [type: string]: orders.StampedPeerOrder[] };
   }
 
   /*
   * Returns lists of the node's own buy and sell orders
   */
-  public getOwnOrders = (pairId: string, maxResults: number): Map<String, orders.StampedOwnOrder[]> => {
-    return this.getOrders(maxResults, this.ownOrders[pairId]) as Map<String, orders.StampedOwnOrder[]>;
+  public getOwnOrders = (pairId: string, maxResults: number): { [type: string]: orders.StampedOwnOrder[] } => {
+    return this.getOrders(maxResults, this.ownOrders[pairId]) as { [type: string]: orders.StampedOwnOrder[] };
   }
 
-  private getOrders = (maxResults: number, orders: Orders): Map<String, orders.StampedOrder[]> => {
-    const result = new Map<String, orders.StampedOrder[]>();
-
+  private getOrders = (maxResults: number, orders: Orders): { [type: string]: orders.StampedOrder[] } => {
     if (maxResults > 0) {
-      result['buyOrders'] = Object.values(orders.buyOrders).slice(0, maxResults);
-      result['sellOrders'] = Object.values(orders.sellOrders).slice(0, maxResults);
+      return {
+        buyOrders: Object.values(orders.buyOrders).slice(0, maxResults),
+        sellOrders: Object.values(orders.sellOrders).slice(0, maxResults),
+      };
     } else {
-      result['buyOrders'] = Object.values(orders.buyOrders);
-      result['sellOrders'] = Object.values(orders.sellOrders);
+      return {
+        buyOrders: Object.values(orders.buyOrders),
+        sellOrders: Object.values(orders.sellOrders),
+      };
     }
-
-    return result;
   }
 
   public addLimitOrder = (order: orders.OwnOrder): matchingEngine.MatchingResult => {

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -29,8 +29,8 @@ class OrderBook extends EventEmitter {
   private peerOrders: Map<String, Orders> = new Map<String, Orders>();
 
   /**
-   * This map has the localId of and order as key and the global id as value
-   * which makes possible to cancel orders by their local id without iterating
+   * This map has the localId of an order as key and the global id as value
+   * which it makes possible to reference orders by their local id
    */
   private localIdMap: Map<String, String> = new Map<String, String>();
 
@@ -124,6 +124,7 @@ class OrderBook extends EventEmitter {
     }
 
     if (matchingEngine.removeOwnOrder(orderId)) {
+      this.logger.debug(`order removed: ${JSON.stringify(orderId)}`);
       return this.removeOrder(this.ownOrders, orderId, pairId);
     } else {
       return false;

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -137,7 +137,7 @@ class OrderBook extends EventEmitter {
 
   private addOwnOrder = (order: orders.OwnOrder, discardRemaining: boolean = false): matchingEngine.MatchingResult => {
     if (this.localIdMap[order.localId]) {
-      throw errors.DUPLICATED_ORDER;
+      throw errors.DUPLICATED_ORDER(order.localId);
     }
 
     const matchingEngine = this.matchingEngines[order.pairId];

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -164,11 +164,10 @@ class OrderBook extends EventEmitter {
 
   private updateOrderQuantity = (type: { [pairId: string]: Orders }, order: orders.StampedOrder, decreasedQuantity: number) => {
     const orderMap = this.getOrderMap(type, order);
-    const id = this.localIds[order.id] ? this.localIds[order.id] : order.id;
 
-    orderMap[id].quantity = orderMap[id].quantity - decreasedQuantity;
-    if (orderMap[id].quantity === 0) {
-      delete orderMap[id];
+    orderMap[order.id].quantity = orderMap[order.id].quantity - decreasedQuantity;
+    if (orderMap[order.id].quantity === 0) {
+      delete orderMap[order.id];
     }
   }
 

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -8,4 +8,9 @@ errors.INVALID_PAIR_ID = pairId => ({
   code: codesPrefix.concat('1'),
 });
 
+errors.DUPLICATED_ORDER = localId => ({
+  message: `duplicated localId: ${localId}`,
+  code: codesPrefix.concat('2'),
+});
+
 export default errors;

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -298,7 +298,7 @@
         "canceled": {
           "type": "boolean",
           "format": "boolean",
-          "title": "True means that the order was canceled and false means that it wasn't"
+          "title": "Indicates whether an order was successfully canceled"
         }
       }
     },

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -295,9 +295,10 @@
     "xudrpcCancelOrderResponse": {
       "type": "object",
       "properties": {
-        "result": {
+        "canceled": {
           "type": "boolean",
-          "format": "boolean"
+          "format": "boolean",
+          "title": "True means that the order was canceled and false means that it wasn't"
         }
       }
     },

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -296,7 +296,8 @@
       "type": "object",
       "properties": {
         "result": {
-          "type": "string"
+          "type": "boolean",
+          "format": "boolean"
         }
       }
     },
@@ -494,6 +495,10 @@
         "id": {
           "type": "string",
           "title": "A UUID for this order"
+        },
+        "local_id": {
+          "type": "string",
+          "title": "The local ID for this oder"
         },
         "created_at": {
           "type": "string",

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -459,6 +459,9 @@ export class Order extends jspb.Message {
   getId(): string;
   setId(value: string): void;
 
+  getLocalId(): string;
+  setLocalId(value: string): void;
+
   getCreatedAt(): number;
   setCreatedAt(value: number): void;
 
@@ -483,6 +486,7 @@ export namespace Order {
     peerId: number,
     hostId: string,
     id: string,
+    localId: string,
     createdAt: number,
     invoice: string,
   }
@@ -591,8 +595,8 @@ export namespace CancelOrderRequest {
 }
 
 export class CancelOrderResponse extends jspb.Message {
-  getResult(): string;
-  setResult(value: string): void;
+  getResult(): boolean;
+  setResult(value: boolean): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): CancelOrderResponse.AsObject;
@@ -606,7 +610,7 @@ export class CancelOrderResponse extends jspb.Message {
 
 export namespace CancelOrderResponse {
   export type AsObject = {
-    result: string,
+    result: boolean,
   }
 }
 

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -1,778 +1,819 @@
 // package: xudrpc
 // file: xudrpc.proto
 
+/* tslint:disable */
+
 import * as jspb from "google-protobuf";
 import * as annotations_pb from "./annotations_pb";
 
-export class GetInfoRequest extends jspb.Message {
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
-  static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
+export class GetInfoRequest extends jspb.Message { 
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
+    static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
 }
 
 export namespace GetInfoRequest {
-  export type AsObject = {
-  }
+    export type AsObject = {
+    }
 }
 
-export class GetInfoResponse extends jspb.Message {
-  getNumPeers(): number;
-  setNumPeers(value: number): void;
+export class GetInfoResponse extends jspb.Message { 
+    getNumPeers(): number;
+    setNumPeers(value: number): void;
 
-  getNumPairs(): number;
-  setNumPairs(value: number): void;
+    getNumPairs(): number;
+    setNumPairs(value: number): void;
 
-  getVersion(): string;
-  setVersion(value: string): void;
+    getVersion(): string;
+    setVersion(value: string): void;
 
-  hasOrders(): boolean;
-  clearOrders(): void;
-  getOrders(): OrdersCount | undefined;
-  setOrders(value?: OrdersCount): void;
 
-  hasLnd(): boolean;
-  clearLnd(): void;
-  getLnd(): LndInfo | undefined;
-  setLnd(value?: LndInfo): void;
+    hasOrders(): boolean;
+    clearOrders(): void;
+    getOrders(): OrdersCount | undefined;
+    setOrders(value?: OrdersCount): void;
 
-  hasRaiden(): boolean;
-  clearRaiden(): void;
-  getRaiden(): RaidenInfo | undefined;
-  setRaiden(value?: RaidenInfo): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
-  static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
+    hasLnd(): boolean;
+    clearLnd(): void;
+    getLnd(): LndInfo | undefined;
+    setLnd(value?: LndInfo): void;
+
+
+    hasRaiden(): boolean;
+    clearRaiden(): void;
+    getRaiden(): RaidenInfo | undefined;
+    setRaiden(value?: RaidenInfo): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
+    static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
 }
 
 export namespace GetInfoResponse {
-  export type AsObject = {
-    numPeers: number,
-    numPairs: number,
-    version: string,
-    orders?: OrdersCount.AsObject,
-    lnd?: LndInfo.AsObject,
-    raiden?: RaidenInfo.AsObject,
-  }
+    export type AsObject = {
+        numPeers: number,
+        numPairs: number,
+        version: string,
+        orders?: OrdersCount.AsObject,
+        lnd?: LndInfo.AsObject,
+        raiden?: RaidenInfo.AsObject,
+    }
 }
 
-export class OrdersCount extends jspb.Message {
-  getPeer(): number;
-  setPeer(value: number): void;
+export class OrdersCount extends jspb.Message { 
+    getPeer(): number;
+    setPeer(value: number): void;
 
-  getOwn(): number;
-  setOwn(value: number): void;
+    getOwn(): number;
+    setOwn(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): OrdersCount.AsObject;
-  static toObject(includeInstance: boolean, msg: OrdersCount): OrdersCount.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: OrdersCount, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): OrdersCount;
-  static deserializeBinaryFromReader(message: OrdersCount, reader: jspb.BinaryReader): OrdersCount;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): OrdersCount.AsObject;
+    static toObject(includeInstance: boolean, msg: OrdersCount): OrdersCount.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: OrdersCount, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): OrdersCount;
+    static deserializeBinaryFromReader(message: OrdersCount, reader: jspb.BinaryReader): OrdersCount;
 }
 
 export namespace OrdersCount {
-  export type AsObject = {
-    peer: number,
-    own: number,
-  }
+    export type AsObject = {
+        peer: number,
+        own: number,
+    }
 }
 
-export class LndInfo extends jspb.Message {
-  getError(): string;
-  setError(value: string): void;
+export class LndInfo extends jspb.Message { 
+    getError(): string;
+    setError(value: string): void;
 
-  hasChannels(): boolean;
-  clearChannels(): void;
-  getChannels(): LndChannels | undefined;
-  setChannels(value?: LndChannels): void;
 
-  clearChainsList(): void;
-  getChainsList(): Array<string>;
-  setChainsList(value: Array<string>): void;
-  addChains(value: string, index?: number): string;
+    hasChannels(): boolean;
+    clearChannels(): void;
+    getChannels(): LndChannels | undefined;
+    setChannels(value?: LndChannels): void;
 
-  getBlockheight(): number;
-  setBlockheight(value: number): void;
+    clearChainsList(): void;
+    getChainsList(): Array<string>;
+    setChainsList(value: Array<string>): void;
+    addChains(value: string, index?: number): string;
 
-  clearUrisList(): void;
-  getUrisList(): Array<string>;
-  setUrisList(value: Array<string>): void;
-  addUris(value: string, index?: number): string;
+    getBlockheight(): number;
+    setBlockheight(value: number): void;
 
-  getVersion(): string;
-  setVersion(value: string): void;
+    clearUrisList(): void;
+    getUrisList(): Array<string>;
+    setUrisList(value: Array<string>): void;
+    addUris(value: string, index?: number): string;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): LndInfo.AsObject;
-  static toObject(includeInstance: boolean, msg: LndInfo): LndInfo.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: LndInfo, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): LndInfo;
-  static deserializeBinaryFromReader(message: LndInfo, reader: jspb.BinaryReader): LndInfo;
+    getVersion(): string;
+    setVersion(value: string): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): LndInfo.AsObject;
+    static toObject(includeInstance: boolean, msg: LndInfo): LndInfo.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: LndInfo, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): LndInfo;
+    static deserializeBinaryFromReader(message: LndInfo, reader: jspb.BinaryReader): LndInfo;
 }
 
 export namespace LndInfo {
-  export type AsObject = {
-    error: string,
-    channels?: LndChannels.AsObject,
-    chainsList: Array<string>,
-    blockheight: number,
-    urisList: Array<string>,
-    version: string,
-  }
+    export type AsObject = {
+        error: string,
+        channels?: LndChannels.AsObject,
+        chainsList: Array<string>,
+        blockheight: number,
+        urisList: Array<string>,
+        version: string,
+    }
 }
 
-export class LndChannels extends jspb.Message {
-  getActive(): number;
-  setActive(value: number): void;
+export class LndChannels extends jspb.Message { 
+    getActive(): number;
+    setActive(value: number): void;
 
-  getInactive(): number;
-  setInactive(value: number): void;
+    getInactive(): number;
+    setInactive(value: number): void;
 
-  getPending(): number;
-  setPending(value: number): void;
+    getPending(): number;
+    setPending(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): LndChannels.AsObject;
-  static toObject(includeInstance: boolean, msg: LndChannels): LndChannels.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: LndChannels, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): LndChannels;
-  static deserializeBinaryFromReader(message: LndChannels, reader: jspb.BinaryReader): LndChannels;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): LndChannels.AsObject;
+    static toObject(includeInstance: boolean, msg: LndChannels): LndChannels.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: LndChannels, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): LndChannels;
+    static deserializeBinaryFromReader(message: LndChannels, reader: jspb.BinaryReader): LndChannels;
 }
 
 export namespace LndChannels {
-  export type AsObject = {
-    active: number,
-    inactive: number,
-    pending: number,
-  }
+    export type AsObject = {
+        active: number,
+        inactive: number,
+        pending: number,
+    }
 }
 
-export class RaidenInfo extends jspb.Message {
-  getError(): string;
-  setError(value: string): void;
+export class RaidenInfo extends jspb.Message { 
+    getError(): string;
+    setError(value: string): void;
 
-  getAddress(): string;
-  setAddress(value: string): void;
+    getAddress(): string;
+    setAddress(value: string): void;
 
-  getChannels(): number;
-  setChannels(value: number): void;
+    getChannels(): number;
+    setChannels(value: number): void;
 
-  getVersion(): string;
-  setVersion(value: string): void;
+    getVersion(): string;
+    setVersion(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): RaidenInfo.AsObject;
-  static toObject(includeInstance: boolean, msg: RaidenInfo): RaidenInfo.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: RaidenInfo, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): RaidenInfo;
-  static deserializeBinaryFromReader(message: RaidenInfo, reader: jspb.BinaryReader): RaidenInfo;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): RaidenInfo.AsObject;
+    static toObject(includeInstance: boolean, msg: RaidenInfo): RaidenInfo.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: RaidenInfo, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): RaidenInfo;
+    static deserializeBinaryFromReader(message: RaidenInfo, reader: jspb.BinaryReader): RaidenInfo;
 }
 
 export namespace RaidenInfo {
-  export type AsObject = {
-    error: string,
-    address: string,
-    channels: number,
-    version: string,
-  }
+    export type AsObject = {
+        error: string,
+        address: string,
+        channels: number,
+        version: string,
+    }
 }
 
-export class Pair extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class Pair extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getBaseCurrency(): string;
-  setBaseCurrency(value: string): void;
+    getBaseCurrency(): string;
+    setBaseCurrency(value: string): void;
 
-  getQuoteCurrency(): string;
-  setQuoteCurrency(value: string): void;
+    getQuoteCurrency(): string;
+    setQuoteCurrency(value: string): void;
 
-  getSwapProtocol(): string;
-  setSwapProtocol(value: string): void;
+    getSwapProtocol(): string;
+    setSwapProtocol(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): Pair.AsObject;
-  static toObject(includeInstance: boolean, msg: Pair): Pair.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: Pair, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): Pair;
-  static deserializeBinaryFromReader(message: Pair, reader: jspb.BinaryReader): Pair;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Pair.AsObject;
+    static toObject(includeInstance: boolean, msg: Pair): Pair.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Pair, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Pair;
+    static deserializeBinaryFromReader(message: Pair, reader: jspb.BinaryReader): Pair;
 }
 
 export namespace Pair {
-  export type AsObject = {
-    id: string,
-    baseCurrency: string,
-    quoteCurrency: string,
-    swapProtocol: string,
-  }
+    export type AsObject = {
+        id: string,
+        baseCurrency: string,
+        quoteCurrency: string,
+        swapProtocol: string,
+    }
 }
 
-export class GetPairsRequest extends jspb.Message {
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetPairsRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: GetPairsRequest): GetPairsRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetPairsRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetPairsRequest;
-  static deserializeBinaryFromReader(message: GetPairsRequest, reader: jspb.BinaryReader): GetPairsRequest;
+export class GetPairsRequest extends jspb.Message { 
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetPairsRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: GetPairsRequest): GetPairsRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetPairsRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetPairsRequest;
+    static deserializeBinaryFromReader(message: GetPairsRequest, reader: jspb.BinaryReader): GetPairsRequest;
 }
 
 export namespace GetPairsRequest {
-  export type AsObject = {
-  }
+    export type AsObject = {
+    }
 }
 
-export class GetPairsResponse extends jspb.Message {
-  clearPairsList(): void;
-  getPairsList(): Array<Pair>;
-  setPairsList(value: Array<Pair>): void;
-  addPairs(value?: Pair, index?: number): Pair;
+export class GetPairsResponse extends jspb.Message { 
+    clearPairsList(): void;
+    getPairsList(): Array<Pair>;
+    setPairsList(value: Array<Pair>): void;
+    addPairs(value?: Pair, index?: number): Pair;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetPairsResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: GetPairsResponse): GetPairsResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetPairsResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetPairsResponse;
-  static deserializeBinaryFromReader(message: GetPairsResponse, reader: jspb.BinaryReader): GetPairsResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetPairsResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: GetPairsResponse): GetPairsResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetPairsResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetPairsResponse;
+    static deserializeBinaryFromReader(message: GetPairsResponse, reader: jspb.BinaryReader): GetPairsResponse;
 }
 
 export namespace GetPairsResponse {
-  export type AsObject = {
-    pairsList: Array<Pair.AsObject>,
-  }
+    export type AsObject = {
+        pairsList: Array<Pair.AsObject>,
+    }
 }
 
-export class SwapPayload extends jspb.Message {
-  getRole(): string;
-  setRole(value: string): void;
+export class SwapPayload extends jspb.Message { 
+    getRole(): string;
+    setRole(value: string): void;
 
-  getSendingAmount(): number;
-  setSendingAmount(value: number): void;
+    getSendingAmount(): number;
+    setSendingAmount(value: number): void;
 
-  getSendingToken(): string;
-  setSendingToken(value: string): void;
+    getSendingToken(): string;
+    setSendingToken(value: string): void;
 
-  getReceivingAmount(): number;
-  setReceivingAmount(value: number): void;
+    getReceivingAmount(): number;
+    setReceivingAmount(value: number): void;
 
-  getReceivingToken(): string;
-  setReceivingToken(value: string): void;
+    getReceivingToken(): string;
+    setReceivingToken(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SwapPayload.AsObject;
-  static toObject(includeInstance: boolean, msg: SwapPayload): SwapPayload.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SwapPayload, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SwapPayload;
-  static deserializeBinaryFromReader(message: SwapPayload, reader: jspb.BinaryReader): SwapPayload;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SwapPayload.AsObject;
+    static toObject(includeInstance: boolean, msg: SwapPayload): SwapPayload.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SwapPayload, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SwapPayload;
+    static deserializeBinaryFromReader(message: SwapPayload, reader: jspb.BinaryReader): SwapPayload;
 }
 
 export namespace SwapPayload {
-  export type AsObject = {
-    role: string,
-    sendingAmount: number,
-    sendingToken: string,
-    receivingAmount: number,
-    receivingToken: string,
-  }
+    export type AsObject = {
+        role: string,
+        sendingAmount: number,
+        sendingToken: string,
+        receivingAmount: number,
+        receivingToken: string,
+    }
 }
 
-export class ExecuteSwapRequest extends jspb.Message {
-  getTargetAddress(): string;
-  setTargetAddress(value: string): void;
+export class ExecuteSwapRequest extends jspb.Message { 
+    getTargetAddress(): string;
+    setTargetAddress(value: string): void;
 
-  getIdentifier(): string;
-  setIdentifier(value: string): void;
+    getIdentifier(): string;
+    setIdentifier(value: string): void;
 
-  hasPayload(): boolean;
-  clearPayload(): void;
-  getPayload(): SwapPayload | undefined;
-  setPayload(value?: SwapPayload): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
-  static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
+    hasPayload(): boolean;
+    clearPayload(): void;
+    getPayload(): SwapPayload | undefined;
+    setPayload(value?: SwapPayload): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
+    static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
 }
 
 export namespace ExecuteSwapRequest {
-  export type AsObject = {
-    targetAddress: string,
-    identifier: string,
-    payload?: SwapPayload.AsObject,
-  }
+    export type AsObject = {
+        targetAddress: string,
+        identifier: string,
+        payload?: SwapPayload.AsObject,
+    }
 }
 
-export class ExecuteSwapResponse extends jspb.Message {
-  getResult(): string;
-  setResult(value: string): void;
+export class ExecuteSwapResponse extends jspb.Message { 
+    getResult(): string;
+    setResult(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ExecuteSwapResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: ExecuteSwapResponse): ExecuteSwapResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ExecuteSwapResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ExecuteSwapResponse;
-  static deserializeBinaryFromReader(message: ExecuteSwapResponse, reader: jspb.BinaryReader): ExecuteSwapResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ExecuteSwapResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: ExecuteSwapResponse): ExecuteSwapResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ExecuteSwapResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ExecuteSwapResponse;
+    static deserializeBinaryFromReader(message: ExecuteSwapResponse, reader: jspb.BinaryReader): ExecuteSwapResponse;
 }
 
 export namespace ExecuteSwapResponse {
-  export type AsObject = {
-    result: string,
-  }
+    export type AsObject = {
+        result: string,
+    }
 }
 
-export class ConnectRequest extends jspb.Message {
-  getHost(): string;
-  setHost(value: string): void;
+export class ConnectRequest extends jspb.Message { 
+    getHost(): string;
+    setHost(value: string): void;
 
-  getPort(): number;
-  setPort(value: number): void;
+    getPort(): number;
+    setPort(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ConnectRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: ConnectRequest): ConnectRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ConnectRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ConnectRequest;
-  static deserializeBinaryFromReader(message: ConnectRequest, reader: jspb.BinaryReader): ConnectRequest;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ConnectRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: ConnectRequest): ConnectRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ConnectRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ConnectRequest;
+    static deserializeBinaryFromReader(message: ConnectRequest, reader: jspb.BinaryReader): ConnectRequest;
 }
 
 export namespace ConnectRequest {
-  export type AsObject = {
-    host: string,
-    port: number,
-  }
+    export type AsObject = {
+        host: string,
+        port: number,
+    }
 }
 
-export class ConnectResponse extends jspb.Message {
-  getResult(): string;
-  setResult(value: string): void;
+export class ConnectResponse extends jspb.Message { 
+    getResult(): string;
+    setResult(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ConnectResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: ConnectResponse): ConnectResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ConnectResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ConnectResponse;
-  static deserializeBinaryFromReader(message: ConnectResponse, reader: jspb.BinaryReader): ConnectResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ConnectResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: ConnectResponse): ConnectResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ConnectResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ConnectResponse;
+    static deserializeBinaryFromReader(message: ConnectResponse, reader: jspb.BinaryReader): ConnectResponse;
 }
 
 export namespace ConnectResponse {
-  export type AsObject = {
-    result: string,
-  }
+    export type AsObject = {
+        result: string,
+    }
 }
 
-export class DisconnectRequest extends jspb.Message {
-  getHost(): string;
-  setHost(value: string): void;
+export class DisconnectRequest extends jspb.Message { 
+    getHost(): string;
+    setHost(value: string): void;
 
-  getPort(): number;
-  setPort(value: number): void;
+    getPort(): number;
+    setPort(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): DisconnectRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: DisconnectRequest): DisconnectRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: DisconnectRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): DisconnectRequest;
-  static deserializeBinaryFromReader(message: DisconnectRequest, reader: jspb.BinaryReader): DisconnectRequest;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): DisconnectRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: DisconnectRequest): DisconnectRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: DisconnectRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): DisconnectRequest;
+    static deserializeBinaryFromReader(message: DisconnectRequest, reader: jspb.BinaryReader): DisconnectRequest;
 }
 
 export namespace DisconnectRequest {
-  export type AsObject = {
-    host: string,
-    port: number,
-  }
+    export type AsObject = {
+        host: string,
+        port: number,
+    }
 }
 
-export class DisconnectResponse extends jspb.Message {
-  getResult(): string;
-  setResult(value: string): void;
+export class DisconnectResponse extends jspb.Message { 
+    getResult(): string;
+    setResult(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): DisconnectResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: DisconnectResponse): DisconnectResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: DisconnectResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): DisconnectResponse;
-  static deserializeBinaryFromReader(message: DisconnectResponse, reader: jspb.BinaryReader): DisconnectResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): DisconnectResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: DisconnectResponse): DisconnectResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: DisconnectResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): DisconnectResponse;
+    static deserializeBinaryFromReader(message: DisconnectResponse, reader: jspb.BinaryReader): DisconnectResponse;
 }
 
 export namespace DisconnectResponse {
-  export type AsObject = {
-    result: string,
-  }
+    export type AsObject = {
+        result: string,
+    }
 }
 
-export class Order extends jspb.Message {
-  getPrice(): number;
-  setPrice(value: number): void;
+export class Order extends jspb.Message { 
+    getPrice(): number;
+    setPrice(value: number): void;
 
-  getQuantity(): number;
-  setQuantity(value: number): void;
+    getQuantity(): number;
+    setQuantity(value: number): void;
 
-  getPairId(): string;
-  setPairId(value: string): void;
+    getPairId(): string;
+    setPairId(value: string): void;
 
-  getPeerId(): number;
-  setPeerId(value: number): void;
+    getPeerId(): number;
+    setPeerId(value: number): void;
 
-  getHostId(): string;
-  setHostId(value: string): void;
+    getHostId(): string;
+    setHostId(value: string): void;
 
-  getId(): string;
-  setId(value: string): void;
+    getId(): string;
+    setId(value: string): void;
 
-  getLocalId(): string;
-  setLocalId(value: string): void;
+    getLocalId(): string;
+    setLocalId(value: string): void;
 
-  getCreatedAt(): number;
-  setCreatedAt(value: number): void;
+    getCreatedAt(): number;
+    setCreatedAt(value: number): void;
 
-  getInvoice(): string;
-  setInvoice(value: string): void;
+    getInvoice(): string;
+    setInvoice(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): Order.AsObject;
-  static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): Order;
-  static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Order.AsObject;
+    static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Order;
+    static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
 }
 
 export namespace Order {
-  export type AsObject = {
-    price: number,
-    quantity: number,
-    pairId: string,
-    peerId: number,
-    hostId: string,
-    id: string,
-    localId: string,
-    createdAt: number,
-    invoice: string,
-  }
+    export type AsObject = {
+        price: number,
+        quantity: number,
+        pairId: string,
+        peerId: number,
+        hostId: string,
+        id: string,
+        localId: string,
+        createdAt: number,
+        invoice: string,
+    }
 }
 
-export class OrderMatch extends jspb.Message {
-  hasMaker(): boolean;
-  clearMaker(): void;
-  getMaker(): Order | undefined;
-  setMaker(value?: Order): void;
+export class OrderMatch extends jspb.Message { 
 
-  hasTaker(): boolean;
-  clearTaker(): void;
-  getTaker(): Order | undefined;
-  setTaker(value?: Order): void;
+    hasMaker(): boolean;
+    clearMaker(): void;
+    getMaker(): Order | undefined;
+    setMaker(value?: Order): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): OrderMatch.AsObject;
-  static toObject(includeInstance: boolean, msg: OrderMatch): OrderMatch.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: OrderMatch, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): OrderMatch;
-  static deserializeBinaryFromReader(message: OrderMatch, reader: jspb.BinaryReader): OrderMatch;
+
+    hasTaker(): boolean;
+    clearTaker(): void;
+    getTaker(): Order | undefined;
+    setTaker(value?: Order): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): OrderMatch.AsObject;
+    static toObject(includeInstance: boolean, msg: OrderMatch): OrderMatch.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: OrderMatch, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): OrderMatch;
+    static deserializeBinaryFromReader(message: OrderMatch, reader: jspb.BinaryReader): OrderMatch;
 }
 
 export namespace OrderMatch {
-  export type AsObject = {
-    maker?: Order.AsObject,
-    taker?: Order.AsObject,
-  }
+    export type AsObject = {
+        maker?: Order.AsObject,
+        taker?: Order.AsObject,
+    }
 }
 
-export class PlaceOrderRequest extends jspb.Message {
-  hasOrder(): boolean;
-  clearOrder(): void;
-  getOrder(): Order | undefined;
-  setOrder(value?: Order): void;
+export class PlaceOrderRequest extends jspb.Message { 
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: PlaceOrderRequest): PlaceOrderRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: PlaceOrderRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): PlaceOrderRequest;
-  static deserializeBinaryFromReader(message: PlaceOrderRequest, reader: jspb.BinaryReader): PlaceOrderRequest;
+    hasOrder(): boolean;
+    clearOrder(): void;
+    getOrder(): Order | undefined;
+    setOrder(value?: Order): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: PlaceOrderRequest): PlaceOrderRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PlaceOrderRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PlaceOrderRequest;
+    static deserializeBinaryFromReader(message: PlaceOrderRequest, reader: jspb.BinaryReader): PlaceOrderRequest;
 }
 
 export namespace PlaceOrderRequest {
-  export type AsObject = {
-    order?: Order.AsObject,
-  }
+    export type AsObject = {
+        order?: Order.AsObject,
+    }
 }
 
-export class PlaceOrderResponse extends jspb.Message {
-  clearMatchesList(): void;
-  getMatchesList(): Array<OrderMatch>;
-  setMatchesList(value: Array<OrderMatch>): void;
-  addMatches(value?: OrderMatch, index?: number): OrderMatch;
+export class PlaceOrderResponse extends jspb.Message { 
+    clearMatchesList(): void;
+    getMatchesList(): Array<OrderMatch>;
+    setMatchesList(value: Array<OrderMatch>): void;
+    addMatches(value?: OrderMatch, index?: number): OrderMatch;
 
-  hasRemainingOrder(): boolean;
-  clearRemainingOrder(): void;
-  getRemainingOrder(): Order | undefined;
-  setRemainingOrder(value?: Order): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: PlaceOrderResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): PlaceOrderResponse;
-  static deserializeBinaryFromReader(message: PlaceOrderResponse, reader: jspb.BinaryReader): PlaceOrderResponse;
+    hasRemainingOrder(): boolean;
+    clearRemainingOrder(): void;
+    getRemainingOrder(): Order | undefined;
+    setRemainingOrder(value?: Order): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PlaceOrderResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PlaceOrderResponse;
+    static deserializeBinaryFromReader(message: PlaceOrderResponse, reader: jspb.BinaryReader): PlaceOrderResponse;
 }
 
 export namespace PlaceOrderResponse {
-  export type AsObject = {
-    matchesList: Array<OrderMatch.AsObject>,
-    remainingOrder?: Order.AsObject,
-  }
+    export type AsObject = {
+        matchesList: Array<OrderMatch.AsObject>,
+        remainingOrder?: Order.AsObject,
+    }
 }
 
-export class CancelOrderRequest extends jspb.Message {
-  getOrderId(): string;
-  setOrderId(value: string): void;
+export class CancelOrderRequest extends jspb.Message { 
+    getOrderId(): string;
+    setOrderId(value: string): void;
 
-  getPairId(): string;
-  setPairId(value: string): void;
+    getPairId(): string;
+    setPairId(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): CancelOrderRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: CancelOrderRequest): CancelOrderRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: CancelOrderRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): CancelOrderRequest;
-  static deserializeBinaryFromReader(message: CancelOrderRequest, reader: jspb.BinaryReader): CancelOrderRequest;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): CancelOrderRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: CancelOrderRequest): CancelOrderRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: CancelOrderRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): CancelOrderRequest;
+    static deserializeBinaryFromReader(message: CancelOrderRequest, reader: jspb.BinaryReader): CancelOrderRequest;
 }
 
 export namespace CancelOrderRequest {
-  export type AsObject = {
-    orderId: string,
-    pairId: string,
-  }
+    export type AsObject = {
+        orderId: string,
+        pairId: string,
+    }
 }
 
-export class CancelOrderResponse extends jspb.Message {
-  getResult(): boolean;
-  setResult(value: boolean): void;
+export class CancelOrderResponse extends jspb.Message { 
+    getCanceled(): boolean;
+    setCanceled(value: boolean): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): CancelOrderResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: CancelOrderResponse): CancelOrderResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: CancelOrderResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): CancelOrderResponse;
-  static deserializeBinaryFromReader(message: CancelOrderResponse, reader: jspb.BinaryReader): CancelOrderResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): CancelOrderResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: CancelOrderResponse): CancelOrderResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: CancelOrderResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): CancelOrderResponse;
+    static deserializeBinaryFromReader(message: CancelOrderResponse, reader: jspb.BinaryReader): CancelOrderResponse;
 }
 
 export namespace CancelOrderResponse {
-  export type AsObject = {
-    result: boolean,
-  }
+    export type AsObject = {
+        canceled: boolean,
+    }
 }
 
-export class GetOrdersRequest extends jspb.Message {
-  getPairId(): string;
-  setPairId(value: string): void;
+export class GetOrdersRequest extends jspb.Message { 
+    getPairId(): string;
+    setPairId(value: string): void;
 
-  getMaxResults(): number;
-  setMaxResults(value: number): void;
+    getMaxResults(): number;
+    setMaxResults(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: GetOrdersRequest): GetOrdersRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetOrdersRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetOrdersRequest;
-  static deserializeBinaryFromReader(message: GetOrdersRequest, reader: jspb.BinaryReader): GetOrdersRequest;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: GetOrdersRequest): GetOrdersRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetOrdersRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetOrdersRequest;
+    static deserializeBinaryFromReader(message: GetOrdersRequest, reader: jspb.BinaryReader): GetOrdersRequest;
 }
 
 export namespace GetOrdersRequest {
-  export type AsObject = {
-    pairId: string,
-    maxResults: number,
-  }
+    export type AsObject = {
+        pairId: string,
+        maxResults: number,
+    }
 }
 
-export class GetOrdersResponse extends jspb.Message {
-  clearBuyOrdersList(): void;
-  getBuyOrdersList(): Array<Order>;
-  setBuyOrdersList(value: Array<Order>): void;
-  addBuyOrders(value?: Order, index?: number): Order;
+export class GetOrdersResponse extends jspb.Message { 
+    clearBuyOrdersList(): void;
+    getBuyOrdersList(): Array<Order>;
+    setBuyOrdersList(value: Array<Order>): void;
+    addBuyOrders(value?: Order, index?: number): Order;
 
-  clearSellOrdersList(): void;
-  getSellOrdersList(): Array<Order>;
-  setSellOrdersList(value: Array<Order>): void;
-  addSellOrders(value?: Order, index?: number): Order;
+    clearSellOrdersList(): void;
+    getSellOrdersList(): Array<Order>;
+    setSellOrdersList(value: Array<Order>): void;
+    addSellOrders(value?: Order, index?: number): Order;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetOrdersResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: GetOrdersResponse): GetOrdersResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetOrdersResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetOrdersResponse;
-  static deserializeBinaryFromReader(message: GetOrdersResponse, reader: jspb.BinaryReader): GetOrdersResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetOrdersResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: GetOrdersResponse): GetOrdersResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetOrdersResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetOrdersResponse;
+    static deserializeBinaryFromReader(message: GetOrdersResponse, reader: jspb.BinaryReader): GetOrdersResponse;
 }
 
 export namespace GetOrdersResponse {
-  export type AsObject = {
-    buyOrdersList: Array<Order.AsObject>,
-    sellOrdersList: Array<Order.AsObject>,
-  }
+    export type AsObject = {
+        buyOrdersList: Array<Order.AsObject>,
+        sellOrdersList: Array<Order.AsObject>,
+    }
 }
 
-export class ShutdownRequest extends jspb.Message {
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ShutdownRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: ShutdownRequest): ShutdownRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ShutdownRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ShutdownRequest;
-  static deserializeBinaryFromReader(message: ShutdownRequest, reader: jspb.BinaryReader): ShutdownRequest;
+export class ShutdownRequest extends jspb.Message { 
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ShutdownRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: ShutdownRequest): ShutdownRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ShutdownRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ShutdownRequest;
+    static deserializeBinaryFromReader(message: ShutdownRequest, reader: jspb.BinaryReader): ShutdownRequest;
 }
 
 export namespace ShutdownRequest {
-  export type AsObject = {
-  }
+    export type AsObject = {
+    }
 }
 
-export class ShutdownResponse extends jspb.Message {
-  getResult(): string;
-  setResult(value: string): void;
+export class ShutdownResponse extends jspb.Message { 
+    getResult(): string;
+    setResult(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ShutdownResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: ShutdownResponse): ShutdownResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ShutdownResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ShutdownResponse;
-  static deserializeBinaryFromReader(message: ShutdownResponse, reader: jspb.BinaryReader): ShutdownResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ShutdownResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: ShutdownResponse): ShutdownResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ShutdownResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ShutdownResponse;
+    static deserializeBinaryFromReader(message: ShutdownResponse, reader: jspb.BinaryReader): ShutdownResponse;
 }
 
 export namespace ShutdownResponse {
-  export type AsObject = {
-    result: string,
-  }
+    export type AsObject = {
+        result: string,
+    }
 }
 
-export class SubscribePeerOrdersRequest extends jspb.Message {
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SubscribePeerOrdersRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: SubscribePeerOrdersRequest): SubscribePeerOrdersRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SubscribePeerOrdersRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersRequest;
-  static deserializeBinaryFromReader(message: SubscribePeerOrdersRequest, reader: jspb.BinaryReader): SubscribePeerOrdersRequest;
+export class SubscribePeerOrdersRequest extends jspb.Message { 
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SubscribePeerOrdersRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: SubscribePeerOrdersRequest): SubscribePeerOrdersRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SubscribePeerOrdersRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersRequest;
+    static deserializeBinaryFromReader(message: SubscribePeerOrdersRequest, reader: jspb.BinaryReader): SubscribePeerOrdersRequest;
 }
 
 export namespace SubscribePeerOrdersRequest {
-  export type AsObject = {
-  }
+    export type AsObject = {
+    }
 }
 
-export class SubscribePeerOrdersResponse extends jspb.Message {
-  hasOrder(): boolean;
-  clearOrder(): void;
-  getOrder(): Order | undefined;
-  setOrder(value?: Order): void;
+export class SubscribePeerOrdersResponse extends jspb.Message { 
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SubscribePeerOrdersResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: SubscribePeerOrdersResponse): SubscribePeerOrdersResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SubscribePeerOrdersResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersResponse;
-  static deserializeBinaryFromReader(message: SubscribePeerOrdersResponse, reader: jspb.BinaryReader): SubscribePeerOrdersResponse;
+    hasOrder(): boolean;
+    clearOrder(): void;
+    getOrder(): Order | undefined;
+    setOrder(value?: Order): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SubscribePeerOrdersResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: SubscribePeerOrdersResponse): SubscribePeerOrdersResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SubscribePeerOrdersResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersResponse;
+    static deserializeBinaryFromReader(message: SubscribePeerOrdersResponse, reader: jspb.BinaryReader): SubscribePeerOrdersResponse;
 }
 
 export namespace SubscribePeerOrdersResponse {
-  export type AsObject = {
-    order?: Order.AsObject,
-  }
+    export type AsObject = {
+        order?: Order.AsObject,
+    }
 }
 
-export class SubscribeSwapsRequest extends jspb.Message {
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SubscribeSwapsRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: SubscribeSwapsRequest): SubscribeSwapsRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SubscribeSwapsRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SubscribeSwapsRequest;
-  static deserializeBinaryFromReader(message: SubscribeSwapsRequest, reader: jspb.BinaryReader): SubscribeSwapsRequest;
+export class SubscribeSwapsRequest extends jspb.Message { 
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SubscribeSwapsRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: SubscribeSwapsRequest): SubscribeSwapsRequest.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SubscribeSwapsRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SubscribeSwapsRequest;
+    static deserializeBinaryFromReader(message: SubscribeSwapsRequest, reader: jspb.BinaryReader): SubscribeSwapsRequest;
 }
 
 export namespace SubscribeSwapsRequest {
-  export type AsObject = {
-  }
+    export type AsObject = {
+    }
 }
 
-export class SubscribeSwapsResponse extends jspb.Message {
-  getResult(): string;
-  setResult(value: string): void;
+export class SubscribeSwapsResponse extends jspb.Message { 
+    getResult(): string;
+    setResult(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SubscribeSwapsResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: SubscribeSwapsResponse): SubscribeSwapsResponse.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SubscribeSwapsResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SubscribeSwapsResponse;
-  static deserializeBinaryFromReader(message: SubscribeSwapsResponse, reader: jspb.BinaryReader): SubscribeSwapsResponse;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SubscribeSwapsResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: SubscribeSwapsResponse): SubscribeSwapsResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SubscribeSwapsResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SubscribeSwapsResponse;
+    static deserializeBinaryFromReader(message: SubscribeSwapsResponse, reader: jspb.BinaryReader): SubscribeSwapsResponse;
 }
 
 export namespace SubscribeSwapsResponse {
-  export type AsObject = {
-    result: string,
-  }
+    export type AsObject = {
+        result: string,
+    }
 }
-

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -1,819 +1,778 @@
 // package: xudrpc
 // file: xudrpc.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 import * as annotations_pb from "./annotations_pb";
 
-export class GetInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
-    static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
+export class GetInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
+  static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
 }
 
 export namespace GetInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetInfoResponse extends jspb.Message { 
-    getNumPeers(): number;
-    setNumPeers(value: number): void;
+export class GetInfoResponse extends jspb.Message {
+  getNumPeers(): number;
+  setNumPeers(value: number): void;
 
-    getNumPairs(): number;
-    setNumPairs(value: number): void;
+  getNumPairs(): number;
+  setNumPairs(value: number): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
+  getVersion(): string;
+  setVersion(value: string): void;
 
+  hasOrders(): boolean;
+  clearOrders(): void;
+  getOrders(): OrdersCount | undefined;
+  setOrders(value?: OrdersCount): void;
 
-    hasOrders(): boolean;
-    clearOrders(): void;
-    getOrders(): OrdersCount | undefined;
-    setOrders(value?: OrdersCount): void;
+  hasLnd(): boolean;
+  clearLnd(): void;
+  getLnd(): LndInfo | undefined;
+  setLnd(value?: LndInfo): void;
 
+  hasRaiden(): boolean;
+  clearRaiden(): void;
+  getRaiden(): RaidenInfo | undefined;
+  setRaiden(value?: RaidenInfo): void;
 
-    hasLnd(): boolean;
-    clearLnd(): void;
-    getLnd(): LndInfo | undefined;
-    setLnd(value?: LndInfo): void;
-
-
-    hasRaiden(): boolean;
-    clearRaiden(): void;
-    getRaiden(): RaidenInfo | undefined;
-    setRaiden(value?: RaidenInfo): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
-    static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
+  static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
 }
 
 export namespace GetInfoResponse {
-    export type AsObject = {
-        numPeers: number,
-        numPairs: number,
-        version: string,
-        orders?: OrdersCount.AsObject,
-        lnd?: LndInfo.AsObject,
-        raiden?: RaidenInfo.AsObject,
-    }
+  export type AsObject = {
+    numPeers: number,
+    numPairs: number,
+    version: string,
+    orders?: OrdersCount.AsObject,
+    lnd?: LndInfo.AsObject,
+    raiden?: RaidenInfo.AsObject,
+  }
 }
 
-export class OrdersCount extends jspb.Message { 
-    getPeer(): number;
-    setPeer(value: number): void;
+export class OrdersCount extends jspb.Message {
+  getPeer(): number;
+  setPeer(value: number): void;
 
-    getOwn(): number;
-    setOwn(value: number): void;
+  getOwn(): number;
+  setOwn(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OrdersCount.AsObject;
-    static toObject(includeInstance: boolean, msg: OrdersCount): OrdersCount.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OrdersCount, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OrdersCount;
-    static deserializeBinaryFromReader(message: OrdersCount, reader: jspb.BinaryReader): OrdersCount;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OrdersCount.AsObject;
+  static toObject(includeInstance: boolean, msg: OrdersCount): OrdersCount.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OrdersCount, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OrdersCount;
+  static deserializeBinaryFromReader(message: OrdersCount, reader: jspb.BinaryReader): OrdersCount;
 }
 
 export namespace OrdersCount {
-    export type AsObject = {
-        peer: number,
-        own: number,
-    }
+  export type AsObject = {
+    peer: number,
+    own: number,
+  }
 }
 
-export class LndInfo extends jspb.Message { 
-    getError(): string;
-    setError(value: string): void;
+export class LndInfo extends jspb.Message {
+  getError(): string;
+  setError(value: string): void;
 
+  hasChannels(): boolean;
+  clearChannels(): void;
+  getChannels(): LndChannels | undefined;
+  setChannels(value?: LndChannels): void;
 
-    hasChannels(): boolean;
-    clearChannels(): void;
-    getChannels(): LndChannels | undefined;
-    setChannels(value?: LndChannels): void;
+  clearChainsList(): void;
+  getChainsList(): Array<string>;
+  setChainsList(value: Array<string>): void;
+  addChains(value: string, index?: number): string;
 
-    clearChainsList(): void;
-    getChainsList(): Array<string>;
-    setChainsList(value: Array<string>): void;
-    addChains(value: string, index?: number): string;
+  getBlockheight(): number;
+  setBlockheight(value: number): void;
 
-    getBlockheight(): number;
-    setBlockheight(value: number): void;
+  clearUrisList(): void;
+  getUrisList(): Array<string>;
+  setUrisList(value: Array<string>): void;
+  addUris(value: string, index?: number): string;
 
-    clearUrisList(): void;
-    getUrisList(): Array<string>;
-    setUrisList(value: Array<string>): void;
-    addUris(value: string, index?: number): string;
+  getVersion(): string;
+  setVersion(value: string): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LndInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: LndInfo): LndInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LndInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LndInfo;
-    static deserializeBinaryFromReader(message: LndInfo, reader: jspb.BinaryReader): LndInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LndInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: LndInfo): LndInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LndInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LndInfo;
+  static deserializeBinaryFromReader(message: LndInfo, reader: jspb.BinaryReader): LndInfo;
 }
 
 export namespace LndInfo {
-    export type AsObject = {
-        error: string,
-        channels?: LndChannels.AsObject,
-        chainsList: Array<string>,
-        blockheight: number,
-        urisList: Array<string>,
-        version: string,
-    }
+  export type AsObject = {
+    error: string,
+    channels?: LndChannels.AsObject,
+    chainsList: Array<string>,
+    blockheight: number,
+    urisList: Array<string>,
+    version: string,
+  }
 }
 
-export class LndChannels extends jspb.Message { 
-    getActive(): number;
-    setActive(value: number): void;
+export class LndChannels extends jspb.Message {
+  getActive(): number;
+  setActive(value: number): void;
 
-    getInactive(): number;
-    setInactive(value: number): void;
+  getInactive(): number;
+  setInactive(value: number): void;
 
-    getPending(): number;
-    setPending(value: number): void;
+  getPending(): number;
+  setPending(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LndChannels.AsObject;
-    static toObject(includeInstance: boolean, msg: LndChannels): LndChannels.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LndChannels, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LndChannels;
-    static deserializeBinaryFromReader(message: LndChannels, reader: jspb.BinaryReader): LndChannels;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LndChannels.AsObject;
+  static toObject(includeInstance: boolean, msg: LndChannels): LndChannels.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LndChannels, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LndChannels;
+  static deserializeBinaryFromReader(message: LndChannels, reader: jspb.BinaryReader): LndChannels;
 }
 
 export namespace LndChannels {
-    export type AsObject = {
-        active: number,
-        inactive: number,
-        pending: number,
-    }
+  export type AsObject = {
+    active: number,
+    inactive: number,
+    pending: number,
+  }
 }
 
-export class RaidenInfo extends jspb.Message { 
-    getError(): string;
-    setError(value: string): void;
+export class RaidenInfo extends jspb.Message {
+  getError(): string;
+  setError(value: string): void;
 
-    getAddress(): string;
-    setAddress(value: string): void;
+  getAddress(): string;
+  setAddress(value: string): void;
 
-    getChannels(): number;
-    setChannels(value: number): void;
+  getChannels(): number;
+  setChannels(value: number): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
+  getVersion(): string;
+  setVersion(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RaidenInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: RaidenInfo): RaidenInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RaidenInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RaidenInfo;
-    static deserializeBinaryFromReader(message: RaidenInfo, reader: jspb.BinaryReader): RaidenInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RaidenInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: RaidenInfo): RaidenInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RaidenInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RaidenInfo;
+  static deserializeBinaryFromReader(message: RaidenInfo, reader: jspb.BinaryReader): RaidenInfo;
 }
 
 export namespace RaidenInfo {
-    export type AsObject = {
-        error: string,
-        address: string,
-        channels: number,
-        version: string,
-    }
+  export type AsObject = {
+    error: string,
+    address: string,
+    channels: number,
+    version: string,
+  }
 }
 
-export class Pair extends jspb.Message { 
-    getId(): string;
-    setId(value: string): void;
+export class Pair extends jspb.Message {
+  getId(): string;
+  setId(value: string): void;
 
-    getBaseCurrency(): string;
-    setBaseCurrency(value: string): void;
+  getBaseCurrency(): string;
+  setBaseCurrency(value: string): void;
 
-    getQuoteCurrency(): string;
-    setQuoteCurrency(value: string): void;
+  getQuoteCurrency(): string;
+  setQuoteCurrency(value: string): void;
 
-    getSwapProtocol(): string;
-    setSwapProtocol(value: string): void;
+  getSwapProtocol(): string;
+  setSwapProtocol(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Pair.AsObject;
-    static toObject(includeInstance: boolean, msg: Pair): Pair.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Pair, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Pair;
-    static deserializeBinaryFromReader(message: Pair, reader: jspb.BinaryReader): Pair;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Pair.AsObject;
+  static toObject(includeInstance: boolean, msg: Pair): Pair.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Pair, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Pair;
+  static deserializeBinaryFromReader(message: Pair, reader: jspb.BinaryReader): Pair;
 }
 
 export namespace Pair {
-    export type AsObject = {
-        id: string,
-        baseCurrency: string,
-        quoteCurrency: string,
-        swapProtocol: string,
-    }
+  export type AsObject = {
+    id: string,
+    baseCurrency: string,
+    quoteCurrency: string,
+    swapProtocol: string,
+  }
 }
 
-export class GetPairsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetPairsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetPairsRequest): GetPairsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetPairsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetPairsRequest;
-    static deserializeBinaryFromReader(message: GetPairsRequest, reader: jspb.BinaryReader): GetPairsRequest;
+export class GetPairsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetPairsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetPairsRequest): GetPairsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetPairsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetPairsRequest;
+  static deserializeBinaryFromReader(message: GetPairsRequest, reader: jspb.BinaryReader): GetPairsRequest;
 }
 
 export namespace GetPairsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetPairsResponse extends jspb.Message { 
-    clearPairsList(): void;
-    getPairsList(): Array<Pair>;
-    setPairsList(value: Array<Pair>): void;
-    addPairs(value?: Pair, index?: number): Pair;
+export class GetPairsResponse extends jspb.Message {
+  clearPairsList(): void;
+  getPairsList(): Array<Pair>;
+  setPairsList(value: Array<Pair>): void;
+  addPairs(value?: Pair, index?: number): Pair;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetPairsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetPairsResponse): GetPairsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetPairsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetPairsResponse;
-    static deserializeBinaryFromReader(message: GetPairsResponse, reader: jspb.BinaryReader): GetPairsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetPairsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetPairsResponse): GetPairsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetPairsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetPairsResponse;
+  static deserializeBinaryFromReader(message: GetPairsResponse, reader: jspb.BinaryReader): GetPairsResponse;
 }
 
 export namespace GetPairsResponse {
-    export type AsObject = {
-        pairsList: Array<Pair.AsObject>,
-    }
+  export type AsObject = {
+    pairsList: Array<Pair.AsObject>,
+  }
 }
 
-export class SwapPayload extends jspb.Message { 
-    getRole(): string;
-    setRole(value: string): void;
+export class SwapPayload extends jspb.Message {
+  getRole(): string;
+  setRole(value: string): void;
 
-    getSendingAmount(): number;
-    setSendingAmount(value: number): void;
+  getSendingAmount(): number;
+  setSendingAmount(value: number): void;
 
-    getSendingToken(): string;
-    setSendingToken(value: string): void;
+  getSendingToken(): string;
+  setSendingToken(value: string): void;
 
-    getReceivingAmount(): number;
-    setReceivingAmount(value: number): void;
+  getReceivingAmount(): number;
+  setReceivingAmount(value: number): void;
 
-    getReceivingToken(): string;
-    setReceivingToken(value: string): void;
+  getReceivingToken(): string;
+  setReceivingToken(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SwapPayload.AsObject;
-    static toObject(includeInstance: boolean, msg: SwapPayload): SwapPayload.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SwapPayload, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SwapPayload;
-    static deserializeBinaryFromReader(message: SwapPayload, reader: jspb.BinaryReader): SwapPayload;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SwapPayload.AsObject;
+  static toObject(includeInstance: boolean, msg: SwapPayload): SwapPayload.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SwapPayload, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SwapPayload;
+  static deserializeBinaryFromReader(message: SwapPayload, reader: jspb.BinaryReader): SwapPayload;
 }
 
 export namespace SwapPayload {
-    export type AsObject = {
-        role: string,
-        sendingAmount: number,
-        sendingToken: string,
-        receivingAmount: number,
-        receivingToken: string,
-    }
+  export type AsObject = {
+    role: string,
+    sendingAmount: number,
+    sendingToken: string,
+    receivingAmount: number,
+    receivingToken: string,
+  }
 }
 
-export class ExecuteSwapRequest extends jspb.Message { 
-    getTargetAddress(): string;
-    setTargetAddress(value: string): void;
+export class ExecuteSwapRequest extends jspb.Message {
+  getTargetAddress(): string;
+  setTargetAddress(value: string): void;
 
-    getIdentifier(): string;
-    setIdentifier(value: string): void;
+  getIdentifier(): string;
+  setIdentifier(value: string): void;
 
+  hasPayload(): boolean;
+  clearPayload(): void;
+  getPayload(): SwapPayload | undefined;
+  setPayload(value?: SwapPayload): void;
 
-    hasPayload(): boolean;
-    clearPayload(): void;
-    getPayload(): SwapPayload | undefined;
-    setPayload(value?: SwapPayload): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
-    static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
+  static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
 }
 
 export namespace ExecuteSwapRequest {
-    export type AsObject = {
-        targetAddress: string,
-        identifier: string,
-        payload?: SwapPayload.AsObject,
-    }
+  export type AsObject = {
+    targetAddress: string,
+    identifier: string,
+    payload?: SwapPayload.AsObject,
+  }
 }
 
-export class ExecuteSwapResponse extends jspb.Message { 
-    getResult(): string;
-    setResult(value: string): void;
+export class ExecuteSwapResponse extends jspb.Message {
+  getResult(): string;
+  setResult(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ExecuteSwapResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ExecuteSwapResponse): ExecuteSwapResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ExecuteSwapResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ExecuteSwapResponse;
-    static deserializeBinaryFromReader(message: ExecuteSwapResponse, reader: jspb.BinaryReader): ExecuteSwapResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ExecuteSwapResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ExecuteSwapResponse): ExecuteSwapResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ExecuteSwapResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ExecuteSwapResponse;
+  static deserializeBinaryFromReader(message: ExecuteSwapResponse, reader: jspb.BinaryReader): ExecuteSwapResponse;
 }
 
 export namespace ExecuteSwapResponse {
-    export type AsObject = {
-        result: string,
-    }
+  export type AsObject = {
+    result: string,
+  }
 }
 
-export class ConnectRequest extends jspb.Message { 
-    getHost(): string;
-    setHost(value: string): void;
+export class ConnectRequest extends jspb.Message {
+  getHost(): string;
+  setHost(value: string): void;
 
-    getPort(): number;
-    setPort(value: number): void;
+  getPort(): number;
+  setPort(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectRequest): ConnectRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectRequest;
-    static deserializeBinaryFromReader(message: ConnectRequest, reader: jspb.BinaryReader): ConnectRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectRequest): ConnectRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectRequest;
+  static deserializeBinaryFromReader(message: ConnectRequest, reader: jspb.BinaryReader): ConnectRequest;
 }
 
 export namespace ConnectRequest {
-    export type AsObject = {
-        host: string,
-        port: number,
-    }
+  export type AsObject = {
+    host: string,
+    port: number,
+  }
 }
 
-export class ConnectResponse extends jspb.Message { 
-    getResult(): string;
-    setResult(value: string): void;
+export class ConnectResponse extends jspb.Message {
+  getResult(): string;
+  setResult(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectResponse): ConnectResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectResponse;
-    static deserializeBinaryFromReader(message: ConnectResponse, reader: jspb.BinaryReader): ConnectResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectResponse): ConnectResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectResponse;
+  static deserializeBinaryFromReader(message: ConnectResponse, reader: jspb.BinaryReader): ConnectResponse;
 }
 
 export namespace ConnectResponse {
-    export type AsObject = {
-        result: string,
-    }
+  export type AsObject = {
+    result: string,
+  }
 }
 
-export class DisconnectRequest extends jspb.Message { 
-    getHost(): string;
-    setHost(value: string): void;
+export class DisconnectRequest extends jspb.Message {
+  getHost(): string;
+  setHost(value: string): void;
 
-    getPort(): number;
-    setPort(value: number): void;
+  getPort(): number;
+  setPort(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DisconnectRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DisconnectRequest): DisconnectRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DisconnectRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DisconnectRequest;
-    static deserializeBinaryFromReader(message: DisconnectRequest, reader: jspb.BinaryReader): DisconnectRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DisconnectRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DisconnectRequest): DisconnectRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DisconnectRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DisconnectRequest;
+  static deserializeBinaryFromReader(message: DisconnectRequest, reader: jspb.BinaryReader): DisconnectRequest;
 }
 
 export namespace DisconnectRequest {
-    export type AsObject = {
-        host: string,
-        port: number,
-    }
+  export type AsObject = {
+    host: string,
+    port: number,
+  }
 }
 
-export class DisconnectResponse extends jspb.Message { 
-    getResult(): string;
-    setResult(value: string): void;
+export class DisconnectResponse extends jspb.Message {
+  getResult(): string;
+  setResult(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DisconnectResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DisconnectResponse): DisconnectResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DisconnectResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DisconnectResponse;
-    static deserializeBinaryFromReader(message: DisconnectResponse, reader: jspb.BinaryReader): DisconnectResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DisconnectResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DisconnectResponse): DisconnectResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DisconnectResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DisconnectResponse;
+  static deserializeBinaryFromReader(message: DisconnectResponse, reader: jspb.BinaryReader): DisconnectResponse;
 }
 
 export namespace DisconnectResponse {
-    export type AsObject = {
-        result: string,
-    }
+  export type AsObject = {
+    result: string,
+  }
 }
 
-export class Order extends jspb.Message { 
-    getPrice(): number;
-    setPrice(value: number): void;
+export class Order extends jspb.Message {
+  getPrice(): number;
+  setPrice(value: number): void;
 
-    getQuantity(): number;
-    setQuantity(value: number): void;
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getPeerId(): number;
-    setPeerId(value: number): void;
+  getPeerId(): number;
+  setPeerId(value: number): void;
 
-    getHostId(): string;
-    setHostId(value: string): void;
+  getHostId(): string;
+  setHostId(value: string): void;
 
-    getId(): string;
-    setId(value: string): void;
+  getId(): string;
+  setId(value: string): void;
 
-    getLocalId(): string;
-    setLocalId(value: string): void;
+  getLocalId(): string;
+  setLocalId(value: string): void;
 
-    getCreatedAt(): number;
-    setCreatedAt(value: number): void;
+  getCreatedAt(): number;
+  setCreatedAt(value: number): void;
 
-    getInvoice(): string;
-    setInvoice(value: string): void;
+  getInvoice(): string;
+  setInvoice(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Order.AsObject;
-    static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Order;
-    static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Order.AsObject;
+  static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Order;
+  static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
 }
 
 export namespace Order {
-    export type AsObject = {
-        price: number,
-        quantity: number,
-        pairId: string,
-        peerId: number,
-        hostId: string,
-        id: string,
-        localId: string,
-        createdAt: number,
-        invoice: string,
-    }
+  export type AsObject = {
+    price: number,
+    quantity: number,
+    pairId: string,
+    peerId: number,
+    hostId: string,
+    id: string,
+    localId: string,
+    createdAt: number,
+    invoice: string,
+  }
 }
 
-export class OrderMatch extends jspb.Message { 
+export class OrderMatch extends jspb.Message {
+  hasMaker(): boolean;
+  clearMaker(): void;
+  getMaker(): Order | undefined;
+  setMaker(value?: Order): void;
 
-    hasMaker(): boolean;
-    clearMaker(): void;
-    getMaker(): Order | undefined;
-    setMaker(value?: Order): void;
+  hasTaker(): boolean;
+  clearTaker(): void;
+  getTaker(): Order | undefined;
+  setTaker(value?: Order): void;
 
-
-    hasTaker(): boolean;
-    clearTaker(): void;
-    getTaker(): Order | undefined;
-    setTaker(value?: Order): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OrderMatch.AsObject;
-    static toObject(includeInstance: boolean, msg: OrderMatch): OrderMatch.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OrderMatch, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OrderMatch;
-    static deserializeBinaryFromReader(message: OrderMatch, reader: jspb.BinaryReader): OrderMatch;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OrderMatch.AsObject;
+  static toObject(includeInstance: boolean, msg: OrderMatch): OrderMatch.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OrderMatch, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OrderMatch;
+  static deserializeBinaryFromReader(message: OrderMatch, reader: jspb.BinaryReader): OrderMatch;
 }
 
 export namespace OrderMatch {
-    export type AsObject = {
-        maker?: Order.AsObject,
-        taker?: Order.AsObject,
-    }
+  export type AsObject = {
+    maker?: Order.AsObject,
+    taker?: Order.AsObject,
+  }
 }
 
-export class PlaceOrderRequest extends jspb.Message { 
+export class PlaceOrderRequest extends jspb.Message {
+  hasOrder(): boolean;
+  clearOrder(): void;
+  getOrder(): Order | undefined;
+  setOrder(value?: Order): void;
 
-    hasOrder(): boolean;
-    clearOrder(): void;
-    getOrder(): Order | undefined;
-    setOrder(value?: Order): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PlaceOrderRequest): PlaceOrderRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PlaceOrderRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PlaceOrderRequest;
-    static deserializeBinaryFromReader(message: PlaceOrderRequest, reader: jspb.BinaryReader): PlaceOrderRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: PlaceOrderRequest): PlaceOrderRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PlaceOrderRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PlaceOrderRequest;
+  static deserializeBinaryFromReader(message: PlaceOrderRequest, reader: jspb.BinaryReader): PlaceOrderRequest;
 }
 
 export namespace PlaceOrderRequest {
-    export type AsObject = {
-        order?: Order.AsObject,
-    }
+  export type AsObject = {
+    order?: Order.AsObject,
+  }
 }
 
-export class PlaceOrderResponse extends jspb.Message { 
-    clearMatchesList(): void;
-    getMatchesList(): Array<OrderMatch>;
-    setMatchesList(value: Array<OrderMatch>): void;
-    addMatches(value?: OrderMatch, index?: number): OrderMatch;
+export class PlaceOrderResponse extends jspb.Message {
+  clearMatchesList(): void;
+  getMatchesList(): Array<OrderMatch>;
+  setMatchesList(value: Array<OrderMatch>): void;
+  addMatches(value?: OrderMatch, index?: number): OrderMatch;
 
+  hasRemainingOrder(): boolean;
+  clearRemainingOrder(): void;
+  getRemainingOrder(): Order | undefined;
+  setRemainingOrder(value?: Order): void;
 
-    hasRemainingOrder(): boolean;
-    clearRemainingOrder(): void;
-    getRemainingOrder(): Order | undefined;
-    setRemainingOrder(value?: Order): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PlaceOrderResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PlaceOrderResponse;
-    static deserializeBinaryFromReader(message: PlaceOrderResponse, reader: jspb.BinaryReader): PlaceOrderResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PlaceOrderResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PlaceOrderResponse;
+  static deserializeBinaryFromReader(message: PlaceOrderResponse, reader: jspb.BinaryReader): PlaceOrderResponse;
 }
 
 export namespace PlaceOrderResponse {
-    export type AsObject = {
-        matchesList: Array<OrderMatch.AsObject>,
-        remainingOrder?: Order.AsObject,
-    }
+  export type AsObject = {
+    matchesList: Array<OrderMatch.AsObject>,
+    remainingOrder?: Order.AsObject,
+  }
 }
 
-export class CancelOrderRequest extends jspb.Message { 
-    getOrderId(): string;
-    setOrderId(value: string): void;
+export class CancelOrderRequest extends jspb.Message {
+  getOrderId(): string;
+  setOrderId(value: string): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
+  getPairId(): string;
+  setPairId(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CancelOrderRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: CancelOrderRequest): CancelOrderRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CancelOrderRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CancelOrderRequest;
-    static deserializeBinaryFromReader(message: CancelOrderRequest, reader: jspb.BinaryReader): CancelOrderRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CancelOrderRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: CancelOrderRequest): CancelOrderRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CancelOrderRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CancelOrderRequest;
+  static deserializeBinaryFromReader(message: CancelOrderRequest, reader: jspb.BinaryReader): CancelOrderRequest;
 }
 
 export namespace CancelOrderRequest {
-    export type AsObject = {
-        orderId: string,
-        pairId: string,
-    }
+  export type AsObject = {
+    orderId: string,
+    pairId: string,
+  }
 }
 
-export class CancelOrderResponse extends jspb.Message { 
-    getCanceled(): boolean;
-    setCanceled(value: boolean): void;
+export class CancelOrderResponse extends jspb.Message {
+  getCanceled(): boolean;
+  setCanceled(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CancelOrderResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: CancelOrderResponse): CancelOrderResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CancelOrderResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CancelOrderResponse;
-    static deserializeBinaryFromReader(message: CancelOrderResponse, reader: jspb.BinaryReader): CancelOrderResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CancelOrderResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: CancelOrderResponse): CancelOrderResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CancelOrderResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CancelOrderResponse;
+  static deserializeBinaryFromReader(message: CancelOrderResponse, reader: jspb.BinaryReader): CancelOrderResponse;
 }
 
 export namespace CancelOrderResponse {
-    export type AsObject = {
-        canceled: boolean,
-    }
+  export type AsObject = {
+    canceled: boolean,
+  }
 }
 
-export class GetOrdersRequest extends jspb.Message { 
-    getPairId(): string;
-    setPairId(value: string): void;
+export class GetOrdersRequest extends jspb.Message {
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getMaxResults(): number;
-    setMaxResults(value: number): void;
+  getMaxResults(): number;
+  setMaxResults(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetOrdersRequest): GetOrdersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetOrdersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetOrdersRequest;
-    static deserializeBinaryFromReader(message: GetOrdersRequest, reader: jspb.BinaryReader): GetOrdersRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetOrdersRequest): GetOrdersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetOrdersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetOrdersRequest;
+  static deserializeBinaryFromReader(message: GetOrdersRequest, reader: jspb.BinaryReader): GetOrdersRequest;
 }
 
 export namespace GetOrdersRequest {
-    export type AsObject = {
-        pairId: string,
-        maxResults: number,
-    }
+  export type AsObject = {
+    pairId: string,
+    maxResults: number,
+  }
 }
 
-export class GetOrdersResponse extends jspb.Message { 
-    clearBuyOrdersList(): void;
-    getBuyOrdersList(): Array<Order>;
-    setBuyOrdersList(value: Array<Order>): void;
-    addBuyOrders(value?: Order, index?: number): Order;
+export class GetOrdersResponse extends jspb.Message {
+  clearBuyOrdersList(): void;
+  getBuyOrdersList(): Array<Order>;
+  setBuyOrdersList(value: Array<Order>): void;
+  addBuyOrders(value?: Order, index?: number): Order;
 
-    clearSellOrdersList(): void;
-    getSellOrdersList(): Array<Order>;
-    setSellOrdersList(value: Array<Order>): void;
-    addSellOrders(value?: Order, index?: number): Order;
+  clearSellOrdersList(): void;
+  getSellOrdersList(): Array<Order>;
+  setSellOrdersList(value: Array<Order>): void;
+  addSellOrders(value?: Order, index?: number): Order;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetOrdersResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetOrdersResponse): GetOrdersResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetOrdersResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetOrdersResponse;
-    static deserializeBinaryFromReader(message: GetOrdersResponse, reader: jspb.BinaryReader): GetOrdersResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetOrdersResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetOrdersResponse): GetOrdersResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetOrdersResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetOrdersResponse;
+  static deserializeBinaryFromReader(message: GetOrdersResponse, reader: jspb.BinaryReader): GetOrdersResponse;
 }
 
 export namespace GetOrdersResponse {
-    export type AsObject = {
-        buyOrdersList: Array<Order.AsObject>,
-        sellOrdersList: Array<Order.AsObject>,
-    }
+  export type AsObject = {
+    buyOrdersList: Array<Order.AsObject>,
+    sellOrdersList: Array<Order.AsObject>,
+  }
 }
 
-export class ShutdownRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ShutdownRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ShutdownRequest): ShutdownRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ShutdownRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ShutdownRequest;
-    static deserializeBinaryFromReader(message: ShutdownRequest, reader: jspb.BinaryReader): ShutdownRequest;
+export class ShutdownRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ShutdownRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ShutdownRequest): ShutdownRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ShutdownRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ShutdownRequest;
+  static deserializeBinaryFromReader(message: ShutdownRequest, reader: jspb.BinaryReader): ShutdownRequest;
 }
 
 export namespace ShutdownRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ShutdownResponse extends jspb.Message { 
-    getResult(): string;
-    setResult(value: string): void;
+export class ShutdownResponse extends jspb.Message {
+  getResult(): string;
+  setResult(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ShutdownResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ShutdownResponse): ShutdownResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ShutdownResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ShutdownResponse;
-    static deserializeBinaryFromReader(message: ShutdownResponse, reader: jspb.BinaryReader): ShutdownResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ShutdownResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ShutdownResponse): ShutdownResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ShutdownResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ShutdownResponse;
+  static deserializeBinaryFromReader(message: ShutdownResponse, reader: jspb.BinaryReader): ShutdownResponse;
 }
 
 export namespace ShutdownResponse {
-    export type AsObject = {
-        result: string,
-    }
+  export type AsObject = {
+    result: string,
+  }
 }
 
-export class SubscribePeerOrdersRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribePeerOrdersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribePeerOrdersRequest): SubscribePeerOrdersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribePeerOrdersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersRequest;
-    static deserializeBinaryFromReader(message: SubscribePeerOrdersRequest, reader: jspb.BinaryReader): SubscribePeerOrdersRequest;
+export class SubscribePeerOrdersRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribePeerOrdersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribePeerOrdersRequest): SubscribePeerOrdersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribePeerOrdersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersRequest;
+  static deserializeBinaryFromReader(message: SubscribePeerOrdersRequest, reader: jspb.BinaryReader): SubscribePeerOrdersRequest;
 }
 
 export namespace SubscribePeerOrdersRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class SubscribePeerOrdersResponse extends jspb.Message { 
+export class SubscribePeerOrdersResponse extends jspb.Message {
+  hasOrder(): boolean;
+  clearOrder(): void;
+  getOrder(): Order | undefined;
+  setOrder(value?: Order): void;
 
-    hasOrder(): boolean;
-    clearOrder(): void;
-    getOrder(): Order | undefined;
-    setOrder(value?: Order): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribePeerOrdersResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribePeerOrdersResponse): SubscribePeerOrdersResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribePeerOrdersResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersResponse;
-    static deserializeBinaryFromReader(message: SubscribePeerOrdersResponse, reader: jspb.BinaryReader): SubscribePeerOrdersResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribePeerOrdersResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribePeerOrdersResponse): SubscribePeerOrdersResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribePeerOrdersResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribePeerOrdersResponse;
+  static deserializeBinaryFromReader(message: SubscribePeerOrdersResponse, reader: jspb.BinaryReader): SubscribePeerOrdersResponse;
 }
 
 export namespace SubscribePeerOrdersResponse {
-    export type AsObject = {
-        order?: Order.AsObject,
-    }
+  export type AsObject = {
+    order?: Order.AsObject,
+  }
 }
 
-export class SubscribeSwapsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribeSwapsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribeSwapsRequest): SubscribeSwapsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribeSwapsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribeSwapsRequest;
-    static deserializeBinaryFromReader(message: SubscribeSwapsRequest, reader: jspb.BinaryReader): SubscribeSwapsRequest;
+export class SubscribeSwapsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribeSwapsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribeSwapsRequest): SubscribeSwapsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribeSwapsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribeSwapsRequest;
+  static deserializeBinaryFromReader(message: SubscribeSwapsRequest, reader: jspb.BinaryReader): SubscribeSwapsRequest;
 }
 
 export namespace SubscribeSwapsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class SubscribeSwapsResponse extends jspb.Message { 
-    getResult(): string;
-    setResult(value: string): void;
+export class SubscribeSwapsResponse extends jspb.Message {
+  getResult(): string;
+  setResult(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribeSwapsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribeSwapsResponse): SubscribeSwapsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribeSwapsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribeSwapsResponse;
-    static deserializeBinaryFromReader(message: SubscribeSwapsResponse, reader: jspb.BinaryReader): SubscribeSwapsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribeSwapsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribeSwapsResponse): SubscribeSwapsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribeSwapsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribeSwapsResponse;
+  static deserializeBinaryFromReader(message: SubscribeSwapsResponse, reader: jspb.BinaryReader): SubscribeSwapsResponse;
 }
 
 export namespace SubscribeSwapsResponse {
-    export type AsObject = {
-        result: string,
-    }
+  export type AsObject = {
+    result: string,
+  }
 }
+

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -4285,7 +4285,7 @@ proto.xudrpc.CancelOrderResponse.prototype.toObject = function(opt_includeInstan
  */
 proto.xudrpc.CancelOrderResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    result: jspb.Message.getFieldWithDefault(msg, 1, false)
+    canceled: jspb.Message.getFieldWithDefault(msg, 1, false)
   };
 
   if (includeInstance) {
@@ -4324,7 +4324,7 @@ proto.xudrpc.CancelOrderResponse.deserializeBinaryFromReader = function(msg, rea
     switch (field) {
     case 1:
       var value = /** @type {boolean} */ (reader.readBool());
-      msg.setResult(value);
+      msg.setCanceled(value);
       break;
     default:
       reader.skipField();
@@ -4355,7 +4355,7 @@ proto.xudrpc.CancelOrderResponse.prototype.serializeBinary = function() {
  */
 proto.xudrpc.CancelOrderResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getResult();
+  f = message.getCanceled();
   if (f) {
     writer.writeBool(
       1,
@@ -4366,18 +4366,18 @@ proto.xudrpc.CancelOrderResponse.serializeBinaryToWriter = function(message, wri
 
 
 /**
- * optional bool result = 1;
+ * optional bool canceled = 1;
  * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
  * You should avoid comparisons like {@code val === true/false} in those cases.
  * @return {boolean}
  */
-proto.xudrpc.CancelOrderResponse.prototype.getResult = function() {
+proto.xudrpc.CancelOrderResponse.prototype.getCanceled = function() {
   return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 1, false));
 };
 
 
 /** @param {boolean} value */
-proto.xudrpc.CancelOrderResponse.prototype.setResult = function(value) {
+proto.xudrpc.CancelOrderResponse.prototype.setCanceled = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -3190,8 +3190,9 @@ proto.xudrpc.Order.toObject = function(includeInstance, msg) {
     peerId: jspb.Message.getFieldWithDefault(msg, 4, 0),
     hostId: jspb.Message.getFieldWithDefault(msg, 5, ""),
     id: jspb.Message.getFieldWithDefault(msg, 6, ""),
-    createdAt: jspb.Message.getFieldWithDefault(msg, 7, 0),
-    invoice: jspb.Message.getFieldWithDefault(msg, 8, "")
+    localId: jspb.Message.getFieldWithDefault(msg, 7, ""),
+    createdAt: jspb.Message.getFieldWithDefault(msg, 8, 0),
+    invoice: jspb.Message.getFieldWithDefault(msg, 9, "")
   };
 
   if (includeInstance) {
@@ -3253,10 +3254,14 @@ proto.xudrpc.Order.deserializeBinaryFromReader = function(msg, reader) {
       msg.setId(value);
       break;
     case 7:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setLocalId(value);
+      break;
+    case 8:
       var value = /** @type {number} */ (reader.readInt64());
       msg.setCreatedAt(value);
       break;
-    case 8:
+    case 9:
       var value = /** @type {string} */ (reader.readString());
       msg.setInvoice(value);
       break;
@@ -3331,17 +3336,24 @@ proto.xudrpc.Order.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
+  f = message.getLocalId();
+  if (f.length > 0) {
+    writer.writeString(
+      7,
+      f
+    );
+  }
   f = message.getCreatedAt();
   if (f !== 0) {
     writer.writeInt64(
-      7,
+      8,
       f
     );
   }
   f = message.getInvoice();
   if (f.length > 0) {
     writer.writeString(
-      8,
+      9,
       f
     );
   }
@@ -3439,32 +3451,47 @@ proto.xudrpc.Order.prototype.setId = function(value) {
 
 
 /**
- * optional int64 created_at = 7;
- * @return {number}
+ * optional string local_id = 7;
+ * @return {string}
  */
-proto.xudrpc.Order.prototype.getCreatedAt = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 7, 0));
+proto.xudrpc.Order.prototype.getLocalId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 7, ""));
 };
 
 
-/** @param {number} value */
-proto.xudrpc.Order.prototype.setCreatedAt = function(value) {
+/** @param {string} value */
+proto.xudrpc.Order.prototype.setLocalId = function(value) {
   jspb.Message.setField(this, 7, value);
 };
 
 
 /**
- * optional string invoice = 8;
+ * optional int64 created_at = 8;
+ * @return {number}
+ */
+proto.xudrpc.Order.prototype.getCreatedAt = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 8, 0));
+};
+
+
+/** @param {number} value */
+proto.xudrpc.Order.prototype.setCreatedAt = function(value) {
+  jspb.Message.setField(this, 8, value);
+};
+
+
+/**
+ * optional string invoice = 9;
  * @return {string}
  */
 proto.xudrpc.Order.prototype.getInvoice = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 8, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 9, ""));
 };
 
 
 /** @param {string} value */
 proto.xudrpc.Order.prototype.setInvoice = function(value) {
-  jspb.Message.setField(this, 8, value);
+  jspb.Message.setField(this, 9, value);
 };
 
 
@@ -4258,7 +4285,7 @@ proto.xudrpc.CancelOrderResponse.prototype.toObject = function(opt_includeInstan
  */
 proto.xudrpc.CancelOrderResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    result: jspb.Message.getFieldWithDefault(msg, 1, "")
+    result: jspb.Message.getFieldWithDefault(msg, 1, false)
   };
 
   if (includeInstance) {
@@ -4296,7 +4323,7 @@ proto.xudrpc.CancelOrderResponse.deserializeBinaryFromReader = function(msg, rea
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {string} */ (reader.readString());
+      var value = /** @type {boolean} */ (reader.readBool());
       msg.setResult(value);
       break;
     default:
@@ -4329,8 +4356,8 @@ proto.xudrpc.CancelOrderResponse.prototype.serializeBinary = function() {
 proto.xudrpc.CancelOrderResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getResult();
-  if (f.length > 0) {
-    writer.writeString(
+  if (f) {
+    writer.writeBool(
       1,
       f
     );
@@ -4339,15 +4366,17 @@ proto.xudrpc.CancelOrderResponse.serializeBinaryToWriter = function(message, wri
 
 
 /**
- * optional string result = 1;
- * @return {string}
+ * optional bool result = 1;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
  */
 proto.xudrpc.CancelOrderResponse.prototype.getResult = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 1, false));
 };
 
 
-/** @param {string} value */
+/** @param {boolean} value */
 proto.xudrpc.CancelOrderResponse.prototype.setResult = function(value) {
   jspb.Message.setField(this, 1, value);
 };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -162,8 +162,7 @@ class Service extends EventEmitter {
    * Cancel placed order from the orderbook.
    */
   public cancelOrder = async ({ pairId, orderId }: { pairId: string, orderId: string }) => {
-    return {
-      canceled: this.orderBook.removeOwnOrderByLocalId(pairId, orderId) };
+    return { canceled: this.orderBook.removeOwnOrderByLocalId(pairId, orderId) };
   }
 
   /**

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -73,8 +73,8 @@ class Service extends EventEmitter {
         this.orderBook.getOwnOrders(pair.id, 0),
       ]);
 
-      peerOrdersCount += Object.keys(peerOrders.buyOrders).length + Object.keys(peerOrders.sellOrders).length;
-      ownOrdersCount += Object.keys(ownOrders.buyOrders).length + Object.keys(ownOrders.sellOrders).length;
+      peerOrdersCount += peerOrders['buyOrders'].length + peerOrders['sellOrders'].length;
+      ownOrdersCount += ownOrders['buyOrders'].length + ownOrders['sellOrders'].length;
     }
 
     info.orders = {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -161,8 +161,8 @@ class Service extends EventEmitter {
   /*
    * Cancel placed order from the orderbook.
    */
-  public cancelOrder = async ({ orderId, pairId }: { orderId: string, pairId: string }) => {
-    return this.orderBook.removeOwnOrder(orderId, pairId);
+  public cancelOrder = async ({ pairId, orderId }: { pairId: string, orderId: string }) => {
+    return this.orderBook.removeOwnOrder(pairId, orderId);
   }
 
   /**

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -73,8 +73,8 @@ class Service extends EventEmitter {
         this.orderBook.getOwnOrders(pair.id, 0),
       ]);
 
-      peerOrdersCount += peerOrders['buyOrders'].length + peerOrders['sellOrders'].length;
-      ownOrdersCount += ownOrders['buyOrders'].length + ownOrders['sellOrders'].length;
+      peerOrdersCount += Object.keys(peerOrders.buyOrders).length + Object.keys(peerOrders.sellOrders).length;
+      ownOrdersCount += Object.keys(ownOrders.buyOrders).length + Object.keys(ownOrders.sellOrders).length;
     }
 
     info.orders = {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -162,7 +162,8 @@ class Service extends EventEmitter {
    * Cancel placed order from the orderbook.
    */
   public cancelOrder = async ({ pairId, orderId }: { pairId: string, orderId: string }) => {
-    return this.orderBook.removeOwnOrder(pairId, orderId);
+    return {
+      canceled: this.orderBook.removeOwnOrderByLocalId(pairId, orderId) };
   }
 
   /**

--- a/lib/types/matchingEngine.ts
+++ b/lib/types/matchingEngine.ts
@@ -1,4 +1,4 @@
-import { StampedOrder } from './orders';
+import { StampedOrder, StampedOwnOrder } from './orders';
 
 export type OrderMatch = {
   maker: StampedOrder;
@@ -7,5 +7,5 @@ export type OrderMatch = {
 
 export type MatchingResult = {
   matches: OrderMatch[];
-  remainingOrder: StampedOrder;
+  remainingOrder: StampedOwnOrder;
 };

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -3,11 +3,16 @@ export type MarketOrder = {
   pairId: string;
 };
 
-export type OwnOrder = MarketOrder & {
+export type OwnMarketOrder = MarketOrder & {
+  localId: string;
+};
+
+export type OwnOrder = OwnMarketOrder & {
   price: number;
 };
 
-export type PeerOrder = OwnOrder & {
+export type PeerOrder = MarketOrder & {
+  price: number;
   id: string;
   hostId: number;
   invoice: string;
@@ -24,7 +29,8 @@ export type StampedPeerOrder = PeerOrder & {
 
 export type StampedOrder = StampedOwnOrder | StampedPeerOrder;
 
-export type OutgoingOrder = OwnOrder & {
+export type OutgoingOrder = MarketOrder & {
+  price: number;
   id: string;
   invoice: string;
 };

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -220,7 +220,8 @@ message CancelOrderRequest {
 }
 
 message CancelOrderResponse {
-  bool result = 1 [json_name = "result"];
+  // True means that the order was canceled and false means that it wasn't
+  bool canceled = 1 [json_name = "canceled"];
 }
 
 message GetOrdersRequest {

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -191,10 +191,12 @@ message Order {
   string host_id = 5 [json_name = "host_id"];
   // A UUID for this order
   string id = 6 [json_name = "id"];
+  // The local ID for this oder
+  string local_id = 7 [json_name = "local_id"];
   // The epoch time when this order was created
-  int64 created_at = 7 [json_name = "created_at"];
+  int64 created_at = 8 [json_name = "created_at"];
   // Lightning invoice
-  string invoice = 8 [json_name = "invoice"];
+  string invoice = 9 [json_name = "invoice"];
 }
 
 message OrderMatch {
@@ -218,7 +220,7 @@ message CancelOrderRequest {
 }
 
 message CancelOrderResponse {
-  string result = 1 [json_name = "result"];
+  bool result = 1 [json_name = "result"];
 }
 
 message GetOrdersRequest {

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -220,7 +220,7 @@ message CancelOrderRequest {
 }
 
 message CancelOrderResponse {
-  // True means that the order was canceled and false means that it wasn't
+  // Indicates whether an order was successfully canceled
   bool canceled = 1 [json_name = "canceled"];
 }
 

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -45,9 +45,9 @@ describe('OrderBook', () => {
     let array: StampedOrder[];
 
     if (order.quantity > 0) {
-      array = ownOrders.buyOrders;
+      array = ownOrders['buyOrders'];
     } else {
-      array = ownOrders.sellOrders;
+      array = ownOrders['sellOrders'];
     }
 
     let result;

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import uuidv1 from 'uuid/v1';
 import Config from '../../lib/Config';
 import DB from '../../lib/db/DB';
 import { SwapProtocol } from '../../lib/types/enums';
@@ -68,13 +69,13 @@ describe('OrderBook', () => {
   });
 
   it('should append two new ownOrder', async () => {
-    const order: orders.OwnOrder = { pairId: 'BTC/LTC',  quantity: 5, price: 55 };
-    await orderBook.addLimitOrder(order);
-    await orderBook.addLimitOrder(order);
+    const order = { pairId: 'BTC/LTC', quantity: 5, price: 55 };
+    await orderBook.addLimitOrder({ localId: uuidv1(), ...order });
+    await orderBook.addLimitOrder({ localId: uuidv1(), ...order });
   });
 
   it('should fully match new ownOrder and remove matches', async () => {
-    const order: orders.OwnOrder = { pairId: 'BTC/LTC', quantity: -6, price: 55 };
+    const order: orders.OwnOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -6, price: 55 };
     const matches = await orderBook.addLimitOrder(order);
     expect(matches.remainingOrder).to.be.null;
     expect(getOrder(matches.matches[0].maker)).to.be.undefined;
@@ -82,7 +83,7 @@ describe('OrderBook', () => {
   });
 
   it('should partially match new market order and discard remaining order', async () => {
-    const order: orders.MarketOrder = { pairId: 'BTC/LTC', quantity: -10 };
+    const order: orders.OwnMarketOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -10 };
     const matches = await orderBook.addMarketOrder(order);
     expect(matches.remainingOrder.quantity).to.be.greaterThan(order.quantity);
     expect((getOrder(matches.remainingOrder))).to.be.undefined;

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -45,9 +45,9 @@ describe('OrderBook', () => {
     let array: StampedOrder[];
 
     if (order.quantity > 0) {
-      array = ownOrders['buyOrders'];
+      array = ownOrders.buyOrders;
     } else {
-      array = ownOrders['sellOrders'];
+      array = ownOrders.sellOrders;
     }
 
     let result;

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -7,11 +7,12 @@ import { ms } from '../../lib/utils/utils';
 
 const PAIR_ID = 'BTC/LTC';
 
-const createOrder = (price: number, quantity: number, createdAt = ms()): orders.StampedOrder => ({
-  quantity,
+const createOwnOrder = (price: number, quantity: number, createdAt = ms()): orders.StampedOwnOrder => ({
   price,
+  quantity,
   createdAt,
   id: uuidv1(),
+  localId: uuidv1(),
   pairId: PAIR_ID,
 });
 
@@ -25,40 +26,35 @@ const createPeerOrder = (price: number, quantity: number, createdAt = ms(), host
   invoice: '',
 });
 
-const createOwnOrder = (price: number, quantity: number, data = ms()): orders.StampedOwnOrder => {
-  const { hostId, invoice, ...ownOrder } = { ...createOrder(price, quantity, data), localId: uuidv1() };
-  return ownOrder;
-};
-
 describe('MatchingEngine.getMatchingQuantity', () => {
   it('should not match buy order with a lower price then a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOrder(5, 10),
-      createOrder(5.5, -10),
+      createOwnOrder(5, 10),
+      createOwnOrder(5.5, -10),
     );
     expect(res).to.equal(0);
   });
 
   it('should match buy order with a higher then a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOrder(5.5, 10),
-      createOrder(5, -10),
+      createOwnOrder(5.5, 10),
+      createOwnOrder(5, -10),
     );
     expect(res).to.equal(10);
   });
 
   it('should match buy order with an equal price to a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOrder(5, 10),
-      createOrder(5, -10),
+      createOwnOrder(5, 10),
+      createOwnOrder(5, -10),
     );
     expect(res).to.equal(10);
   });
 
   it('should match with lowest quantity of both orders', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOrder(5, 5),
-      createOrder(5, -10),
+      createOwnOrder(5, 5),
+      createOwnOrder(5, -10),
     );
     expect(res).to.equal(5);
   });
@@ -68,8 +64,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize lower price on ASC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.ASC);
     const res = comparator(
-      createOrder(5, 10),
-      createOrder(5.5, -10),
+      createOwnOrder(5, 10),
+      createOwnOrder(5.5, -10),
     );
     expect(res).to.be.true;
   });
@@ -77,8 +73,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should not prioritize higher price on ASC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.ASC);
     const res = comparator(
-      createOrder(5.5, 10),
-      createOrder(5, -10),
+      createOwnOrder(5.5, 10),
+      createOwnOrder(5, -10),
     );
     expect(res).to.be.false;
   });
@@ -86,8 +82,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize higher price on DESC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.DESC);
     const res = comparator(
-      createOrder(5.5, 10),
-      createOrder(5, -10),
+      createOwnOrder(5.5, 10),
+      createOwnOrder(5, -10),
     );
     expect(res).to.be.true;
   });
@@ -95,8 +91,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should not prioritize lower price on DESC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.DESC);
     const res = comparator(
-      createOrder(5, 10),
-      createOrder(5.5, -10),
+      createOwnOrder(5, 10),
+      createOwnOrder(5.5, -10),
     );
     expect(res).to.be.false;
   });
@@ -104,8 +100,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize earlier createdAt when prices are equal on ASC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.ASC);
     const res = comparator(
-      createOrder(5, 10, ms() - 1),
-      createOrder(5, -10, ms()),
+      createOwnOrder(5, 10, ms() - 1),
+      createOwnOrder(5, -10, ms()),
     );
     expect(res).to.be.true;
   });
@@ -113,8 +109,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize earlier createdAt when prices are equal on DESC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.DESC);
     const res = comparator(
-      createOrder(5, 10, ms() - 1),
-      createOrder(5, -10, ms()),
+      createOwnOrder(5, 10, ms() - 1),
+      createOwnOrder(5, -10, ms()),
     );
     expect(res).to.be.true;
   });
@@ -125,7 +121,7 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
     const orderQuantity = 10;
     const targetQuantity = 6;
     const { target, remaining } = MatchingEngine.splitOrderByQuantity(
-      createOrder(5, orderQuantity),
+      createOwnOrder(5, orderQuantity),
       targetQuantity,
     );
     expect(target.quantity).to.equal(targetQuantity);
@@ -136,7 +132,7 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
     const orderQuantity = -10;
     const targetQuantity = 4;
     const { target, remaining } = MatchingEngine.splitOrderByQuantity(
-      createOrder(5, orderQuantity),
+      createOwnOrder(5, orderQuantity),
       targetQuantity,
     );
     expect(target.quantity).to.equal(targetQuantity * -1);
@@ -145,7 +141,7 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
 
   it('should not work when targetQuantity higher than quantity of order', () => {
     expect(() => MatchingEngine.splitOrderByQuantity(
-      createOrder(5, 5),
+      createOwnOrder(5, 5),
       10,
     )).to.throw('order abs quantity should be higher than targetQuantity');
   });
@@ -228,7 +224,7 @@ describe('MatchingEngine.removePeerOrders', () => {
     const removedOrders = engine.removePeerOrders(order => order.hostId === firstHostId);
     expect(JSON.stringify(removedOrders)).to.be.equals(JSON.stringify(firstHostOrders));
 
-    const matchingResult = engine.matchOrAddOwnOrder(createOrder(5, 15), false);
+    const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(5, 15), false);
     expect(matchingResult.remainingOrder.quantity).to.equal(10);
   });
 });

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -17,6 +17,11 @@ const createOrder = (price: number, quantity: number, date = ms()): orders.Stamp
   invoice: '',
 });
 
+const createOwnOrder = (price: number, quantity: number, data = ms()): orders.StampedOwnOrder => {
+  const { hostId, invoice, ...ownOrder } = { ...createOrder(price, quantity, data), localId: uuidv1() };
+  return ownOrder;
+};
+
 describe('MatchingEngine.getMatchingQuantity', () => {
   it('should not match buy order with a lower price then a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
@@ -145,7 +150,7 @@ describe('MatchingEngine.match', () => {
     engine.addPeerOrder(createOrder(5, -5));
     const matchAgainst = [engine.priorityQueues.sellOrders];
     const { remainingOrder } = MatchingEngine.match(
-      createOrder(5, 10),
+      createOwnOrder(5, 10),
       matchAgainst,
     );
     expect(remainingOrder).to.be.null;
@@ -157,7 +162,7 @@ describe('MatchingEngine.match', () => {
     engine.addPeerOrder(createOrder(5, -5));
     const matchAgainst = [engine.priorityQueues.sellOrders];
     const { remainingOrder } = MatchingEngine.match(
-      createOrder(5, 10),
+      createOwnOrder(5, 10),
       matchAgainst,
     );
     expect(remainingOrder.quantity).to.equal(1);
@@ -169,7 +174,7 @@ describe('MatchingEngine.match', () => {
     engine.addPeerOrder(createOrder(5, -6));
     const matchAgainst = [engine.priorityQueues.sellOrders];
     const { matches, remainingOrder } = MatchingEngine.match(
-      createOrder(5, 10),
+      createOwnOrder(5, 10),
       matchAgainst,
     );
     expect(remainingOrder).to.be.null;
@@ -183,7 +188,7 @@ describe('MatchingEngine.match', () => {
     const engine = new MatchingEngine(PAIR_ID);
     expect(engine.isEmpty()).to.be.true;
 
-    const matchingResult = engine.matchOrAddOwnOrder(createOrder(5, -5), false);
+    const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(5, -5), false);
     expect(matchingResult.matches).to.be.empty;
     expect(engine.isEmpty()).to.be.false;
 


### PR DESCRIPTION
Closes #175 

I thought `internalId` (because it is doesn't leave the exchange) is more suitable than `clientOrderId`. Thoughts?