### PR TITLE
Discover node's external IP

### DIFF
--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -5,6 +5,7 @@ const errorCodes = {
   NOT_CONNECTED: codesPrefix.concat('.2'),
   UNEXPECTED_NODE_PUB_KEY: codesPrefix.concat('.3'),
   ATTEMPTED_CONNECTION_TO_SELF: codesPrefix.concat('.4'),
+  EXTERNAL_IP_UNRETRIEVABLE: codesPrefix.concat('.5'),
 };
 
 const errors = {
@@ -24,6 +25,10 @@ const errors = {
     message: 'Cannot attempt connection to self',
     code: errorCodes.ATTEMPTED_CONNECTION_TO_SELF,
   },
+  EXTERNAL_IP_UNRETRIEVABLE: (err: Error) => ({
+    message: `could not retrieve external IP: ${err.message}`,
+    code: errorCodes.EXTERNAL_IP_UNRETRIEVABLE,
+  }),
 };
 
 export { errorCodes };

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,3 +1,32 @@
+import http from 'http';
+import errors from '../p2p/errors';
+
+/**
+ * Gets the external IP of the node
+ */
+export const getExternalIp = () => {
+  return new Promise<string>((resolve, reject) => {
+    http.get('http://ipv4.icanhazip.com/', (res) => {
+      let body = '';
+
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        // Removes new line at the end of the string
+        body = body.trimRight();
+        resolve(body);
+      });
+      res.on('error', (err: Error) => {
+        reject(errors.EXTERNAL_IP_UNRETRIEVABLE(err));
+      });
+
+    }).on('error', (err: Error) => {
+      reject(errors.EXTERNAL_IP_UNRETRIEVABLE(err));
+    });
+  });
+};
+
 /**
  * Check whether a variable is a non-array object
  */


### PR DESCRIPTION
*EDIT:*

Closes #181 

This PR appends the nodes external IP to `handshakeData.addresses` if no address was specified by the user.