### PR TITLE
log 'socket closed' msg only if already connected

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -416,11 +416,14 @@ class Peer extends EventEmitter {
 
     this.socket.once('close', (hadError) => {
       // emitted once the socket is fully closed
-      if (hadError) {
-        this.logger.warn(`Socket closed due to error (${this.id})`);
-      } else {
-        this.logger.info(`Socket closed (${this.id})`);
+      if (this.connected) {
+        if (hadError) {
+          this.logger.warn(`Socket closed due to error (${this.id})`);
+        } else {
+          this.logger.info(`Socket closed (${this.id})`);
+        }
       }
+
       this.close();
     });
 


### PR DESCRIPTION
Small one, addressing #289 

if socket wasn't previously connected, the error msg is a bit verbose, because we're already printing the connection failure reason.