### PR TITLE
Remove db:init

### DIFF
--- a/instructions-for-devs.md
+++ b/instructions-for-devs.md
@@ -155,13 +155,7 @@ host = "localhost"
 port = 5001
 ```
 
-An empty *xud* database with schema gets automatically created when launching `xud`. To initialize an additional *xud_test* database with some pre-filled testing data, run the following command from the `~/xud` folder:
-
-```bash
-npm run db:init
-```
-
-Use the [config file](#configuration-optional) or launch `xud` with `--db.database xud_test` to use the pre-filled *xud_test* database. 
+An empty *xud* database with schema gets automatically created when launching `xud`.
 
 [Releases](https://github.com/ExchangeUnion/xud/releases) currently don't support swaps, thus we recommend to disable lnd & raiden in the config, to avoid unnecessary error outputs:
 


### PR DESCRIPTION
Remove:
To initialize an additional *xud_test* database with some pre-filled testing data, run the following command from the `~/xud` folder:

```bash
npm run db:init
```

Use the [config file](#configuration-optional) or launch `xud` with `--db.database xud_test` to use the pre-filled *xud_test* database.