### PR TITLE
Initialize pool after orderbook

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -55,10 +55,11 @@ class Xud {
       this.raidenClient = new RaidenClient(this.config.raiden);
 
       this.pool = new Pool(this.config.p2p, this.db);
-      this.pool.init();
 
       this.orderBook = new OrderBook(this.db.models, this.pool, this.lndClient);
       await this.orderBook.init();
+
+      await this.pool.init();
 
       this.service = new Service({
         orderBook: this.orderBook,


### PR DESCRIPTION
Fixes #294. This moves the initialization of the p2p pool until after the orderbook is initialized. This is because peer connections will trigger `ORDERS` and `GET_ORDERS` packets that depend on an initialized orderbook to work properly. It also ensures that the p2p pool is initialized before starting the gRPC server.