### PR TITLE
placeOrder gRPC error handling

### DIFF
--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -20,7 +20,7 @@ interface grpcResponse {
  */
 export const callback = (error: Error | null, response: grpcResponse) => {
   if (error) {
-    console.error(error);
+    console.error(`${error.name}: ${error.message}`);
   } else {
     console.log(JSON.stringify(response.toObject(), null, 2));
   }

--- a/lib/constants/errorCodesPrefix.ts
+++ b/lib/constants/errorCodesPrefix.ts
@@ -4,4 +4,5 @@ export default {
   ORDERBOOK: '3',
   LND: '4',
   RAIDEN: '5',
+  SERVICE: '6',
 };

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -1,4 +1,4 @@
-import grpc from 'grpc';
+import grpc, { status, ServiceError } from 'grpc';
 import Logger from '../Logger';
 import Service from '../service/Service';
 import { isObject } from '../utils/utils';
@@ -8,6 +8,8 @@ import { GetInfoResponse } from '../proto/lndrpc_pb';
 import { Orders } from 'lib/orderbook/OrderBook';
 import { MatchingResult } from '../types/matchingEngine';
 import { OwnOrder } from '../types/orders';
+import { default as orderErrors, errorCodes as orderErrorCodes } from '../orderbook/errors';
+import { default as serviceErrors, errorCodes as serviceErrorCodes } from '../service/errors';
 
 function serializeDateProperties(response) {
   Object.keys(response).forEach((key) => {
@@ -36,8 +38,20 @@ class GrpcService {
       const response = serializeDateProperties(rawResponse);
       callback(null, response);
     } catch (err) {
+      // if we recognize this error, return a proper gRPC ServiceError with a descriptive and appropriate code
+      let grpcError: ServiceError | undefined;
+      switch (err.code) {
+        case serviceErrorCodes.INVALID_ARGUMENT:
+          grpcError = { ...err, code: status.INVALID_ARGUMENT };
+          break;
+        case orderErrorCodes.INVALID_PAIR_ID:
+          grpcError = { ...err, code: status.NOT_FOUND };
+          break;
+      }
       this.logger.error(err);
-      callback(err, null);
+
+      // return grpcError if we've created one, otherwise pass along the caught error as UNKNOWN
+      callback(grpcError ? grpcError : err, null);
     }
   }
 

--- a/lib/lndclient/errors.ts
+++ b/lib/lndclient/errors.ts
@@ -1,11 +1,16 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
 
 const codesPrefix = errorCodesPrefix.LND;
-const errors: any = {};
-
-errors.LND_IS_DISABLED = {
-  message: 'lnd is disabled',
-  code: codesPrefix.concat('1'),
+const errorCodes = {
+  LND_IS_DISABLED: codesPrefix.concat('.1'),
 };
 
+const errors = {
+  LND_IS_DISABLED: {
+    message: 'lnd is disabled',
+    code: errorCodes.LND_IS_DISABLED,
+  },
+};
+
+export { errorCodes };
 export default errors;

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -7,11 +7,11 @@ const errorCodes = {
 };
 
 const errors = {
-  INVALID_PAIR_ID: pairId => ({
+  INVALID_PAIR_ID: (pairId: string) => ({
     message: `invalid pairId: ${pairId}`,
     code: errorCodes.INVALID_PAIR_ID,
   }),
-  DUPLICATED_ORDER: localId => ({
+  DUPLICATED_ORDER: (localId: string) => ({
     message: `duplicated localId: ${localId}`,
     code: codesPrefix.concat('.2'),
   }),

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -1,16 +1,21 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
 
 const codesPrefix = errorCodesPrefix.ORDERBOOK;
-const errors: any = {};
+const errorCodes = {
+  INVALID_PAIR_ID: codesPrefix.concat('.1'),
+  DUPLICATED_ORDER: codesPrefix.concat('.2'),
+};
 
-errors.INVALID_PAIR_ID = pairId => ({
-  message: `invalid pairId: ${pairId}`,
-  code: codesPrefix.concat('1'),
-});
+const errors = {
+  INVALID_PAIR_ID: pairId => ({
+    message: `invalid pairId: ${pairId}`,
+    code: errorCodes.INVALID_PAIR_ID,
+  }),
+  DUPLICATED_ORDER: localId => ({
+    message: `duplicated localId: ${localId}`,
+    code: codesPrefix.concat('.2'),
+  }),
+};
 
-errors.DUPLICATED_ORDER = localId => ({
-  message: `duplicated localId: ${localId}`,
-  code: codesPrefix.concat('2'),
-});
-
+export { errorCodes };
 export default errors;

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -1,8 +1,21 @@
-class P2PError {
-  constructor(public message: string) {}
-}
+import errorCodesPrefix from '../constants/errorCodesPrefix';
 
-export default {
-  ADDRESS_ALREADY_CONNECTED: (address: string) => new P2PError(`Address (${address}) already connected`),
-  NOT_CONNECTED: (address: string) => new P2PError(`Address (${address}) is not connected`),
+const codesPrefix = errorCodesPrefix.P2P;
+const errorCodes = {
+  ADDRESS_ALREADY_CONNECTED: codesPrefix.concat('.1'),
+  NOT_CONNECTED: codesPrefix.concat('.2'),
 };
+
+const errors = {
+  ADDRESS_ALREADY_CONNECTED: (address: string) => ({
+    message: `Address (${address}) already connected`,
+    code: errorCodes.ADDRESS_ALREADY_CONNECTED,
+  }),
+  NOT_CONNECTED: (address: string) => ({
+    message: `Address (${address}) is not connected`,
+    code: errorCodes.NOT_CONNECTED,
+  }),
+};
+
+export { errorCodes };
+export default errors;

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -2,7 +2,7 @@ import http from 'http';
 
 import Logger from '../Logger';
 import BaseClient, { ClientStatus } from '../BaseClient';
-import * as errors from './errors';
+import errors from './errors';
 
 /**
  * A utility function to parse the payload from an http response.

--- a/lib/raidenclient/errors.ts
+++ b/lib/raidenclient/errors.ts
@@ -1,33 +1,41 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
 
 const codesPrefix = errorCodesPrefix.RAIDEN;
-
-export const RAIDEN_IS_DISABLED = {
-  message: 'raiden is disabled',
-  code: codesPrefix.concat('1'),
+const errorCodes = {
+  RAIDEN_IS_DISABLED: codesPrefix.concat('.1'),
+  INSUFFICIENT_BALANCE: codesPrefix.concat('.2'),
+  TIMEOUT: codesPrefix.concat('.3'),
+  INVALID: codesPrefix.concat('.4'),
+  SERVER_ERROR: codesPrefix.concat('.5'),
+  UNEXPECTED: codesPrefix.concat('.6'),
 };
 
-export const INSUFFICIENT_BALANCE = {
-  message: 'insufficient balance to perform request',
-  code: codesPrefix.concat('2'),
+const errors = {
+  RAIDEN_IS_DISABLED: {
+    message: 'raiden is disabled',
+    code: errorCodes.RAIDEN_IS_DISABLED,
+  },
+  INSUFFICIENT_BALANCE: {
+    message: 'insufficient balance to perform request',
+    code: errorCodes.INSUFFICIENT_BALANCE,
+  },
+  TIMEOUT: {
+    message: 'request timed out',
+    code: errorCodes.TIMEOUT,
+  },
+  INVALID: {
+    message: 'request is conflicting or otherwise invalid',
+    code: errorCodes.INVALID,
+  },
+  SERVER_ERROR: {
+    message: 'raiden server error',
+    code: errorCodes.SERVER_ERROR,
+  },
+  UNEXPECTED: {
+    message: 'unexpected error during raiden request',
+    code: errorCodes.UNEXPECTED,
+  },
 };
 
-export const TIMEOUT = {
-  message: 'request timed out',
-  code: codesPrefix.concat('3'),
-};
-
-export const INVALID = {
-  message: 'request is conflicting or otherwise invalid',
-  code: codesPrefix.concat('4'),
-};
-
-export const SERVER_ERROR = {
-  message: 'raiden server error',
-  code: codesPrefix.concat('5'),
-};
-
-export const UNEXPECTED = {
-  message: 'unexpected error during raiden request',
-  code: codesPrefix.concat('6'),
-};
+export { errorCodes };
+export default errors;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Logger from '../Logger';
 import Pool from '../p2p/Pool';
 import OrderBook from '../orderbook/OrderBook';
@@ -7,8 +6,8 @@ import RaidenClient, { TokenSwapPayload } from '../raidenclient/RaidenClient';
 import { OwnOrder } from '../types/orders';
 import Config from '../Config';
 import { EventEmitter } from 'events';
-import { orders } from '../types';
 import SocketAddress from '../p2p/SocketAddress';
+import errors from './errors';
 
 const packageJson = require('../../package.json');
 
@@ -24,6 +23,12 @@ export type ServiceComponents = {
   /** The function to be called to shutdown the parent process */
   shutdown: Function;
 };
+
+function checkArgument(expectedCondition: boolean, message: string) {
+  if (!expectedCondition) {
+    throw errors.INVALID_ARGUMENT(message);
+  }
+}
 
 /** Class containing the available RPC methods for XUD */
 class Service extends EventEmitter {
@@ -149,13 +154,10 @@ class Service extends EventEmitter {
    * Add an order to the order book.
    */
   public placeOrder = async (order: OwnOrder) => {
-    assert(order.price >= 0, 'price cannot be negative');
-    assert(order.quantity !== 0, 'quantity must not equal 0');
-    if (order.price === 0) {
-      return this.orderBook.addMarketOrder(order);
-    } else {
-      return this.orderBook.addLimitOrder(order);
-    }
+    checkArgument(order.price >= 0, 'price cannot be negative');
+    checkArgument(order.quantity !== 0, 'quantity must not equal 0');
+
+    return order.price > 0 ? this.orderBook.addLimitOrder(order) : this.orderBook.addMarketOrder(order);
   }
 
   /*

--- a/lib/service/errors.ts
+++ b/lib/service/errors.ts
@@ -1,0 +1,16 @@
+import errorCodesPrefix from '../constants/errorCodesPrefix';
+
+const codesPrefix = errorCodesPrefix.SERVICE;
+const errorCodes = {
+  INVALID_ARGUMENT: codesPrefix.concat('.1'),
+};
+
+const errors = {
+  INVALID_ARGUMENT: (message: string) => ({
+    message,
+    code: errorCodes.INVALID_ARGUMENT,
+  }),
+};
+
+export { errorCodes };
+export default errors;


### PR DESCRIPTION
Fixes #229. Partially addresses #116. This gracefully handles invalid `placeOrder` requests such that they don't crash the main xud process. I changed `xucli` to not print the stack trace, since I don't think it's helpful for developers/testers and it's even less helpful for end users. I also tried to standardize the `errors` classes to not use the `any` type, and I added a `.` separator in the `code` after the prefix.