### PR TITLE
Remove extraneous p2p logging & closes

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -242,7 +242,7 @@ class Pool extends EventEmitter {
     });
 
     peer.on('error', (err) => {
-      this.logger.error('peer error', err);
+      this.logger.error(`peer error (${peer.id}): ${err.message}`);
     });
 
     peer.once('open', (handshakeState) => {


### PR DESCRIPTION
This removes calls of the `Peer.close` method before a socket is open, which prevents the `close` event from firing, instead relying on the `cleanup` method to tie up loose ends when a connection to a peer errors or times out. It also removes duplicate log messages when a socket errors or is closed, and prevents logging stack traces for non-fatal peer errors.