### PR TITLE
Order invalidation implementation

### DIFF
--- a/lib/orderbook/MatchesProcessor.ts
+++ b/lib/orderbook/MatchesProcessor.ts
@@ -31,7 +31,6 @@ class MatchesProcessor {
 
   public executeSwap(_args) {
     // TODO: execute the swap procedure
-    // TODO: invalidate the maker if it is of the type ownOrder
   }
 }
 

--- a/lib/orderbook/MatchesProcessor.ts
+++ b/lib/orderbook/MatchesProcessor.ts
@@ -31,6 +31,7 @@ class MatchesProcessor {
 
   public executeSwap(_args) {
     // TODO: execute the swap procedure
+    // TODO: invalidate the maker if it is of the type ownOrder
   }
 }
 

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -161,8 +161,18 @@ class MatchingEngine {
     return this.removeOrder(orderId) as StampedOwnOrder | undefined;
   }
 
-  public removePeerOrder = (orderId: string): StampedPeerOrder | undefined => {
-    return this.removeOrder(orderId) as StampedPeerOrder | undefined;
+  public removePeerOrder = (orderId: string, decreasedQuantity?: number): StampedPeerOrder | undefined => {
+    const order = this.removeOrder(orderId) as StampedPeerOrder | undefined;
+
+    if (order && decreasedQuantity) {
+      order.quantity = order.quantity - decreasedQuantity;
+      this.addPeerOrder(order);
+
+      // Return how much was removed
+      return { ...order, quantity: decreasedQuantity };
+    }
+
+    return order;
   }
 
   public removePeerOrders = (peerId: string): StampedPeerOrder[] => {

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -11,6 +11,7 @@ import Logger from '../Logger';
 import LndClient from '../lndclient/LndClient';
 import { ms } from '../utils/utils';
 import { Models } from '../db/DB';
+import { OrderIdentifier } from '../types/orders';
 
 type OrdersMap = Map<String, Orders>;
 
@@ -37,7 +38,7 @@ class OrderBook extends EventEmitter {
 
   private logger: Logger = Logger.orderbook;
   private repository: OrderBookRepository;
-  private matchesProcessor: MatchesProcessor = new MatchesProcessor();
+  private matchesProcessor = new MatchesProcessor();
 
   private ownOrders: OrdersMap = new Map<String, Orders>();
   private peerOrders: OrdersMap = new Map<String, Orders>();
@@ -53,12 +54,7 @@ class OrderBook extends EventEmitter {
     this.repository = new OrderBookRepository(models);
     if (pool) {
       pool.on('packet.order', this.addPeerOrder);
-      pool.on('packet.orderInvalidation', (body: orders.OrderIdentifier) => {
-        // TODO: implement quantity invalidation
-        if (this.removePeerOrder(body.orderId, body.pairId)) {
-          this.emit('peerOrder.invalidation', body);
-        }
-      });
+      pool.on('packet.orderInvalidation', this.handleOrderInvalidation);
       pool.on('packet.getOrders', this.sendOrders);
       pool.on('peer.close', this.removePeerOrders);
     }
@@ -141,6 +137,12 @@ class OrderBook extends EventEmitter {
     }
   }
 
+  private handleOrderInvalidation = (body: OrderIdentifier) => {
+    if (this.removePeerOrder(body.orderId, body.pairId, body.quantity)) {
+      this.emit('peerOrder.invalidation', body);
+    }
+  }
+
   private removeOwnOrder = (pairId: string, orderId: string): boolean => {
     const matchingEngine = this.matchingEngines[pairId];
     if (!matchingEngine) {
@@ -156,18 +158,28 @@ class OrderBook extends EventEmitter {
     }
   }
 
-  private removePeerOrder = (orderId: string, pairId: string): boolean => {
+  private removePeerOrder = (orderId: string, pairId: string, decreasedQuantity?: number): boolean => {
     const matchingEngine = this.matchingEngines[pairId];
-    if (!matchingEngine) {
+    const ordersMap = this.peerOrders[pairId];
+    if (!matchingEngine || !ordersMap) {
       this.logger.warn(`Invalid pairId: ${pairId}`);
       return false;
     }
 
-    if (matchingEngine.removePeerOrder(orderId)) {
-      return this.removeOrder(this.peerOrders, orderId, pairId);
-    } else {
-      return false;
+    const order = ordersMap[orderId];
+
+    if (order) {
+      if (matchingEngine.removePeerOrder(orderId, decreasedQuantity)) {
+        if (!decreasedQuantity || decreasedQuantity === 0) {
+          return this.removeOrder(this.peerOrders, orderId, pairId);
+        } else {
+          return this.updateOrderQuantity(order, decreasedQuantity);
+        }
+      }
     }
+
+    this.logger.warn(`Invalid orderId: ${orderId}`);
+    return false;
   }
 
   private addOwnOrder = (order: orders.OwnOrder, discardRemaining: boolean = false): matchingEngine.MatchingResult => {
@@ -227,18 +239,26 @@ class OrderBook extends EventEmitter {
     });
   }
 
-  private updateOrderQuantity = (order: orders.StampedOrder, decreasedQuantity: number) => {
+  private updateOrderQuantity = (order: orders.StampedOrder, decreasedQuantity: number): boolean => {
     const isOwnOrder = orders.isOwnOrder(order);
     const orderMap = this.getOrderMap(isOwnOrder ? this.ownOrders : this.peerOrders, order);
 
-    orderMap[order.id].quantity = orderMap[order.id].quantity - decreasedQuantity;
-    if (orderMap[order.id].quantity === 0) {
+    const orderInstance = orderMap[order.id];
+
+    if (!orderInstance) {
+      return false;
+    }
+
+    orderInstance.quantity = orderInstance.quantity - decreasedQuantity;
+    if (orderInstance.quantity === 0) {
       if (isOwnOrder) {
         const { localId } = order as orders.StampedOwnOrder;
         delete this.localIdMap[localId];
       }
       delete orderMap[order.id];
     }
+
+    return true;
   }
 
   private addOrder = (type: OrdersMap, order: orders.StampedOrder) => {
@@ -312,6 +332,15 @@ class OrderBook extends EventEmitter {
 
   private handleMatch = ({ maker, taker }): void => {
     this.logger.debug(`order match: ${JSON.stringify({ maker, taker })}`);
+    if (this.pool) {
+      if (orders.isOwnOrder(maker)) {
+        this.pool.broadcastOrderInvalidation({
+          orderId: maker.id,
+          pairId: maker.pairId,
+          quantity: maker.quantity,
+        });
+      }
+    }
     this.matchesProcessor.add({ maker, taker });
   }
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -162,20 +162,18 @@ class OrderBook extends EventEmitter {
 
     const order = ordersMap[orderId];
 
-    if (order) {
-      if (matchingEngine.removePeerOrder(orderId, decreasedQuantity)) {
-        let result;
+    if (order && matchingEngine.removePeerOrder(orderId, decreasedQuantity)) {
+      let result;
 
-        if (!decreasedQuantity || decreasedQuantity === 0) {
-          result = this.removeOrder(this.peerOrders, orderId, pairId);
-        } else {
-          result = this.updateOrderQuantity(order, decreasedQuantity);
-        }
+      if (!decreasedQuantity || decreasedQuantity === 0) {
+        result = this.removeOrder(this.peerOrders, orderId, pairId);
+      } else {
+        result = this.updateOrderQuantity(order, decreasedQuantity);
+      }
 
-        if (result) {
-          this.emit('peerOrder.invalidation', { orderId, pairId, quantity: decreasedQuantity });
-          return true;
-        }
+      if (result) {
+        this.emit('peerOrder.invalidation', { orderId, pairId, quantity: decreasedQuantity });
+        return true;
       }
     }
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -129,8 +129,8 @@ class Pool extends EventEmitter {
     // TODO: send only to peers which accepts the pairId
   }
 
-  public broadcastOrderInvalidation = (orderId: string, pairId: string) => {
-    const orderInvalidationPacket = new OrderInvalidationPacket({ orderId, pairId });
+  public broadcastOrderInvalidation = (order: OrderIdentifier) => {
+    const orderInvalidationPacket = new OrderInvalidationPacket(order);
     this.peers.forEach(peer => peer.sendPacket(orderInvalidationPacket));
 
     // TODO: send only to peers which accepts the pairId

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -184,7 +184,10 @@ class Service extends EventEmitter {
     const { removed, globalId } = this.orderBook.removeOwnOrderByLocalId(pairId, orderId);
 
     if (removed) {
-      this.pool.broadcastOrderInvalidation(globalId, pairId);
+      this.pool.broadcastOrderInvalidation({
+        pairId,
+        orderId: globalId,
+      });
     }
     return { canceled: removed };
   }

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -7,7 +7,6 @@ import OrderBook from '../../lib/orderbook/OrderBook';
 import OrderBookRepository from '../../lib/orderbook/OrderBookRepository';
 import P2PRepository from '../../lib/p2p/P2PRepository';
 import { orders } from '../../lib/types';
-import { StampedOrder } from '../../lib/types/orders';
 
 describe('OrderBook', () => {
   let db: DB;
@@ -40,9 +39,9 @@ describe('OrderBook', () => {
     await orderBook.init();
   });
 
-  const getOrder = (order: orders.StampedOrder): orders.StampedOrder => {
+  const getOwnOrder = (order: orders.StampedOrder): orders.StampedOwnOrder => {
     const ownOrders = orderBook.getOwnOrders(order.pairId, 0);
-    let array: StampedOrder[];
+    let array: orders.StampedOrder[];
 
     if (order.quantity > 0) {
       array = ownOrders.buyOrders;
@@ -78,15 +77,15 @@ describe('OrderBook', () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -6, price: 55 };
     const matches = await orderBook.addLimitOrder(order);
     expect(matches.remainingOrder).to.be.null;
-    expect(getOrder(matches.matches[0].maker)).to.be.undefined;
-    expect(getOrder(matches.matches[1].maker).quantity).to.be.equal(4);
+    expect(getOwnOrder(matches.matches[0].maker)).to.be.undefined;
+    expect(getOwnOrder(matches.matches[1].maker).quantity).to.be.equal(4);
   });
 
   it('should partially match new market order and discard remaining order', async () => {
     const order: orders.OwnMarketOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -10 };
     const matches = await orderBook.addMarketOrder(order);
     expect(matches.remainingOrder.quantity).to.be.greaterThan(order.quantity);
-    expect((getOrder(matches.remainingOrder))).to.be.undefined;
+    expect(getOwnOrder(matches.remainingOrder)).to.be.undefined;
   });
 
   after(async () => {

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -210,22 +210,40 @@ describe('MatchingEngine.removeOwnOrder', () => {
 });
 
 describe('MatchingEngine.removePeerOrders', () => {
-  it('should add a new peerOrders and then remove some of them', () => {
+  it('should add new peerOrders and then remove some of them', () => {
     const engine = new MatchingEngine(PAIR_ID);
-    const firstHostId = '127.0.0.1:8885';
-    const secondHostId = '127.0.0.1:9885';
+
+    const firstPeerId = '127.0.0.1:8885';
+    const secondPeertId = '127.0.0.1:9885';
 
     expect(engine.isEmpty()).to.be.true;
 
-    const firstHostOrders = [createPeerOrder(5, -5, ms(), firstHostId), createPeerOrder(5, -5, ms(), firstHostId)];
+    const firstHostOrders = [createPeerOrder(5, -5, ms(), firstPeerId), createPeerOrder(5, -5, ms(), firstPeerId)];
     engine.addPeerOrder(firstHostOrders[0]);
     engine.addPeerOrder(firstHostOrders[1]);
-    engine.addPeerOrder(createPeerOrder(5, -5, ms(), secondHostId));
+    engine.addPeerOrder(createPeerOrder(5, -5, ms(), secondPeertId));
 
-    const removedOrders = engine.removePeerOrders(firstHostId);
+    const removedOrders = engine.removePeerOrders(firstPeerId);
     expect(JSON.stringify(removedOrders)).to.be.equals(JSON.stringify(firstHostOrders));
 
     const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(5, 15), false);
     expect(matchingResult.remainingOrder.quantity).to.equal(10);
+  });
+
+  it('should add a new peerOrder and then remove it partially', () => {
+    const engine = new MatchingEngine(PAIR_ID);
+    expect(engine.isEmpty()).to.be.true;
+
+    const quantity = -5;
+    const decreasedQuantity = -3;
+
+    const order = createPeerOrder(5, quantity);
+    engine.addPeerOrder(order);
+
+    let removedOrder = engine.removePeerOrder(order.id, decreasedQuantity) as orders.StampedPeerOrder;
+    expect(removedOrder.quantity).to.be.equal(decreasedQuantity);
+
+    removedOrder = engine.removePeerOrder(order.id) as orders.StampedPeerOrder;
+    expect(removedOrder.quantity).to.be.equal(quantity - decreasedQuantity);
   });
 });


### PR DESCRIPTION
Closes #176 

The `OrderBook` sends the `OrderInvalidationPacket` after a match. After the Raiden swap integration the packet should be sent after a successful swap. And the `OrderBook` is able to handle `OrderInvalidationPacket` with a quantity (= partially filled orders).

And I would prefer that #265 gets merged first.