### PR TITLE
non-internal match order update

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -58,6 +58,10 @@ class OrderBook extends EventEmitter {
     }
   }
 
+  private static isOwnOrder(order: orders.StampedOrder): order is orders.StampedOwnOrder {
+    return order['hostId'] === undefined && typeof order['localId'] === 'string';
+  }
+
   public init = async () => {
     const pairs = await this.repository.getPairs();
 
@@ -213,7 +217,7 @@ class OrderBook extends EventEmitter {
   }
 
   private updateOrderQuantity = (order: orders.StampedOrder, decreasedQuantity: number) => {
-    const isOwnOrder = this.isOwnOrder(order);
+    const isOwnOrder = OrderBook.isOwnOrder(order);
     const orderMap = this.getOrderMap(isOwnOrder ? this.ownOrders : this.peerOrders, order);
 
     orderMap[order.id].quantity = orderMap[order.id].quantity - decreasedQuantity;
@@ -260,10 +264,6 @@ class OrderBook extends EventEmitter {
 
   private isOwnOrdersMap = (type: OrdersMap) => {
     return type === this.ownOrders;
-  }
-
-  private isOwnOrder = (order: orders.StampedOrder) => {
-    return !order['hostId'];
   }
 
   private sendOrders = async (peer: Peer, reqId: string) => {

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -58,10 +58,6 @@ class OrderBook extends EventEmitter {
     }
   }
 
-  private static isOwnOrder(order: orders.StampedOrder): order is orders.StampedOwnOrder {
-    return order['hostId'] === undefined && typeof order['localId'] === 'string';
-  }
-
   public init = async () => {
     const pairs = await this.repository.getPairs();
 
@@ -215,7 +211,7 @@ class OrderBook extends EventEmitter {
   }
 
   private updateOrderQuantity = (order: orders.StampedOrder, decreasedQuantity: number) => {
-    const isOwnOrder = OrderBook.isOwnOrder(order);
+    const isOwnOrder = orders.isOwnOrder(order);
     const orderMap = this.getOrderMap(isOwnOrder ? this.ownOrders : this.peerOrders, order);
 
     orderMap[order.id].quantity = orderMap[order.id].quantity - decreasedQuantity;

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -484,9 +484,13 @@
           "type": "string",
           "title": "The trading pair that this order is for"
         },
-        "host_id": {
+        "peer_id": {
           "type": "integer",
           "format": "int32",
+          "title": "The id of the peer that created this order"
+        },
+        "host_id": {
+          "type": "string",
           "title": "The id of the host that created this order"
         },
         "id": {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -485,8 +485,7 @@
           "title": "The trading pair that this order is for"
         },
         "peer_id": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "title": "The id of the peer - consisting of a [host]:[port] socket address - that created this order"
         },
         "id": {

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -450,8 +450,8 @@ export class Order extends jspb.Message {
   getPairId(): string;
   setPairId(value: string): void;
 
-  getPeerId(): number;
-  setPeerId(value: number): void;
+  getPeerId(): string;
+  setPeerId(value: string): void;
 
   getId(): string;
   setId(value: string): void;
@@ -480,7 +480,7 @@ export namespace Order {
     price: number,
     quantity: number,
     pairId: string,
-    peerId: number,
+    peerId: string,
     id: string,
     localId: string,
     createdAt: number,

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -450,8 +450,11 @@ export class Order extends jspb.Message {
   getPairId(): string;
   setPairId(value: string): void;
 
-  getHostId(): number;
-  setHostId(value: number): void;
+  getPeerId(): number;
+  setPeerId(value: number): void;
+
+  getHostId(): string;
+  setHostId(value: string): void;
 
   getId(): string;
   setId(value: string): void;
@@ -480,7 +483,8 @@ export namespace Order {
     price: number,
     quantity: number,
     pairId: string,
-    hostId: number,
+    peerId: number,
+    hostId: string,
     id: string,
     localId: string,
     createdAt: number,

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -3187,7 +3187,7 @@ proto.xudrpc.Order.toObject = function(includeInstance, msg) {
     price: +jspb.Message.getFieldWithDefault(msg, 1, 0.0),
     quantity: +jspb.Message.getFieldWithDefault(msg, 2, 0.0),
     pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    peerId: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    peerId: jspb.Message.getFieldWithDefault(msg, 4, ""),
     id: jspb.Message.getFieldWithDefault(msg, 6, ""),
     localId: jspb.Message.getFieldWithDefault(msg, 7, ""),
     createdAt: jspb.Message.getFieldWithDefault(msg, 8, 0),
@@ -3241,7 +3241,7 @@ proto.xudrpc.Order.deserializeBinaryFromReader = function(msg, reader) {
       msg.setPairId(value);
       break;
     case 4:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {string} */ (reader.readString());
       msg.setPeerId(value);
       break;
     case 6:
@@ -3311,8 +3311,8 @@ proto.xudrpc.Order.serializeBinaryToWriter = function(message, writer) {
     );
   }
   f = message.getPeerId();
-  if (f !== 0) {
-    writer.writeInt32(
+  if (f.length > 0) {
+    writer.writeString(
       4,
       f
     );
@@ -3394,15 +3394,15 @@ proto.xudrpc.Order.prototype.setPairId = function(value) {
 
 
 /**
- * optional int32 peer_id = 4;
- * @return {number}
+ * optional string peer_id = 4;
+ * @return {string}
  */
 proto.xudrpc.Order.prototype.getPeerId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
 };
 
 
-/** @param {number} value */
+/** @param {string} value */
 proto.xudrpc.Order.prototype.setPeerId = function(value) {
   jspb.Message.setField(this, 4, value);
 };

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -3187,7 +3187,8 @@ proto.xudrpc.Order.toObject = function(includeInstance, msg) {
     price: +jspb.Message.getFieldWithDefault(msg, 1, 0.0),
     quantity: +jspb.Message.getFieldWithDefault(msg, 2, 0.0),
     pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    hostId: jspb.Message.getFieldWithDefault(msg, 5, 0),
+    peerId: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    hostId: jspb.Message.getFieldWithDefault(msg, 5, ""),
     id: jspb.Message.getFieldWithDefault(msg, 6, ""),
     localId: jspb.Message.getFieldWithDefault(msg, 7, ""),
     createdAt: jspb.Message.getFieldWithDefault(msg, 8, 0),
@@ -3240,8 +3241,12 @@ proto.xudrpc.Order.deserializeBinaryFromReader = function(msg, reader) {
       var value = /** @type {string} */ (reader.readString());
       msg.setPairId(value);
       break;
-    case 5:
+    case 4:
       var value = /** @type {number} */ (reader.readInt32());
+      msg.setPeerId(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
       msg.setHostId(value);
       break;
     case 6:
@@ -3310,9 +3315,16 @@ proto.xudrpc.Order.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
-  f = message.getHostId();
+  f = message.getPeerId();
   if (f !== 0) {
     writer.writeInt32(
+      4,
+      f
+    );
+  }
+  f = message.getHostId();
+  if (f.length > 0) {
+    writer.writeString(
       5,
       f
     );
@@ -3394,15 +3406,30 @@ proto.xudrpc.Order.prototype.setPairId = function(value) {
 
 
 /**
- * optional int32 host_id = 5;
+ * optional int32 peer_id = 4;
  * @return {number}
  */
-proto.xudrpc.Order.prototype.getHostId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+proto.xudrpc.Order.prototype.getPeerId = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
 };
 
 
 /** @param {number} value */
+proto.xudrpc.Order.prototype.setPeerId = function(value) {
+  jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional string host_id = 5;
+ * @return {string}
+ */
+proto.xudrpc.Order.prototype.getHostId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/** @param {string} value */
 proto.xudrpc.Order.prototype.setHostId = function(value) {
   jspb.Message.setField(this, 5, value);
 };

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -40,3 +40,7 @@ export type OrderIdentifier = {
   pairId: string;
   quantity?: number;
 };
+
+export function isOwnOrder(order: StampedOrder): order is StampedOwnOrder {
+  return order['peerId'] === undefined && typeof order['localId'] === 'string';
+}

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -185,10 +185,8 @@ message Order {
   double quantity = 2 [json_name = "quantity"];
   // The trading pair that this order is for
   string pair_id = 3 [json_name = "pair_id"];
-  // The id of the peer that created this order
-  int32 peer_id = 4 [json_name = "peer_id"];
   // The id of the host that created this order
-  string host_id = 5 [json_name = "host_id"];
+  int32 host_id = 5 [json_name = "host_id"];
   // A UUID for this order
   string id = 6 [json_name = "id"];
   // The local ID for this oder

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -186,7 +186,7 @@ message Order {
   // The trading pair that this order is for
   string pair_id = 3 [json_name = "pair_id"];
   // The id of the peer - consisting of a [host]:[port] socket address - that created this order
-  int32 peer_id = 4 [json_name = "peer_id"];
+  string peer_id = 4 [json_name = "peer_id"];
   // A UUID for this order
   string id = 6 [json_name = "id"];
   // The local ID for this order


### PR DESCRIPTION
Fix #276 

* renaming existing `isOwnOrder` to `isOwnOrdersMap`
* after match, doing order update, without assuming it was an internal match
* proto `Order` message: remove `peer_id`, change `host_id` to int32 (it caused an error). 
Please regenerate the proto files for me, because I still didn't downgrade my version. 
