### PR TITLE
Handle duplicate placeorder localId

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -47,6 +47,9 @@ class GrpcService {
         case orderErrorCodes.INVALID_PAIR_ID:
           grpcError = { ...err, code: status.NOT_FOUND };
           break;
+        case orderErrorCodes.DUPLICATE_ORDER:
+          grpcError = { ...err, code: status.ALREADY_EXISTS };
+          break;
       }
       this.logger.error(err);
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -163,7 +163,7 @@ class OrderBook extends EventEmitter {
 
   private addOwnOrder = (order: orders.OwnOrder, discardRemaining: boolean = false): matchingEngine.MatchingResult => {
     if (this.localIdMap[order.localId]) {
-      throw errors.DUPLICATED_ORDER(order.localId);
+      throw errors.DUPLICATE_ORDER(order.localId);
     }
 
     const matchingEngine = this.matchingEngines[order.pairId];

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -3,7 +3,7 @@ import errorCodesPrefix from '../constants/errorCodesPrefix';
 const codesPrefix = errorCodesPrefix.ORDERBOOK;
 const errorCodes = {
   INVALID_PAIR_ID: codesPrefix.concat('.1'),
-  DUPLICATED_ORDER: codesPrefix.concat('.2'),
+  DUPLICATE_ORDER: codesPrefix.concat('.2'),
 };
 
 const errors = {
@@ -11,8 +11,8 @@ const errors = {
     message: `invalid pairId: ${pairId}`,
     code: errorCodes.INVALID_PAIR_ID,
   }),
-  DUPLICATED_ORDER: (localId: string) => ({
-    message: `duplicated localId: ${localId}`,
+  DUPLICATE_ORDER: (localId: string) => ({
+    message: `order with localId ${localId} already exists`,
     code: codesPrefix.concat('.2'),
   }),
 };


### PR DESCRIPTION
Fixes #257. @kilrau give this a quick test if you can, it's a minor change so we can merge without much review. I did also rename `DUPLICATED_ORDER` to `DUPLICATE_ORDER` since "duplicate" and "duplicated" have [slightly different meanings](https://english.stackexchange.com/questions/67463/duplicate-data-or-duplicated-data) and I think the former is more appropriate here.