### PR TITLE
Added Auto-Restart section to Readme #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ Options:
   --rpc.host, -h  The RPC service hostname       [string] [default: "localhost"]
 ```
 
+## Auto Restart Support
+
+Auto restart on every file change under `dist` folder with `nodemon`.
+
+```
+nodemon --watch dist -e js bin/xud
+```
+
+With args;
+
+```
+nodemon --watch dist -e js bin/xud --lnd.disable=true
+```
+
 ## Database Initialization
 
 To initialize the database with default testing data, run the following command:


### PR DESCRIPTION
fixes #46 

- Added to the readme,

@kilrau But couldn't add for typedoc, since typedoc is an auto generated documentation from codes, where should I add this information in the code since we didn't do any change on code ?