### PR TITLE
Priority queue types & removePeerOrders fix

### DIFF
--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -16,6 +16,7 @@ type PriorityQueue = {
   isEmpty: Function;
   has: Function;
 };
+import { StampedOrder, StampedOwnOrder, StampedPeerOrder } from '../types/orders';
 
 type PriorityQueues = {
   buyOrders: PriorityQueue;
@@ -160,11 +161,15 @@ class MatchingEngine {
     return this.removeOrder(orderId) as orders.StampedPeerOrder;
   }
 
-  public removePeerOrders = (predicate: Function): orders.StampedPeerOrder[] => {
+  public removePeerOrders = (hostId: number): StampedPeerOrder[] => {
+    const callback = (order: StampedOrder) => {
+      return (order as StampedPeerOrder).hostId === hostId;
+    };
+
     return [
-      ...this.priorityQueues.buyOrders.removeMany(predicate),
-      ...this.priorityQueues.sellOrders.removeMany(predicate),
-    ];
+      ...this.priorityQueues.buyOrders.removeMany(callback),
+      ...this.priorityQueues.sellOrders.removeMany(callback),
+    ] as StampedPeerOrder[];
   }
 
   public isEmpty = (): boolean => {

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -1,31 +1,35 @@
 import assert from 'assert';
 import FastPriorityQueue from 'fastpriorityqueue';
 
-import { orders, matchingEngine } from '../types';
+import { matchingEngine } from '../types';
 import { OrderingDirection } from '../types/enums';
 import Logger from '../Logger';
-
-type PriorityQueue = {
-  add: Function;
-  removeOne: Function;
-  removeMany: Function;
-  heapify: Function;
-  peek: Function;
-  poll: Function;
-  trim: Function;
-  isEmpty: Function;
-  has: Function;
-};
 import { StampedOrder, StampedOwnOrder, StampedPeerOrder } from '../types/orders';
 
+interface PriorityQueue<T> {
+  add: (value: T) => void;
+  clone: () => PriorityQueue<T>;
+  forEach: (callback: (value: T, index: number) => void) => void;
+  heapify: (array: T[]) => void;
+  isEmpty: () => boolean;
+  peek: () => T | undefined;
+  poll: () => T | undefined;
+  remove: (value: T) => boolean;
+  removeMany: (callback: (a: T) => boolean, limit?: number) => T[];
+  removeOne: (callback: (a: T) => boolean) => T | undefined;
+  replaceTop: (value: T) => T | undefined;
+  size: number;
+  trim: () => void;
+}
+
 type PriorityQueues = {
-  buyOrders: PriorityQueue;
-  sellOrders: PriorityQueue;
+  buyOrders: PriorityQueue<StampedOrder>;
+  sellOrders: PriorityQueue<StampedOrder>;
 };
 
 type SplitOrder = {
-  target: orders.StampedOrder;
-  remaining: orders.StampedOrder;
+  target: StampedOrder;
+  remaining: StampedOrder;
 };
 
 class MatchingEngine {
@@ -39,17 +43,17 @@ class MatchingEngine {
     };
   }
 
-  private static createPriorityQueue(orderingDirection): PriorityQueue {
+  private static createPriorityQueue(orderingDirection: OrderingDirection): PriorityQueue<StampedOrder> {
     const comparator = this.getOrdersPriorityQueueComparator(orderingDirection);
     return new FastPriorityQueue(comparator);
   }
 
-  public static getOrdersPriorityQueueComparator(orderingDirection): Function {
+  public static getOrdersPriorityQueueComparator(orderingDirection: OrderingDirection) {
     const directionComparator = orderingDirection === OrderingDirection.ASC
-      ? (a, b) => a < b
-      : (a, b) => a > b;
+      ? (a: number, b: number) => a < b
+      : (a: number, b: number) => a > b;
 
-    return (a, b) => {
+    return (a: StampedOrder, b: StampedOrder) => {
       if (a.price === b.price) {
         return a.createdAt < b.createdAt;
       } else {
@@ -58,7 +62,7 @@ class MatchingEngine {
     };
   }
 
-  public static getMatchingQuantity = (buyOrder: orders.StampedOrder, sellOrder: orders.StampedOrder): number => {
+  public static getMatchingQuantity = (buyOrder: StampedOrder, sellOrder: StampedOrder): number => {
     if (buyOrder.price >= sellOrder.price) {
       return Math.min(buyOrder.quantity, sellOrder.quantity * -1);
     } else {
@@ -66,7 +70,7 @@ class MatchingEngine {
     }
   }
 
-  public static splitOrderByQuantity = (order: orders.StampedOrder, targetQuantity: number): SplitOrder => {
+  public static splitOrderByQuantity = (order: StampedOrder, targetQuantity: number): SplitOrder => {
     const { quantity } = order;
     const absQuantity = Math.abs(quantity);
     assert(absQuantity > targetQuantity, 'order abs quantity should be higher than targetQuantity');
@@ -78,10 +82,10 @@ class MatchingEngine {
     };
   }
 
-  public static match(order: orders.StampedOwnOrder, matchAgainst: PriorityQueue[]): matchingEngine.MatchingResult {
+  public static match(order: StampedOwnOrder, matchAgainst: PriorityQueue<StampedOrder>[]): matchingEngine.MatchingResult {
     const isBuyOrder = order.quantity > 0;
     const matches: matchingEngine.OrderMatch[] = [];
-    let remainingOrder: orders.StampedOwnOrder | null = { ...order };
+    let remainingOrder: StampedOwnOrder | null = { ...order };
 
     const getMatchingQuantity = (remainingOrder, oppositeOrder) => isBuyOrder
       ? MatchingEngine.getMatchingQuantity(remainingOrder, oppositeOrder)
@@ -94,7 +98,7 @@ class MatchingEngine {
         if (matchingQuantity <= 0) {
           break;
         } else {
-          const oppositeOrder = priorityQueue.poll();
+          const oppositeOrder = priorityQueue.poll()!;
           const oppositeOrderAbsQuantity = Math.abs(oppositeOrder.quantity);
           const remainingOrderAbsQuantity = Math.abs(remainingOrder.quantity);
           if (
@@ -111,7 +115,7 @@ class MatchingEngine {
           } else if (oppositeOrderAbsQuantity === matchingQuantity) { // taker order quantity is not sufficient. maker order will split
             const splitOrder = this.splitOrderByQuantity(remainingOrder, matchingQuantity);
             matches.push({ maker: oppositeOrder, taker: splitOrder.target });
-            remainingOrder = splitOrder.remaining as orders.StampedOwnOrder;
+            remainingOrder = splitOrder.remaining as StampedOwnOrder;
           } else {
             assert(false, 'matchingQuantity should not be lower than both orders quantity values');
           }
@@ -125,17 +129,17 @@ class MatchingEngine {
     };
   }
 
-  public addPeerOrder = (order: orders.StampedPeerOrder): void => {
+  public addPeerOrder = (order: StampedPeerOrder): void => {
     (order.quantity > 0
       ? this.priorityQueues.buyOrders
       : this.priorityQueues.sellOrders
     ).add(order);
   }
 
-  public matchOrAddOwnOrder = (order: orders.StampedOwnOrder, discardRemaining: boolean): matchingEngine.MatchingResult => {
+  public matchOrAddOwnOrder = (order: StampedOwnOrder, discardRemaining: boolean): matchingEngine.MatchingResult => {
     const isBuyOrder = order.quantity > 0;
-    let matchAgainst: PriorityQueue | null = null;
-    let addTo: PriorityQueue | null = null;
+    let matchAgainst: PriorityQueue<StampedOrder> | undefined ;
+    let addTo: PriorityQueue<StampedOrder> | undefined;
 
     if (isBuyOrder) {
       matchAgainst = this.priorityQueues.sellOrders;
@@ -153,12 +157,12 @@ class MatchingEngine {
     return matchingResult;
   }
 
-  public removeOwnOrder = (orderId: string): orders.StampedOwnOrder | null => {
-    return this.removeOrder(orderId) as orders.StampedOwnOrder;
+  public removeOwnOrder = (orderId: string): StampedOwnOrder | undefined => {
+    return this.removeOrder(orderId) as StampedOwnOrder | undefined;
   }
 
-  public removePeerOrder = (orderId: string): orders.StampedPeerOrder | null => {
-    return this.removeOrder(orderId) as orders.StampedPeerOrder;
+  public removePeerOrder = (orderId: string): StampedPeerOrder | undefined => {
+    return this.removeOrder(orderId) as StampedPeerOrder | undefined;
   }
 
   public removePeerOrders = (hostId: number): StampedPeerOrder[] => {
@@ -176,7 +180,7 @@ class MatchingEngine {
     return this.priorityQueues.buyOrders.isEmpty() && this.priorityQueues.sellOrders.isEmpty();
   }
 
-  private removeOrder = (orderId: string): orders.StampedOrder | null => {
+  private removeOrder = (orderId: string): StampedOrder | undefined => {
     return this.priorityQueues.buyOrders.removeOne(order => order.id === orderId) ||
       this.priorityQueues.sellOrders.removeOne(order => order.id === orderId);
   }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -197,7 +197,7 @@ class OrderBook extends EventEmitter {
   private removePeerOrders = async (peer: Peer): Promise<void> => {
     if (peer.hostId) {
       this.pairs.forEach((pair) => {
-        this.matchingEngines[pair.id].removePeerOrders(order => order === peer.hostId!);
+        this.matchingEngines[pair.id].removePeerOrders(peer.hostId!);
       });
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,7 +2398,7 @@
       }
     },
     "fastpriorityqueue": {
-      "version": "git://github.com/ExchangeUnion/FastPriorityQueue.js.git#4cf06737d322d887a573b451dc3a86154ea51f9a",
+      "version": "git://github.com/ExchangeUnion/FastPriorityQueue.js.git#6c95bf27401bac8abd60c6a2789dac9f051af804",
       "from": "git://github.com/ExchangeUnion/FastPriorityQueue.js.git#master"
     },
     "fecha": {
@@ -2632,7 +2632,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
@@ -2643,7 +2643,7 @@
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
@@ -2673,22 +2673,22 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
@@ -2709,7 +2709,7 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
@@ -2730,13 +2730,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -2752,7 +2752,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
@@ -2766,7 +2766,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
@@ -2790,7 +2790,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -2800,7 +2800,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
@@ -2811,7 +2811,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -2819,13 +2819,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -2833,7 +2833,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
@@ -2856,7 +2856,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -2864,7 +2864,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
@@ -2905,7 +2905,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -2943,18 +2943,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -2962,13 +2962,13 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
@@ -2984,7 +2984,7 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
@@ -3008,7 +3008,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -3063,19 +3063,19 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -3094,7 +3094,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3102,7 +3102,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
@@ -3123,13 +3123,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
@@ -3138,7 +3138,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
@@ -3520,7 +3520,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -3534,7 +3534,7 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "cliui": {
@@ -3577,7 +3577,7 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
         },
         "delegates": {
@@ -3592,7 +3592,7 @@
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -3638,7 +3638,7 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -3646,7 +3646,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
@@ -3694,12 +3694,12 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
           "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -3708,7 +3708,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "requires": {
             "minipass": "^2.2.1"
@@ -3724,7 +3724,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
@@ -3736,7 +3736,7 @@
         },
         "needle": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
           "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
           "requires": {
             "debug": "^2.1.2",
@@ -3746,7 +3746,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "requires": {
             "detect-libc": "^1.0.2",
@@ -3772,12 +3772,12 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -3833,7 +3833,7 @@
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
@@ -3847,7 +3847,7 @@
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "protobufjs": {
@@ -3863,7 +3863,7 @@
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "requires": {
             "deep-extend": "^0.5.1",
@@ -3874,7 +3874,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3896,17 +3896,17 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
@@ -3936,7 +3936,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -3957,7 +3957,7 @@
         },
         "tar": {
           "version": "4.4.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.3.tgz",
           "integrity": "sha512-LBw+tcY+/iCCTvF4i3SjqKWIgixSs/dB+Elg3BaY0MXh03D9jWclYskg3BiOkgg414NqpFI3nRgr2Qnw5jJs7Q==",
           "requires": {
             "chownr": "^1.0.1",
@@ -3989,7 +3989,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         },
         "yargs": {

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -185,7 +185,9 @@ describe('MatchingEngine.match', () => {
     matches.forEach((match) => {
       expect(match.maker.quantity).to.equal(-5);
     });
-    expect(engine.priorityQueues.sellOrders.peek().quantity).to.equal(-1);
+    const peekResult = engine.priorityQueues.sellOrders.peek();
+    expect(peekResult).to.not.be.undefined;
+    expect(peekResult!.quantity).to.equal(-1);
   });
 });
 

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -214,14 +214,13 @@ describe('MatchingEngine.removePeerOrders', () => {
     const secondHostId = 2;
 
     expect(engine.isEmpty()).to.be.true;
-    expect(engine.removePeerOrders(() => true)).to.be.empty;
 
     const firstHostOrders = [createPeerOrder(5, -5, ms(), firstHostId), createPeerOrder(5, -5, ms(), firstHostId)];
     engine.addPeerOrder(firstHostOrders[0]);
     engine.addPeerOrder(firstHostOrders[1]);
     engine.addPeerOrder(createPeerOrder(5, -5, ms(), secondHostId));
 
-    const removedOrders = engine.removePeerOrders(order => order.hostId === firstHostId);
+    const removedOrders = engine.removePeerOrders(firstHostId);
     expect(JSON.stringify(removedOrders)).to.be.equals(JSON.stringify(firstHostOrders));
 
     const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(5, 15), false);

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -200,7 +200,7 @@ describe('MatchingEngine.removeOwnOrder', () => {
     expect(matchingResult.matches).to.be.empty;
     expect(engine.isEmpty()).to.be.false;
 
-    expect(engine.removeOwnOrder(uuidv1())).to.be.null;
+    expect(engine.removeOwnOrder(uuidv1())).to.be.undefined;
     expect(engine.isEmpty()).to.be.false;
 
     const removedOrder = engine.removeOwnOrder(matchingResult.remainingOrder.id);


### PR DESCRIPTION
I created a typed interface for our priority queues in the MatchingEngine.ts class, and in the process detected and fixed a bug with the way peer orders were previously being removed.