### PR TITLE
Travis build file improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: required
+
 node_js:
   - "8"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ services:
 
 script:
   - npm run lint
-  - npm run test:unit
-  - npm run test:int
+  - npm run test
   - cd docker/xud && docker build -t exchangeunion/xud .
 
 before_install:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "proto": "cross-os proto && cross-os swagger",
     "start": "node dist/Xud.js",
     "stop": "cross-os stop",
-    "test": "npm run test:unit && npm run test:int",
+    "test": "npm run test:unit && npm run test:int && npm run test:p2p",
     "test:int": "mocha -r ts-node/register test/integration/*",
     "test:int:watch": "mocha -r ts-node/register test/integration/*  --watch --watch-extensions ts",
     "test:unit": "mocha -r ts-node/register test/unit/*",


### PR DESCRIPTION
This PR:
- removes `sudo: required` which will result in [faster boot times](https://docs.travis-ci.com/user/reference/overview/#sudo-enabled)
- adds the P2P tests to `npm run test` and lets Travis run `npm run test` instead of every category of test separately