### PR TITLE
 Separated placeorder command

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -18,7 +18,7 @@ require('yargs')
       type: 'string',
     },
   })
-  .commandDir('../dist/cli/commands')
+  .commandDir('../dist/cli/commands/', { recurse: true })
   .demandCommand(1, '')
   .strict()
   .argv; // we must read the argv property for the command line args to initialize properly

--- a/lib/cli/commands/orders/limitorder.ts
+++ b/lib/cli/commands/orders/limitorder.ts
@@ -1,10 +1,10 @@
-import { callback, loadXudClient } from '../command';
+import { callback, loadXudClient } from '../../command';
 import { Arguments } from 'yargs';
-import { PlaceOrderRequest, Order } from '../../proto/xudrpc_pb';
+import { PlaceOrderRequest, Order } from '../../../proto/xudrpc_pb';
 
-export const command = 'placeorder <pair_id> <order_id> <quantity> [price]';
+export const command = 'limitorder <pair_id> <order_id> <quantity> <price>';
 
-export const describe = 'place an order, if price is 0 or unspecified a market order is placed';
+export const describe = 'place a limit order';
 
 export const builder = {
   pair_id: {
@@ -13,10 +13,10 @@ export const builder = {
   order_id: {
     type: 'string',
   },
-  price: {
+  quantity: {
     type: 'number',
   },
-  quantity: {
+  price: {
     type: 'number',
   },
 };
@@ -29,6 +29,7 @@ export const handler = (argv: Arguments) => {
   order.setLocalId(argv.order_id);
   order.setQuantity(argv.quantity);
   order.setPrice(argv.price);
+
   request.setOrder(order);
 
   loadXudClient(argv).placeOrder(request, callback);

--- a/lib/cli/commands/orders/marketorder.ts
+++ b/lib/cli/commands/orders/marketorder.ts
@@ -1,0 +1,22 @@
+import { Arguments } from 'yargs';
+import * as limitorder from './limitorder';
+
+export const command = 'marketorder <pair_id> <order_id> <quantity>';
+
+export const describe = 'place a market order';
+
+export const builder = {
+  pair_id: {
+    type: 'string',
+  },
+  order_id: {
+    type: 'string',
+  },
+  quantity: {
+    type: 'number',
+  },
+};
+
+export const handler = (argv: Arguments) => {
+  limitorder.handler(argv);
+};


### PR DESCRIPTION
Closes #249 

This PR separates the CLI command `placeorder` into `limitorder` and `marketorder`. 