### PR TITLE
Add tslint rules

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -91,7 +91,7 @@ class Config {
     };
   }
 
-  public async load() {
+  public load() {
     if (!fs.existsSync(this.xudir)) {
       fs.mkdirSync(this.xudir);
     } else if (fs.existsSync(`${this.xudir}xud.conf`)) {

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -83,7 +83,7 @@ class Logger {
     });
   }
 
-  public static createLoggers = (instanceId: number = 0): Loggers => {
+  public static createLoggers = (instanceId = 0): Loggers => {
     return {
       global: new Logger({ instanceId, context: Context.GLOBAL }),
       db: new Logger({ instanceId, context: Context.DB }),

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -47,7 +47,7 @@ class Xud {
    * Start all processes necessary for the operation of an Exchange Union node.
    */
   public start = async () => {
-    await this.config.load();
+    this.config.load();
     const loggers = Logger.createLoggers(this.config.instanceId);
     this.logger = loggers.global;
     this.logger.info('config loaded');
@@ -110,7 +110,7 @@ class Xud {
         if (!listening) {
           // if rpc should be enabled but fails to start, treat it as a fatal error
           this.logger.error('Could not start gRPC server, exiting...');
-          this.shutdown();
+          await this.shutdown();
           return;
         }
 
@@ -140,7 +140,7 @@ class Xud {
     }
     // TODO: ensure we are not in the middle of executing any trades
     const msg = 'XUD shutdown gracefully';
-    (async () => {
+    await (async () => {
       // we use an immediately invoked function here exit the process AFTER the
       // shutdown method returns a response.
       this.lndbtcClient.close();
@@ -165,7 +165,7 @@ class Xud {
 
 if (!module.parent) {
   const xud = new Xud();
-  xud.start();
+  void xud.start();
 }
 
 export default Xud;

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -106,7 +106,7 @@ class Xud {
       // start rpc server last
       if (!this.config.rpc.disable) {
         this.rpcServer = new GrpcServer(loggers.rpc, this.service);
-        const listening = await this.rpcServer.listen(this.config.rpc.port, this.config.rpc.host);
+        const listening = this.rpcServer.listen(this.config.rpc.port, this.config.rpc.host);
         if (!listening) {
           // if rpc should be enabled but fails to start, treat it as a fatal error
           this.logger.error('Could not start gRPC server, exiting...');

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -1,4 +1,4 @@
-/* tslint:disable no-floating-promises */
+/* tslint:disable no-floating-promises no-null-keyword */
 import grpc, { status } from 'grpc';
 import Logger from '../Logger';
 import Service from '../service/Service';

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -1,5 +1,6 @@
+/* tslint:disable no-floating-promises */
+import grpc, { status } from 'grpc';
 import Logger from '../Logger';
-import grpc, { status, ServiceError } from 'grpc';
 import Service from '../service/Service';
 import { isObject } from '../utils/utils';
 import { TokenSwapPayload } from '../raidenclient/RaidenClient';

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -39,7 +39,7 @@ class LndClient extends BaseClient {
   constructor(config: LndClientConfig, logger: Logger) {
     super(logger);
 
-    let shouldEnable: boolean = true;
+    let shouldEnable = true;
     const { disable, certpath, macaroonpath } = config;
 
     if (disable) {

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -237,18 +237,18 @@ class LndClient extends BaseClient {
       .on('data', (message: string) => {
         this.logger.info(`invoice update: ${message}`);
       })
-      .on('end', () => {
+      .on('end', async () => {
         this.logger.info('invoice ended');
         this.setStatus(ClientStatus.DISCONNECTED);
-        this.connect();
+        await this.connect();
       })
       .on('status', (status: string) => {
         this.logger.debug(`invoice status: ${JSON.stringify(status)}`);
       })
-      .on('error', (error: any) => {
+      .on('error', async (error) => {
         this.logger.error(`invoice error: ${error}`);
         this.setStatus(ClientStatus.DISCONNECTED);
-        this.connect();
+        await this.connect();
       });
   }
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -202,7 +202,7 @@ class OrderBook extends EventEmitter {
     return false;
   }
 
-  private addOwnOrder = (order: orders.OwnOrder, discardRemaining: boolean = false): matchingEngine.MatchingResult => {
+  private addOwnOrder = (order: orders.OwnOrder, discardRemaining = false): matchingEngine.MatchingResult => {
     if (this.localIdMap.has(order.localId)) {
       throw errors.DUPLICATE_ORDER(order.localId);
     }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -358,7 +358,7 @@ class OrderBook extends EventEmitter {
       orders['buyOrders'].forEach(order => outgoingOrders.push(this.createOutgoingOrder(order as orders.StampedOwnOrder)));
       orders['sellOrders'].forEach(order => outgoingOrders.push(this.createOutgoingOrder(order as orders.StampedOwnOrder)));
     });
-    peer.sendOrders(outgoingOrders as orders.OutgoingOrder[], reqId);
+    peer.sendOrders(outgoingOrders, reqId);
   }
 
   /**

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -42,24 +42,24 @@ class Peer extends EventEmitter {
   // TODO: properties documentation
   public socketAddress!: Address;
   public inbound!: boolean;
-  public connected: boolean = false;
-  private opened: boolean = false;
+  public connected = false;
+  private opened = false;
   private socket?: Socket;
   private parser: Parser = new Parser();
-  private closed: boolean = false;
+  private closed = false;
   private connectTimeout?: NodeJS.Timer;
   private stallTimer?: NodeJS.Timer;
   private pingTimer?: NodeJS.Timer;
   private responseMap: Map<string, PendingResponseEntry> = new Map();
   private connectTime!: number;
-  private banScore: number = 0;
-  private lastRecv: number = 0;
-  private lastSend: number = 0;
+  private banScore = 0;
+  private lastRecv = 0;
+  private lastSend = 0;
   private handshakeState?: HandshakeState;
   /** A counter for packets sent to be used for assigning unique packet ids. */
   private packetCount = 0;
   /** Interval to check required responses from peer. */
-  private static STALL_INTERVAL: number = 5000;
+  private static STALL_INTERVAL = 5000;
   /** Interval for pinging peers. */
   private static PING_INTERVAL = 30000;
   /** Socket connection timeout for outbound peers. */
@@ -560,7 +560,7 @@ class Peer extends EventEmitter {
 
 /** A class representing a wait for an anticipated response packet from a peer. */
 class PendingResponseEntry {
-  public timeout: number = 0;
+  public timeout = 0;
   /** An array of tasks to resolve or reject. */
   public jobs: Job[] = [];
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -39,7 +39,7 @@ class Pool extends EventEmitter {
   private nodes: NodeList;
   private peers: PeerList = new PeerList();
   private server: Server = net.createServer();
-  private connected: boolean = false;
+  private connected = false;
   /** The local handshake data to be sent to newly connected peers. */
   private handshakeData!: HandshakeState;
   /** The port on which to listen for peer connections, undefined if this node is not listening. */

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -338,7 +338,7 @@ class Pool extends EventEmitter {
   }
 
   private unlisten = async (): Promise<void> => {
-    await this.server.close();
+    this.server.close();
   }
 }
 

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -48,9 +48,9 @@ abstract class Packet<T = any> implements PacketInterface {
   constructor(packet: PacketInterface);
 
   /**
-  * Create a packet from a packet body.
-  * @param reqId the id of the requesting packet to set on the header if this packet is a response
-  */
+   * Create a packet from a packet body.
+   * @param reqId the id of the requesting packet to set on the header if this packet is a response
+   */
   constructor(body?: T, reqId?: string);
 
   constructor(bodyOrPacket?: T | PacketInterface, reqId?: string) {

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -11,7 +11,7 @@ import { StampedOrder } from '../types/orders';
 async function parseResponseBody<T>(res: http.IncomingMessage): Promise<T> {
   res.setEncoding('utf8');
   return new Promise<T>((resolve, reject) => {
-    let body: string = '';
+    let body = '';
     res.on('data', (chunk) => {
       body += chunk;
     });

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -170,8 +170,8 @@ class Service extends EventEmitter {
     info.numPeers = this.pool.peerCount;
     info.numPairs = pairIds.length;
 
-    let peerOrdersCount: number = 0;
-    let ownOrdersCount: number = 0;
+    let peerOrdersCount = 0;
+    let ownOrdersCount = 0;
     pairIds.forEach((pairId) => {
       const peerOrders = this.orderBook.getPeerOrders(pairId, 0);
       const ownOrders = this.orderBook.getOwnOrders(pairId, 0);

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -152,7 +152,7 @@ class Service extends EventEmitter {
   }
 
   /**
-   * Execute an atomic swap. Demonstration and testing purposes only.
+   * Execute an atomic swap
    */
   public executeSwap = async ({ target_address, payload }: { target_address: string, payload: TokenSwapPayload }) => {
     return this.raidenClient.tokenSwap(target_address, payload);
@@ -267,11 +267,9 @@ class Service extends EventEmitter {
   }
 
   /*
-   * Subscribe to executed swaps.
+   * Subscribe to executed swaps
    */
-  public subscribeSwaps = async (callback: Function) => {
-    this.raidenClient.on('swap', order => callback(order));
-  }
+  public subscribeSwaps = async (_callback: Function) => {};
 }
 
 export default Service;

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -42,7 +42,7 @@ export const deepMerge = (target: any, ...sources: any[]): object => {
 
 /**
  * Get all methods from an object whose name doesn't start with an underscore.
-*/
+ */
 export const getPublicMethods = (obj: any): any => {
   const ret: any = {};
   Object.getOwnPropertyNames(Object.getPrototypeOf(obj)).forEach((name) => {

--- a/tslint-alt.json
+++ b/tslint-alt.json
@@ -2,6 +2,7 @@
   "extends": "./tslint.json",
   "rules": {
     "no-boolean-literal-compare": false,
-    "no-floating-promises": false
+    "no-floating-promises": false,
+    "no-unnecessary-type-assertion": false
   }
 }

--- a/tslint-alt.json
+++ b/tslint-alt.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tslint.json",
   "rules": {
-    "no-boolean-literal-compare": false
+    "no-boolean-literal-compare": false,
+    "no-floating-promises": false
   }
 }

--- a/tslint-alt.json
+++ b/tslint-alt.json
@@ -3,6 +3,7 @@
   "rules": {
     "no-boolean-literal-compare": false,
     "no-floating-promises": false,
-    "no-unnecessary-type-assertion": false
+    "no-unnecessary-type-assertion": false,
+    "await-promise": false
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -37,6 +37,7 @@
       }
     ],
     "no-floating-promises": [true, "Bluebird"],
-    "no-null-keyword": true
+    "no-null-keyword": true,
+    "jsdoc-format": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -38,6 +38,7 @@
     ],
     "no-floating-promises": [true, "Bluebird"],
     "no-null-keyword": true,
-    "jsdoc-format": true
+    "jsdoc-format": true,
+    "no-unnecessary-type-assertion": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -40,6 +40,7 @@
     "no-null-keyword": true,
     "jsdoc-format": true,
     "no-unnecessary-type-assertion": true,
-    "await-promise": [true, "Bluebird"]
+    "await-promise": [true, "Bluebird"],
+    "no-inferrable-types": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -39,6 +39,7 @@
     "no-floating-promises": [true, "Bluebird"],
     "no-null-keyword": true,
     "jsdoc-format": true,
-    "no-unnecessary-type-assertion": true
+    "no-unnecessary-type-assertion": true,
+    "await-promise": [true, "Bluebird"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -35,11 +35,7 @@
           "instance-method"
         ]
       }
-    ]
-  },
-  "linterOptions": {
-    "exclude": [
-        "lib/lndclient/lndrpc_pb.d.ts"
-    ]
+    ],
+    "no-floating-promises": [true, "Bluebird"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -36,6 +36,7 @@
         ]
       }
     ],
-    "no-floating-promises": [true, "Bluebird"]
+    "no-floating-promises": [true, "Bluebird"],
+    "no-null-keyword": true
   }
 }


### PR DESCRIPTION
I went through the list of available tslint rules to see if there were any we weren't using that I thought would be good for this project. The most significant is the `no-floating-promises` rule which doesn't allow dangling promises whose resolutions are not waited for or handled properly. That has already turned up a handful of places where I think we should've been using async/await but weren't.

The rest are relatively minor and the codebase already largely conformed to them, but I think are worth enforcing. Each rule is in a separate commit.