### PR TITLE
Member-ordering lint rule

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -1,3 +1,4 @@
+/* tslint:disable member-ordering */
 import fs from 'fs';
 import path from 'path';
 import winston from 'winston';
@@ -33,13 +34,7 @@ const contextFileMap = {
 };
 
 class Logger {
-  private level: string;
-  private logDir: string;
-  private context: Context;
-  private logger: any;
-
   private static defaultLogDir = 'logs';
-
   private static defaultLevel = process.env.NODE_ENV === 'production'
   ? Level.INFO
   : Level.DEBUG;
@@ -51,6 +46,11 @@ class Logger {
   public static orderbook = new Logger({ context: Context.ORDERBOOK });
   public static lnd = new Logger({ context: Context.LND });
   public static raiden = new Logger({ context: Context.RAIDEN });
+
+  private level: string;
+  private logDir: string;
+  private context: Context;
+  private logger: any;
 
   constructor({ level, logDir, context }: { level?: string, logDir?: string, context: Context}) {
     this.level = level || Logger.defaultLevel;

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -15,6 +15,7 @@ bootstrap();
 
 /** Class representing a complete Exchange Union daemon. */
 class Xud {
+  public service!: Service;
   private logger: Logger = Logger.global;
   private config: Config;
   private db!: DB;
@@ -25,7 +26,6 @@ class Xud {
   private rpcServer!: GrpcServer;
   private nodeKey!: NodeKey;
   private grpcAPIProxy?: GrpcWebProxyServer;
-  public service!: Service;
 
   /**
    * Create an Exchange Union daemon.

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -45,24 +45,7 @@ interface Peer {
 
 /** Represents a remote XU peer */
 class Peer extends EventEmitter {
-
-  /**
-   * Interval to check required responses from peer.
-   */
-  private static STALL_INTERVAL: number = 5000;
-
-  /**
-   * Interval for pinging peers.
-   */
-  private static PING_INTERVAL = 30000;
-
-  /**
-   * Response timeout for response packets.
-   */
-  private static RESPONSE_TIMEOUT = 10000;
-
   // TODO: properties documentation
-
   public socketAddress!: SocketAddress;
   public direction!: ConnectionDirection;
   public connected: boolean = false;
@@ -83,6 +66,12 @@ class Peer extends EventEmitter {
   private handshakeState?: HandshakeState;
   /** A counter for packets sent to be used for assigning unique packet ids. */
   private packetCount = 0;
+  /** Interval to check required responses from peer. */
+  private static STALL_INTERVAL: number = 5000;
+  /** Interval for pinging peers. */
+  private static PING_INTERVAL = 30000;
+  /** Response timeout for response packets. */
+  private static RESPONSE_TIMEOUT = 10000;
 
   get id(): string {
     assert(this.socketAddress);

--- a/tslint.json
+++ b/tslint.json
@@ -17,7 +17,25 @@
         "variable-declaration": "nospace"
       }
     ],
-    "member-access": true
+    "member-access": true,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "public-instance-field",
+          "public-static-field",
+          "protected-instance-field",
+          "protected-static-field",
+          "private-instance-field",
+          "private-static-field",
+          "public-constructor",
+          "protected-constructor",
+          "private-constructor",
+          "static-method",
+          "instance-method"
+        ]
+      }
+    ]
   },
   "linterOptions": {
     "exclude": [


### PR DESCRIPTION
This adds a new lint rule enforcing a style of declaring public, protected, and private fields in each class in that order. It also requires that methods come after the constructor and that static methods come before instance methods.

This was suggested by @michael1011 and I think it's a good idea, plus conforming to these rules only required a handful of changes meaning we were already more or less following this style. I think it'd be good to enforce it as a rule.