### PR TITLE
Replace hostId with peerId on orders

### DIFF
--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -165,9 +165,9 @@ class MatchingEngine {
     return this.removeOrder(orderId) as StampedPeerOrder | undefined;
   }
 
-  public removePeerOrders = (hostId: number): StampedPeerOrder[] => {
+  public removePeerOrders = (peerId: string): StampedPeerOrder[] => {
     const callback = (order: StampedOrder) => {
-      return (order as StampedPeerOrder).hostId === hostId;
+      return (order as StampedPeerOrder).peerId === peerId;
     };
 
     return [

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -205,11 +205,9 @@ class OrderBook extends EventEmitter {
   }
 
   private removePeerOrders = async (peer: Peer): Promise<void> => {
-    if (peer.hostId) {
-      this.pairs.forEach((pair) => {
-        this.matchingEngines[pair.id].removePeerOrders(peer.hostId!);
-      });
-    }
+    this.pairs.forEach((pair) => {
+      this.matchingEngines[pair.id].removePeerOrders(peer.id);
+    });
   }
 
   private updateOrderQuantity = (type: OrdersMap, order: orders.StampedOrder, decreasedQuantity: number) => {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -161,7 +161,7 @@ class Pool extends EventEmitter {
     switch (packet.type) {
       case PacketType.ORDER: {
         const order = (packet as OrderPacket).body!;
-        this.emit('packet.order', { ...order, hostId: peer.hostId } as PeerOrder);
+        this.emit('packet.order', { ...order, peerId: peer.id } as PeerOrder);
         break;
       }
       case PacketType.ORDER_INVALIDATION: {
@@ -175,7 +175,7 @@ class Pool extends EventEmitter {
       case PacketType.ORDERS: {
         const orders = (packet as OrdersPacket).body!;
         orders.forEach((order) => {
-          this.emit('packet.order', { ...order, hostId: peer.hostId } as PeerOrder);
+          this.emit('packet.order', { ...order, peerId: peer.id } as PeerOrder);
         });
         break;
       }

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -487,11 +487,7 @@
         "peer_id": {
           "type": "integer",
           "format": "int32",
-          "title": "The id of the peer that created this order"
-        },
-        "host_id": {
-          "type": "string",
-          "title": "The id of the host that created this order"
+          "title": "The id of the peer - consisting of a [host]:[port] socket address - that created this order"
         },
         "id": {
           "type": "string",
@@ -499,7 +495,7 @@
         },
         "local_id": {
           "type": "string",
-          "title": "The local ID for this oder"
+          "title": "The local ID for this order"
         },
         "created_at": {
           "type": "string",

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -453,9 +453,6 @@ export class Order extends jspb.Message {
   getPeerId(): number;
   setPeerId(value: number): void;
 
-  getHostId(): string;
-  setHostId(value: string): void;
-
   getId(): string;
   setId(value: string): void;
 
@@ -484,7 +481,6 @@ export namespace Order {
     quantity: number,
     pairId: string,
     peerId: number,
-    hostId: string,
     id: string,
     localId: string,
     createdAt: number,

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -3188,7 +3188,6 @@ proto.xudrpc.Order.toObject = function(includeInstance, msg) {
     quantity: +jspb.Message.getFieldWithDefault(msg, 2, 0.0),
     pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
     peerId: jspb.Message.getFieldWithDefault(msg, 4, 0),
-    hostId: jspb.Message.getFieldWithDefault(msg, 5, ""),
     id: jspb.Message.getFieldWithDefault(msg, 6, ""),
     localId: jspb.Message.getFieldWithDefault(msg, 7, ""),
     createdAt: jspb.Message.getFieldWithDefault(msg, 8, 0),
@@ -3244,10 +3243,6 @@ proto.xudrpc.Order.deserializeBinaryFromReader = function(msg, reader) {
     case 4:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setPeerId(value);
-      break;
-    case 5:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setHostId(value);
       break;
     case 6:
       var value = /** @type {string} */ (reader.readString());
@@ -3319,13 +3314,6 @@ proto.xudrpc.Order.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0) {
     writer.writeInt32(
       4,
-      f
-    );
-  }
-  f = message.getHostId();
-  if (f.length > 0) {
-    writer.writeString(
-      5,
       f
     );
   }
@@ -3417,21 +3405,6 @@ proto.xudrpc.Order.prototype.getPeerId = function() {
 /** @param {number} value */
 proto.xudrpc.Order.prototype.setPeerId = function(value) {
   jspb.Message.setField(this, 4, value);
-};
-
-
-/**
- * optional string host_id = 5;
- * @return {string}
- */
-proto.xudrpc.Order.prototype.getHostId = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
-};
-
-
-/** @param {string} value */
-proto.xudrpc.Order.prototype.setHostId = function(value) {
-  jspb.Message.setField(this, 5, value);
 };
 
 

--- a/lib/types/db.ts
+++ b/lib/types/db.ts
@@ -42,26 +42,6 @@ export type BannedHostAttributes = BannedHostFactory;
 
 export type BannedHostInstance = HostAttributes & Sequelize.Instance<HostAttributes>;
 
-export type OrderFactory = {
-  id: string;
-  pairId: string;
-  hostId?: number;
-  quantity: number;
-  price: number;
-  createdAt?: Date;
-};
-
-export type OrderAttributes = {
-  id: string;
-  pairId: string;
-  hostId: number;
-  quantity: number | Sequelize.literal;
-  price: number;
-  createdAt: Date;
-};
-
-export type OrderInstance = OrderAttributes & Sequelize.Instance<OrderAttributes>;
-
 export type PairFactory = {
   baseCurrency: string;
   quoteCurrency: string;

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -14,7 +14,7 @@ export type OwnOrder = OwnMarketOrder & {
 export type PeerOrder = MarketOrder & {
   price: number;
   id: string;
-  hostId: number;
+  peerId: string;
   invoice: string;
 };
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -185,13 +185,11 @@ message Order {
   double quantity = 2 [json_name = "quantity"];
   // The trading pair that this order is for
   string pair_id = 3 [json_name = "pair_id"];
-  // The id of the peer that created this order
+  // The id of the peer - consisting of a [host]:[port] socket address - that created this order
   int32 peer_id = 4 [json_name = "peer_id"];
-  // The id of the host that created this order
-  string host_id = 5 [json_name = "host_id"];
   // A UUID for this order
   string id = 6 [json_name = "id"];
-  // The local ID for this oder
+  // The local ID for this order
   string local_id = 7 [json_name = "local_id"];
   // The epoch time when this order was created
   int64 created_at = 8 [json_name = "created_at"];

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -16,11 +16,11 @@ const createOwnOrder = (price: number, quantity: number, createdAt = ms()): orde
   pairId: PAIR_ID,
 });
 
-const createPeerOrder = (price: number, quantity: number, createdAt = ms(), hostId = 1): orders.StampedPeerOrder => ({
+const createPeerOrder = (price: number, quantity: number, createdAt = ms(), peerId = '127.0.0.1:8885'): orders.StampedPeerOrder => ({
   quantity,
   price,
   createdAt,
-  hostId,
+  peerId,
   id: uuidv1(),
   pairId: PAIR_ID,
   invoice: '',
@@ -212,8 +212,8 @@ describe('MatchingEngine.removeOwnOrder', () => {
 describe('MatchingEngine.removePeerOrders', () => {
   it('should add a new peerOrders and then remove some of them', () => {
     const engine = new MatchingEngine(PAIR_ID);
-    const firstHostId = 1;
-    const secondHostId = 2;
+    const firstHostId = '127.0.0.1:8885';
+    const secondHostId = '127.0.0.1:9885';
 
     expect(engine.isEmpty()).to.be.true;
 


### PR DESCRIPTION
This replaces the `hostId` identifier on orders with `peerId`. Since orders are no longer being persisted between sessions, and since all orders for a peer are removed once that peer is disconnected, we no longer need to associate orders with a persistent identifier like `hostId`. This will make it easier to associate matched, swapped, or invalidated orders with an actual live peer.

This functionality is a prerequisite for #106 and #236.