### PR TITLE
drop duplicated peer orders

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -232,10 +232,15 @@ class OrderBook extends EventEmitter {
     return matchingResult;
   }
 
+  /**
+   * Add peer order
+   * @returns false if it's a duplicated order or with an invalid pair id, otherwise true
+   */
   private addPeerOrder = (order: orders.PeerOrder): boolean => {
     const matchingEngine = this.matchingEngines.get(order.pairId);
     if (!matchingEngine) {
       this.logger.debug(`incoming peer order invalid pairId: ${order.pairId}`);
+      // TODO: penalize peer
       return false;
     }
 
@@ -289,6 +294,10 @@ class OrderBook extends EventEmitter {
     return true;
   }
 
+  /**
+   * Add an order to an order map
+   * @returns false if an order with the same id already exist, otherwise true
+   */
   private addOrder = (ordersMap: OrdersMap, order: orders.StampedOrder) => {
     if (this.isOwnOrdersMap(ordersMap)) {
       const { localId } = order as orders.StampedOwnOrder;

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -241,7 +241,7 @@ class OrderBook extends EventEmitter {
 
     const stampedOrder: orders.StampedPeerOrder = { ...order, createdAt: ms() };
 
-    if(!this.addOrder(this.peerOrders, stampedOrder)) {
+    if (!this.addOrder(this.peerOrders, stampedOrder)) {
       this.logger.debug(`incoming peer order is duplicated: ${order.id}`);
       // TODO: penalize peer
       return false;


### PR DESCRIPTION
Addressing #142

At the moment it's checking that the order is duplicated, and not solely `id`. 
More precisely, that the id+pairId+orderSide tuple is duplicated. That's because we're dividing the orders by pairId, and then by sell/buy. 
Having a support for a duplication only on the order id would be messy right now. If we want that support, it should be a part of #215.

I didn't add tests, because it requires p2p tests, and not integration tests. But I temporarily turned `addPeerOrder` method to public, run some quick tests, and it looks fine. 