### PR TITLE
Add comments, rename variables, minor refactoring

### DIFF
--- a/lib/BaseClient.ts
+++ b/lib/BaseClient.ts
@@ -6,6 +6,9 @@ enum ClientStatus {
   CONNECTION_VERIFIED,
 }
 
+/**
+ * A base class to represent a client for an external service such as LND or Raiden.
+ */
 abstract class BaseClient extends EventEmitter {
   protected logger: Logger;
   protected status!: ClientStatus;

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -30,7 +30,7 @@ class Xud {
 
   /**
    * Create an Exchange Union daemon.
-   * @param args Optional command line arguments to override configuration parameters.
+   * @param args optional command line arguments to override configuration parameters.
    */
   constructor(args?: Arguments)  {
     this.config = new Config(args);
@@ -61,13 +61,8 @@ class Xud {
       this.orderBook = new OrderBook(this.db.models, this.pool, this.lndClient, this.raidenClient);
       await this.orderBook.init();
 
-      const pairs: string[] = [];
-      (await this.orderBook.getPairs()).forEach((pair) => {
-        pairs.push(pair.id);
-      });
-
       this.pool.init({
-        pairs,
+        pairs: this.orderBook.pairIds,
         version: '1.0',
         nodePubKey: this.nodeKey.nodePubKey,
         listenPort: this.config.p2p.listen ? this.config.p2p.port : undefined,

--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -15,13 +15,13 @@ interface grpcResponse {
 /**
  * A generic function to instantiate an XU client, perform a command, and output the result to the
  * console.
- * @param argv The command line arguments
- * @param callback The callback function to perform a command
+ * @param argv the command line arguments
+ * @param callback the callback function to perform a command
  */
 export const callback = (error: Error | null, response: grpcResponse) => {
   if (error) {
     console.error(`${error.name}: ${error.message}`);
   } else {
-    console.log(JSON.stringify(response.toObject(), null, 2));
+    console.log(JSON.stringify(response.toObject(), undefined, 2));
   }
 };

--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -26,9 +26,10 @@ type Models = {
   Pair: Sequelize.Model<db.PairInstance, db.PairAttributes>;
 };
 
+/** A class representing a connection to a SQL database. */
 class DB {
-  public sequelize!: Sequelize.Sequelize;
-  public models!: Models;
+  public sequelize: Sequelize.Sequelize;
+  public models: Models;
   private logger: Logger = Logger.db;
 
   constructor(private config: DBConfig) {
@@ -70,6 +71,7 @@ class DB {
     ]);
 
     if (newDb) {
+      // populate new databases with seed nodes
       await Host.bulkCreate(<db.HostAttributes[]>[
         { address: 'xud1.test.exchangeunion.com', port: 8885 },
         { address: 'xud2.test.exchangeunion.com', port: 8885 },

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -37,7 +37,6 @@ class GrpcServer {
 
   /**
    * Start the server and begin listening on the provided port
-   * @param port
    * @returns true if the server started listening successfully, false otherwise
    */
   public listen = (port: number, host: string) => {

--- a/lib/grpc/webproxy/GrpcWebProxyServer.ts
+++ b/lib/grpc/webproxy/GrpcWebProxyServer.ts
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import grpc from 'grpc';
 const swaggerDocument = require('../../proto/xudrpc.swagger.json');
 
+/** A class representing an HTTP web proxy for the gRPC service. */
 class GrpcWebProxyServer {
   private logger: Logger;
   private app: express.Express;
@@ -22,7 +23,7 @@ class GrpcWebProxyServer {
   }
 
   /**
-   * Starts the server and begins listening on the specified proxy port
+   * Start the server and begins listening on the specified proxy port.
    */
   public listen = (proxyPort: number, grpcPort: number, grpcHost: string): Promise<void> => {
     // Load the proxy on / URL

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -6,9 +6,7 @@ import errors from './errors';
 import { LightningClient } from '../proto/lndrpc_grpc_pb';
 import * as lndrpc from '../proto/lndrpc_pb';
 
-/**
- * The configurable options for the lnd client.
- */
+/** The configurable options for the lnd client. */
 type LndClientConfig = {
   disable: boolean;
   certpath: string;
@@ -34,7 +32,7 @@ class LndClient extends BaseClient {
 
   /**
    * Create an lnd client.
-   * @param config The lnd configuration
+   * @param config the lnd configuration
    */
   constructor(config: LndClientConfig) {
     super(Logger.lnd);
@@ -103,7 +101,7 @@ class LndClient extends BaseClient {
 
   /**
    * Attempt to add a new invoice to the lnd invoice database.
-   * @param value The value of this invoice in satoshis
+   * @param value the value of this invoice in satoshis
    */
   public addInvoice = (value: number): Promise<lndrpc.AddInvoiceResponse.AsObject> => {
     const request = new lndrpc.Invoice();
@@ -113,7 +111,7 @@ class LndClient extends BaseClient {
 
   /**
    * Pay an invoice through the Lightning Network.
-   * @param payment_request An invoice for a payment within the Lightning Network.
+   * @param payment_request an invoice for a payment within the Lightning Network
    */
   public payInvoice = (paymentRequest: string): Promise<lndrpc.SendResponse.AsObject> => {
     const request = new lndrpc.SendRequest();

--- a/lib/nodekey/NodeKey.ts
+++ b/lib/nodekey/NodeKey.ts
@@ -33,9 +33,9 @@ class NodeKey {
 
   /**
    * Load a NodeKey from a file.
-   * @param path The path to the file
-   * @param password An optional password to decrypt the file
-   * @returns A NodeKey if a file containing a valid ECDSA private key exists at the given path
+   * @param path the path to the file
+   * @param password an optional password to decrypt the file
+   * @returns a NodeKey if a file containing a valid ECDSA private key exists at the given path
    */
   private static fromFile = (path: string, password?: string): NodeKey => {
     let buf: Buffer;
@@ -70,17 +70,17 @@ class NodeKey {
 
   /**
    * Sign a message with the private key.
-   * @param msg The data to sign
-   * @returns The signature
+   * @param msg the data to sign
+   * @returns the signature
    */
   public sign = (msg: Buffer): Buffer => {
     return secp256k1.sign(msg, this.privKey).signature;
   }
 
   /**
-   * Save the private key to a file, optionally encrypted by a password
-   * @param path The path at which to save the file
-   * @param password An optional password parameter for encrypting the private key
+   * Save the private key to a file, optionally encrypted by a password.
+   * @param path the path at which to save the file
+   * @param password an optional password parameter for encrypting the private key
    */
   private toFile = (path: string, password?: string): void => {
     let buf: Buffer | CryptoJS.WordArray;

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -1,38 +1,32 @@
 import assert from 'assert';
 import FastPriorityQueue from '@exchangeunion/fastpriorityqueue';
-
 import { matchingEngine } from '../types';
 import { OrderingDirection } from '../types/enums';
 import Logger from '../Logger';
 import { StampedOrder, StampedOwnOrder, StampedPeerOrder } from '../types/orders';
 
-type PriorityQueues = {
-  buyOrders: FastPriorityQueue<StampedOrder>;
-  sellOrders: FastPriorityQueue<StampedOrder>;
-};
-
 type SplitOrder = {
-  target: StampedOrder;
+  matched: StampedOrder;
   remaining: StampedOrder;
 };
 
+/** A class to represent a matching engine responsible for matching orders for a given trading pair according to their price and quantity. */
 class MatchingEngine {
-  public priorityQueues: PriorityQueues;
+  public buyOrders: FastPriorityQueue<StampedOrder>;
+  public sellOrders: FastPriorityQueue<StampedOrder>;
   private logger: Logger = Logger.orderbook;
 
   constructor(public pairId: string) {
-    this.priorityQueues = {
-      buyOrders: MatchingEngine.createPriorityQueue(OrderingDirection.DESC),
-      sellOrders: MatchingEngine.createPriorityQueue(OrderingDirection.ASC),
-    };
+    this.buyOrders = MatchingEngine.createPriorityQueue(OrderingDirection.DESC);
+    this.sellOrders = MatchingEngine.createPriorityQueue(OrderingDirection.ASC);
   }
 
-  private static createPriorityQueue(orderingDirection: OrderingDirection): FastPriorityQueue<StampedOrder> {
-    const comparator = this.getOrdersPriorityQueueComparator(orderingDirection);
+  private static createPriorityQueue = (orderingDirection: OrderingDirection): FastPriorityQueue<StampedOrder> => {
+    const comparator = MatchingEngine.getOrdersPriorityQueueComparator(orderingDirection);
     return new FastPriorityQueue(comparator);
   }
 
-  public static getOrdersPriorityQueueComparator(orderingDirection: OrderingDirection) {
+  public static getOrdersPriorityQueueComparator = (orderingDirection: OrderingDirection) => {
     const directionComparator = orderingDirection === OrderingDirection.ASC
       ? (a: number, b: number) => a < b
       : (a: number, b: number) => a > b;
@@ -46,6 +40,10 @@ class MatchingEngine {
     };
   }
 
+  /**
+   * Get the matching quantity between two orders.
+   * @returns the smaller of the quantity between the two orders if their price matches, 0 otherwise
+   */
   public static getMatchingQuantity = (buyOrder: StampedOrder, sellOrder: StampedOrder): number => {
     if (buyOrder.price >= sellOrder.price) {
       return Math.min(buyOrder.quantity, sellOrder.quantity * -1);
@@ -54,91 +52,93 @@ class MatchingEngine {
     }
   }
 
-  public static splitOrderByQuantity = (order: StampedOrder, targetQuantity: number): SplitOrder => {
+  /**
+   * Split an order by quantity into a matched portion and a remaining portion.
+   */
+  public static splitOrderByQuantity = (order: StampedOrder, matchingQuantity: number): SplitOrder => {
     const { quantity } = order;
     const absQuantity = Math.abs(quantity);
-    assert(absQuantity > targetQuantity, 'order abs quantity should be higher than targetQuantity');
+    assert(absQuantity > matchingQuantity, 'order abs quantity must be greater than matchingQuantity');
 
     const direction = quantity / absQuantity;
     return {
-      target: { ...order, quantity: targetQuantity * direction },
-      remaining: { ...order, quantity: quantity - (targetQuantity * direction) },
+      matched: { ...order, quantity: matchingQuantity * direction },
+      remaining: { ...order, quantity: quantity - (matchingQuantity * direction) },
     };
   }
 
-  public static match(order: StampedOwnOrder, matchAgainst: FastPriorityQueue<StampedOrder>[]): matchingEngine.MatchingResult {
-    const isBuyOrder = order.quantity > 0;
-    const matches: matchingEngine.OrderMatch[] = [];
-    let remainingOrder: StampedOwnOrder | null = { ...order };
-
-    const getMatchingQuantity = (remainingOrder: StampedOwnOrder, oppositeOrder: StampedOrder) => isBuyOrder
-      ? MatchingEngine.getMatchingQuantity(remainingOrder, oppositeOrder)
-      : MatchingEngine.getMatchingQuantity(oppositeOrder, remainingOrder);
-
-    matchAgainst.forEach((priorityQueue) => {
-      while (remainingOrder && !priorityQueue.isEmpty()) {
-        const oppositeOrder = priorityQueue.peek();
-        const matchingQuantity = getMatchingQuantity(remainingOrder, oppositeOrder!);
-        if (matchingQuantity <= 0) {
-          break;
-        } else {
-          const oppositeOrder = priorityQueue.poll()!;
-          const oppositeOrderAbsQuantity = Math.abs(oppositeOrder.quantity);
-          const remainingOrderAbsQuantity = Math.abs(remainingOrder.quantity);
-          if (
-            oppositeOrderAbsQuantity === matchingQuantity &&
-            remainingOrderAbsQuantity === matchingQuantity
-          ) { // order quantities are fully matching
-            matches.push({ maker: oppositeOrder, taker: remainingOrder });
-            remainingOrder = null;
-          } else if (remainingOrderAbsQuantity === matchingQuantity) {  // maker order quantity is not sufficient. taker order will split
-            const splitOrder = this.splitOrderByQuantity(oppositeOrder, matchingQuantity);
-            matches.push({ maker: splitOrder.target, taker: remainingOrder });
-            priorityQueue.add(splitOrder.remaining);
-            remainingOrder = null;
-          } else if (oppositeOrderAbsQuantity === matchingQuantity) { // taker order quantity is not sufficient. maker order will split
-            const splitOrder = this.splitOrderByQuantity(remainingOrder, matchingQuantity);
-            matches.push({ maker: oppositeOrder, taker: splitOrder.target });
-            remainingOrder = splitOrder.remaining as StampedOwnOrder;
-          } else {
-            assert(false, 'matchingQuantity should not be lower than both orders quantity values');
-          }
-        }
-      }
-    });
-
-    return {
-      matches,
-      remainingOrder,
-    };
-  }
-
-  public addPeerOrder = (order: StampedPeerOrder): void => {
-    (order.quantity > 0
-      ? this.priorityQueues.buyOrders
-      : this.priorityQueues.sellOrders
-    ).add(order);
-  }
-
+  /**
+   * Match an order against its opposite queue, and optionally add the unmatched portion of the order to the queue.
+   * @param discardRemaining whether to discard any unmatched portion of the order rather than add it to the queue
+   * @returns a [[MatchingResult]] with the matches as well as the remaining, unmatched portion of the order
+   */
   public matchOrAddOwnOrder = (order: StampedOwnOrder, discardRemaining: boolean): matchingEngine.MatchingResult => {
     const isBuyOrder = order.quantity > 0;
-    let matchAgainst: FastPriorityQueue<StampedOrder> | undefined ;
-    let addTo: FastPriorityQueue<StampedOrder> | undefined;
+    const addTo = isBuyOrder ? this.buyOrders : this.sellOrders;
 
-    if (isBuyOrder) {
-      matchAgainst = this.priorityQueues.sellOrders;
-      addTo = this.priorityQueues.buyOrders;
-    } else {
-      matchAgainst = this.priorityQueues.buyOrders;
-      addTo = this.priorityQueues.sellOrders;
-    }
-
-    const matchingResult = MatchingEngine.match(order, [matchAgainst]);
-    if (matchingResult.remainingOrder && addTo && !discardRemaining) {
+    const matchingResult = this.match(order);
+    if (matchingResult.remainingOrder && !discardRemaining) {
       addTo.add(matchingResult.remainingOrder);
     }
 
     return matchingResult;
+  }
+
+  /**
+   * Match an order against its opposite queue.
+   * @returns a [[MatchingResult]] with the matches as well as the remaining, unmatched portion of the order
+   */
+  public match = (takerOrder: StampedOwnOrder): matchingEngine.MatchingResult => {
+    const isBuyOrder = takerOrder.quantity > 0;
+    const matches: matchingEngine.OrderMatch[] = [];
+    /** The unmatched remaining taker order, if there is still leftover quantity after matching is complete it will enter the queue. */
+    let remainingOrder: StampedOwnOrder | undefined = { ...takerOrder };
+
+    const matchAgainst = isBuyOrder ? this.sellOrders : this.buyOrders;
+    const getMatchingQuantity = (remainingOrder: StampedOwnOrder, oppositeOrder: StampedOrder) => isBuyOrder
+      ? MatchingEngine.getMatchingQuantity(remainingOrder, oppositeOrder)
+      : MatchingEngine.getMatchingQuantity(oppositeOrder, remainingOrder);
+
+    // as long as we have remaining quantity to match and orders to match against, keep checking for matches
+    while (remainingOrder && !matchAgainst.isEmpty()) {
+      const oppositeOrder = matchAgainst.peek()!;
+      const matchingQuantity = getMatchingQuantity(remainingOrder, oppositeOrder);
+      if (matchingQuantity <= 0) {
+        // there's no match with the best available maker order, so end the matching routine
+        break;
+      } else {
+        const makerOrder = matchAgainst.poll()!;
+        const makerOrderAbsQuantity = Math.abs(makerOrder.quantity);
+        const remainingOrderAbsQuantity = Math.abs(remainingOrder.quantity);
+        if (
+          makerOrderAbsQuantity === matchingQuantity &&
+          remainingOrderAbsQuantity === matchingQuantity
+        ) { // order quantities are fully matching
+          matches.push({ maker: makerOrder, taker: remainingOrder });
+          remainingOrder = undefined;
+        } else if (remainingOrderAbsQuantity === matchingQuantity) {  // maker order quantity is not sufficient. taker order will split
+          const splitOrder = MatchingEngine.splitOrderByQuantity(makerOrder, matchingQuantity);
+          matches.push({ maker: splitOrder.matched, taker: remainingOrder });
+          matchAgainst.add(splitOrder.remaining);
+          remainingOrder = undefined;
+        } else if (makerOrderAbsQuantity === matchingQuantity) { // taker order quantity is not sufficient. maker order will split
+          const splitOrder = MatchingEngine.splitOrderByQuantity(remainingOrder, matchingQuantity);
+          matches.push({ maker: makerOrder, taker: splitOrder.matched });
+          remainingOrder = splitOrder.remaining as StampedOwnOrder;
+        } else {
+          assert(false, 'matchingQuantity should not be lower than both orders quantity values');
+        }
+      }
+    }
+
+    return { matches, remainingOrder };
+  }
+
+  public addPeerOrder = (order: StampedPeerOrder): void => {
+    (order.quantity > 0
+      ? this.buyOrders
+      : this.sellOrders
+    ).add(order);
   }
 
   public removeOwnOrder = (orderId: string): StampedOwnOrder | undefined => {
@@ -159,24 +159,31 @@ class MatchingEngine {
     return order;
   }
 
+  /**
+   * Remove all orders from the queue matching the given peer id.
+   */
   public removePeerOrders = (peerId: string): StampedPeerOrder[] => {
     const callback = (order: StampedOrder) => {
       return (order as StampedPeerOrder).peerId === peerId;
     };
 
     return [
-      ...this.priorityQueues.buyOrders.removeMany(callback),
-      ...this.priorityQueues.sellOrders.removeMany(callback),
+      ...this.buyOrders.removeMany(callback),
+      ...this.sellOrders.removeMany(callback),
     ] as StampedPeerOrder[];
   }
 
+  /**
+   * Check whether the matching queue is empty.
+   * @returns true if both the buy orders and sell orders queues are empty, otherwise false
+   */
   public isEmpty = (): boolean => {
-    return this.priorityQueues.buyOrders.isEmpty() && this.priorityQueues.sellOrders.isEmpty();
+    return this.buyOrders.isEmpty() && this.sellOrders.isEmpty();
   }
 
   private removeOrder = (orderId: string): StampedOrder | undefined => {
-    return this.priorityQueues.buyOrders.removeOne(order => order.id === orderId) ||
-      this.priorityQueues.sellOrders.removeOne(order => order.id === orderId);
+    return this.buyOrders.removeOne(order => order.id === orderId) ||
+      this.sellOrders.removeOne(order => order.id === orderId);
   }
 }
 

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -330,9 +330,9 @@ class Peer extends EventEmitter {
   /**
    * Wait for a packet to be received from peer.
    */
-  private addResponseTimeout = (packetId: string, timeout: number): PendingResponseEntry | null => {
+  private addResponseTimeout = (packetId: string, timeout: number): PendingResponseEntry | undefined => {
     if (this.closed) {
-      return null;
+      return undefined;
     }
 
     const entry = this.getOrAddPendingResponseEntry(packetId);
@@ -545,8 +545,10 @@ class Peer extends EventEmitter {
   }
 }
 
+/** A class representing a wait for an anticipated response packet from a peer. */
 class PendingResponseEntry {
   public timeout: number = 0;
+  /** An array of tasks to resolve or reject. */
   public jobs: Job[] = [];
 
   public addJob = (resolve: Function, reject: Function) => {
@@ -574,6 +576,7 @@ class PendingResponseEntry {
   }
 }
 
+/** A pair of functions for resolving or rejecting a task. */
 class Job {
   constructor(public resolve: Function, public reject: Function) {}
 }

--- a/lib/p2p/PeerList.ts
+++ b/lib/p2p/PeerList.ts
@@ -33,13 +33,13 @@ class PeerList {
     }
   }
 
-  public remove = (socketAddress: SocketAddress): Peer | null => {
+  public remove = (socketAddress: SocketAddress): Peer | undefined => {
     const peer = this.get(socketAddress);
     if (peer) {
       delete this.peers[socketAddress.toString()];
       return peer;
     } else {
-      return null;
+      return undefined;
     }
   }
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -28,7 +28,7 @@ interface Pool {
   emit(event: 'peer.close', peer: Peer): boolean;
 }
 
-/** A pool of peers for handling all network activity */
+/** A class representing a pool of peers that handles network activity. */
 class Pool extends EventEmitter {
   private hosts: HostList;
   private peers: PeerList = new PeerList();

--- a/lib/p2p/SocketAddress.ts
+++ b/lib/p2p/SocketAddress.ts
@@ -1,7 +1,7 @@
 import { Socket } from 'net';
 import assert from 'assert';
 
-/** Represents a network socketAddress. */
+/** Represents a network socket address. */
 class SocketAddress {
   constructor(public address: string, public port: number) {}
 

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -43,14 +43,13 @@ abstract class Packet<T = any> implements PacketInterface {
 
   /**
    * Create a packet from a deserialized packet message.
-   * @param packet A deserialized object containing a packet header and optional body
+   * @param packet a deserialized object containing a packet header and optional body
    */
   constructor(packet: PacketInterface);
 
   /**
   * Create a packet from a packet body.
-  * @param body
-  * @param reqId The id of the requesting packet to set on the header if this packet is a response.
+  * @param reqId the id of the requesting packet to set on the header if this packet is a response
   */
   constructor(body?: T, reqId?: string);
 

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -122,9 +122,9 @@ class RaidenClient extends BaseClient {
 
   /**
    * Send a request to the Raiden REST API.
-   * @param endpoint The URL endpoint
-   * @param method An HTTP request method
-   * @param payload The request payload
+   * @param endpoint the URL endpoint
+   * @param method an HTTP request method
+   * @param payload the request payload
    */
   private sendRequest = (endpoint: string, method: string, payload?: object): Promise<http.IncomingMessage> => {
     return new Promise((resolve, reject) => {
@@ -217,8 +217,8 @@ class RaidenClient extends BaseClient {
 
   /**
    * Initiates or attempts to complete a Raiden token swap
-   * @param target_address The address of the intended swap counterparty
-   * @param payload The token swap payload
+   * @param target_address the address of the intended swap counterparty
+   * @param payload the token swap payload
    */
   public tokenSwap = async (target_address: string, payload: TokenSwapPayload, order?: StampedOrder): Promise<void> => {
     const identifier = ms();
@@ -233,7 +233,7 @@ class RaidenClient extends BaseClient {
 
   /**
    * Get info about a given raiden payment channel.
-   * @param channel_address The address of the channel to query
+   * @param channel_address the address of the channel to query
    */
   public getChannel = async (channel_address: string): Promise<Channel> => {
     const endpoint = `channels/${channel_address}`;
@@ -264,7 +264,7 @@ class RaidenClient extends BaseClient {
 
   /**
    * Close a payment channel.
-   * @param channel_address The address of the channel to close
+   * @param channel_address the address of the channel to close
    */
   public closeChannel = async (channel_address: string): Promise<void> => {
     const endpoint = `channels/${channel_address}`;
@@ -272,9 +272,9 @@ class RaidenClient extends BaseClient {
   }
 
   /**
-   * Deposit more of a token to an existing channel
-   * @param channel_address The address of the channel to deposit to
-   * @param balance The amount to deposit to the channel
+   * Deposit more of a token to an existing channel.
+   * @param channel_address the address of the channel to deposit to
+   * @param balance the amount to deposit to the channel
    */
   public depositToChannel = async(channel_address: string, balance: number): Promise<void> => {
     const endpoint = `channels/${channel_address}`;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -123,23 +123,19 @@ class Service extends EventEmitter {
 
     info.version = packageJson.version;
 
-    const pairs = await this.orderBook.getPairs();
+    const pairIds = this.orderBook.pairIds;
     info.numPeers = this.pool.peerCount;
-    info.numPairs = pairs.length;
+    info.numPairs = pairIds.length;
 
     let peerOrdersCount: number = 0;
     let ownOrdersCount: number = 0;
-    for (const key in pairs) {
-      const pair = pairs[key];
-
-      const [peerOrders, ownOrders] = await Promise.all([
-        this.orderBook.getPeerOrders(pair.id, 0),
-        this.orderBook.getOwnOrders(pair.id, 0),
-      ]);
+    pairIds.forEach((pairId) => {
+      const peerOrders = this.orderBook.getPeerOrders(pairId, 0);
+      const ownOrders = this.orderBook.getOwnOrders(pairId, 0);
 
       peerOrdersCount += Object.keys(peerOrders.buyOrders).length + Object.keys(peerOrders.sellOrders).length;
       ownOrdersCount += Object.keys(ownOrders.buyOrders).length + Object.keys(ownOrders.sellOrders).length;
-    }
+    });
 
     info.orders = {
       peer: peerOrdersCount,
@@ -199,7 +195,7 @@ class Service extends EventEmitter {
     argChecks.HAS_PAIR_ID(args);
     argChecks.MAX_RESULTS_NOT_NEGATIVE(args);
 
-    const result: { [ type: string ]: OrderArrays } = {
+    const result = {
       peerOrders: this.orderBook.getPeerOrders(pairId, maxResults),
       ownOrders: this.orderBook.getOwnOrders(pairId, maxResults),
     };
@@ -212,7 +208,7 @@ class Service extends EventEmitter {
    * @returns A list of available trading pairs
    */
   public getPairs = () => {
-    return this.orderBook.getPairs();
+    return this.orderBook.pairs;
   }
 
   /**

--- a/lib/types/matchingEngine.ts
+++ b/lib/types/matchingEngine.ts
@@ -7,5 +7,5 @@ export type OrderMatch = {
 
 export type MatchingResult = {
   matches: OrderMatch[];
-  remainingOrder: StampedOwnOrder;
+  remainingOrder?: StampedOwnOrder;
 };

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -19,8 +19,8 @@ export const getTsString = (): string => (new Date()).toLocaleString();
 /**
  * Recursively merge properties from different sources into a target object, overriding any
  * existing properties.
- * @param target The destination object to merge into.
- * @param sources The sources objects to copy from.
+ * @param target the destination object to merge into.
+ * @param sources the sources objects to copy from.
  */
 export const deepMerge = (target: any, ...sources: any[]): object => {
   if (!sources.length) return target;

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -63,7 +63,7 @@ describe('OrderBook', () => {
   it('should have pairs and matchingEngines equivalent loaded', () => {
     expect(orderBook.pairs).to.be.an('array');
     orderBook.pairs.forEach((pair) => {
-      expect(orderBook.matchingEngines).to.have.ownProperty(pair.id);
+      expect(orderBook.matchingEngines).to.have.key(pair.id);
     });
   });
 
@@ -76,7 +76,7 @@ describe('OrderBook', () => {
   it('should fully match new ownOrder and remove matches', async () => {
     const order: orders.OwnOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -6, price: 55 };
     const matches = await orderBook.addLimitOrder(order);
-    expect(matches.remainingOrder).to.be.null;
+    expect(matches.remainingOrder).to.be.undefined;
 
     const firstMatch = matches.matches[0];
     const secondMatch = matches.matches[1];
@@ -94,9 +94,10 @@ describe('OrderBook', () => {
   it('should partially match new market order and discard remaining order', async () => {
     const order: orders.OwnMarketOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -10 };
     const matches = await orderBook.addMarketOrder(order);
-    expect(matches.remainingOrder.quantity).to.be.greaterThan(order.quantity);
-    expect(getOwnOrder(matches.remainingOrder)).to.be.undefined;
-    expect((getOwnOrder(matches.remainingOrder))).to.be.undefined;
+    expect(matches.remainingOrder).to.not.be.undefined;
+    expect(matches.remainingOrder!.quantity).to.be.greaterThan(order.quantity);
+    expect(getOwnOrder(matches.remainingOrder!)).to.be.undefined;
+    expect((getOwnOrder(matches.remainingOrder!))).to.be.undefined;
   });
 
   after(async () => {


### PR DESCRIPTION
I'm looking to regenerate the typedoc for the codebase soon, and before doing that I wanted to try to clean up the codebase a bit and add comment blocks anywhere I felt it was lacking or the code wasn't particularly clear. This PR:

- Adds typedoc comments to help document and clarify the code.
- Renames several variables and properties in an attempt to make their use and purpose more clear.
- Replaces internal use of `null` with `undefined`. The code base previously used both interchangeably, but undefined was more common and is the default value for properties defined with the nullable `?` operator.
- Replaces objects used for mapping key-value pairs with `Map` instances.
- Attempts to follow the [javadoc style guide](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#@param) for commenting functions.
- Minor refactoring of the MatchingEngine class.