### PR TITLE
Fix socket error & close handling

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -196,7 +196,7 @@ class Service extends EventEmitter {
    * Disconnect from a connected peer XU node on a given host and port.
    */
   public disconnect = async ({ host, port }: { host: string, port: number}) => {
-    await this.pool.disconnectPeer(host, port);
+    await this.pool.closePeer(host, port);
     return 'success';
   }
 


### PR DESCRIPTION
Fixes #253.

This changes the `socket` property on the `Peer` class to be nullable and adds null checks before we attempt to write to the socket. It also removes a duplicate socket error handler, and it removes the `destroy` call from the other `error` event handler. As per the Node.js Net module documentation. the `close` event is called right after the `error` event, and we already call `destroy` within the `close` handler. Lastly, this renames the `connect` and `disconnect` methods in Pool.ts to `open` and `close` to match the corresponding method names in Peer.ts.

I have run some limited tests with this and verified that connecting works. @kilrau, can you pull down this branch and see if it makes the crash you were seeing go away?