### PR TITLE
Fix bug causing host uniqueness violation

### DIFF
--- a/lib/db/models/Host.ts
+++ b/lib/db/models/Host.ts
@@ -6,7 +6,7 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
     address: { type: DataTypes.STRING(39), allowNull: false },
     port: { type: DataTypes.INTEGER, allowNull: false },
-    pubKey: { type: DataTypes.STRING, allowNull: true, unique: true },
+    pubKey: { type: DataTypes.STRING, allowNull: true, unique: false },
   };
 
   const indexes: Sequelize.DefineIndexesOptions[] = [{
@@ -19,7 +19,7 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
     tableName: 'hosts',
   };
 
-  const Peer = sequelize.define<db.HostInstance, db.HostAttributes>('Host', attributes, options);
+  const Host = sequelize.define<db.HostInstance, db.HostAttributes>('Host', attributes, options);
 
-  return Peer;
+  return Host;
 };

--- a/lib/p2p/HostList.ts
+++ b/lib/p2p/HostList.ts
@@ -2,6 +2,8 @@ import P2PRepository from './P2PRepository';
 import SocketAddress from './SocketAddress';
 import Host from './Host';
 import Peer from './Peer';
+import assert from 'assert';
+import { HostFactory } from '../types/db';
 
 /** Represents a list of hosts for managing network peers activity */
 class HostList {
@@ -24,11 +26,32 @@ class HostList {
   }
 
   /**
-   * Get a host by socket address, or create the host if none exists.
+   * Return an array of hosts that haven't been banned.
    */
-  public getOrCreateHost = async (socketAddress: SocketAddress): Promise<Host> => {
+  public toHostFactoryArray = (): HostFactory[] => {
+    const hostValues = Object.values(this.hosts);
+    const hostFactories: HostFactory[] = Array.from({ length: hostValues.length });
+    for (let i = 0; i < hostValues.length; i += 1) {
+      const hostValue = hostValues[i];
+      hostFactories[i] = {
+        address: hostValue.socketAddress.address,
+        port: hostValue.socketAddress.port,
+      };
+    }
+    return hostFactories;
+  }
+
+  /**
+   * Get a host by a peer's socket address, or create the host if none exists.
+   */
+  public getOrCreateHost = async (peer: Peer): Promise<Host> => {
+    const { socketAddress } = peer;
+    assert(socketAddress instanceof SocketAddress);
     const host = this.hosts[socketAddress.toString()];
-    return host || this.createHost(socketAddress);
+    return host || this.createHost({
+      address: socketAddress.address,
+      port: socketAddress.port,
+    });
   }
 
   public ban = async (peer: Peer): Promise<void> => {
@@ -55,8 +78,8 @@ class HostList {
     this.bannedHosts = new Set<string>(bannedHosts.map(bannedHost => bannedHost.address));
   }
 
-  private createHost = async (socketAddress: SocketAddress): Promise<Host> => {
-    const dbHost = await this.repository.addHost(socketAddress);
+  private createHost = async (hostFactory: HostFactory): Promise<Host> => {
+    const dbHost = await this.repository.addHost(hostFactory);
     const host = new Host(dbHost);
     this.hosts[host.socketAddress.toString()] = host;
     return host;

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -9,6 +9,7 @@ import Logger from '../Logger';
 import { ms } from '../utils/utils';
 import { OutgoingOrder } from '../types/orders';
 import { Packet, PacketDirection, PacketType } from './packets';
+import { HostFactory } from '../types/db';
 
 enum ConnectionDirection {
   INBOUND,
@@ -190,7 +191,7 @@ class Peer extends EventEmitter {
     this.sendPacket(packet);
   }
 
-  public sendHosts = (hosts: Host[], reqId: string): void => {
+  public sendHosts = (hosts: HostFactory[], reqId: string): void => {
     const packet = new packets.HostsPacket(hosts, reqId);
     this.sendPacket(packet);
   }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -180,14 +180,14 @@ class Pool extends EventEmitter {
         break;
       }
       case PacketType.GET_HOSTS: {
-        peer.sendHosts(this.hosts.toArray(), packet.header.id);
+        peer.sendHosts(this.hosts.toHostFactoryArray(), packet.header.id);
         break;
       }
       case PacketType.HOSTS: {
         const hosts = (packet as HostsPacket).body!;
         hosts.forEach(async (host) => {
           try {
-            await this.addOutbound(host.socketAddress);
+            await this.addOutbound(new SocketAddress(host.address, host.port));
           } catch (err) {
             this.logger.info(err);
           }
@@ -207,11 +207,11 @@ class Pool extends EventEmitter {
 
   private setPeerHost = async (peer: Peer, listenPort?: number): Promise<void> => {
     if (peer.direction === ConnectionDirection.OUTBOUND) {
-      const host = await this.hosts.getOrCreateHost(peer.socketAddress);
+      const host = await this.hosts.getOrCreateHost(peer);
       peer.setHost(host);
     } else if (peer.direction === ConnectionDirection.INBOUND && listenPort) {
       const socketAddress = new SocketAddress(peer.socketAddress.address, listenPort);
-      const host = await this.hosts.getOrCreateHost(socketAddress);
+      const host = await this.hosts.getOrCreateHost(peer);
       peer.setHost(host);
     }
   }

--- a/lib/p2p/packets/types/HostsPacket.ts
+++ b/lib/p2p/packets/types/HostsPacket.ts
@@ -1,10 +1,8 @@
 import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
-import Host from '../../Host';
+import { HostFactory } from '../../../types/db';
 
-type HostsPacketBody = Host[];
-
-class HostsPacket extends Packet<HostsPacketBody> {
+class HostsPacket extends Packet<HostFactory[]> {
   public get type() {
     return PacketType.HOSTS;
   }


### PR DESCRIPTION
Fixes #226.

This fixes a bug that was causing xud to attempt to add existing hosts to the database. The `HOSTS` packet was serializing `Host` objects to JSON. Upon receiving this packet, xud would create JSON objects which did not inherit the function definitions of the `Host` class and, critically, of the `SocketAddress` class which was used as a unique identifier for hosts. The `toString()` method of `SocketAddress` was therefore lost and reverted to that of `Object`. `getOrCreateHost` would use the `toString` method to see if a Host exists, but then create using the actual `address` and `port` fields which would still exist on the object.

This commit changes the `HOSTS` packet to pass `HostFactory` typed objects, from which a new `SocketAddress` is constructed. `getOrCreateHost` asserts that `socketAddress` is an instance of `SocketAddress` to catch similar bugs from resurfacing.