### PR TITLE
Refactor gRPC

### DIFF
--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -5,18 +5,16 @@ import Logger from '../Logger';
 import GrpcService from './GrpcService';
 import Service from '../service/Service';
 import errors from './errors';
+import { XudService } from '../proto/xudrpc_grpc_pb';
 
 class GrpcServer {
   private server: Server;
 
   constructor(private logger: Logger, service: Service) {
     this.server = new grpc.Server();
-    const xudrpcProtoPath = path.join(__dirname, '..', '..', 'proto', 'xudrpc.proto');
-    const protoDescriptor = grpc.load(xudrpcProtoPath, 'proto', { convertFieldsToCamelCase: true });
-    const { xudrpc }: any = protoDescriptor;
 
     const grpcService = new GrpcService(logger, service);
-    this.server.addService(xudrpc.Xud.service, {
+    this.server.addService(XudService, {
       cancelOrder: grpcService.cancelOrder,
       connect: grpcService.connect,
       disconnect: grpcService.disconnect,

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -2,144 +2,303 @@
 import grpc, { status } from 'grpc';
 import Logger from '../Logger';
 import Service from '../service/Service';
-import { isObject } from '../utils/utils';
-import { TokenSwapPayload } from '../raidenclient/RaidenClient';
-import { PairInstance } from '../types/db';
-import { GetInfoResponse } from '../proto/lndrpc_pb';
-import { Orders } from 'lib/orderbook/OrderBook';
-import { MatchingResult } from '../types/matchingEngine';
-import { OwnOrder, StampedPeerOrder, StampedOrder } from '../types/orders';
+import * as xudrpc from '../proto/xudrpc_pb';
+import { StampedPeerOrder, StampedOrder, StampedOwnOrder } from '../types/orders';
 import { errorCodes as orderErrorCodes } from '../orderbook/errors';
 import { errorCodes as serviceErrorCodes } from '../service/errors';
 import { errorCodes as p2pErrorCodes } from '../p2p/errors';
-import { PeerInfo } from '../p2p/Peer';
+import { LndInfo } from '../lndclient/LndClient';
+import { OrderArrays } from '../orderbook/OrderBook';
 
-function serializeDateProperties(response: any) {
-  Object.keys(response).forEach((key) => {
-    if (response[key] instanceof Date) {
-      response[key] = response[key].getTime();
-    } else if (isObject(response[key])) {
-      response[key] = serializeDateProperties(response[key]);
-    }
-  });
-
-  return response;
-}
+/**
+ * Convert a [[StampedOrder]] to an xudrpc Order message.
+ */
+const getOrder = (order: StampedOrder) => {
+  const grpcOrder = new xudrpc.Order();
+  grpcOrder.setCanceled(false);
+  grpcOrder.setCreatedAt(order.createdAt);
+  grpcOrder.setId(order.id);
+  grpcOrder.setLocalId((order as StampedOwnOrder).localId);
+  grpcOrder.setPairId(order.pairId);
+  grpcOrder.setPeerPubKey((order as StampedPeerOrder).peerPubKey);
+  grpcOrder.setPrice(order.price);
+  grpcOrder.setQuantity(order.quantity);
+  return grpcOrder;
+};
 
 /** Class containing the available RPC methods for XUD */
 class GrpcService {
   /** Create an instance of available RPC methods and bind all exposed functions. */
   constructor(private logger: Logger, private service: Service) {}
 
-  private unaryCall = async <T, U>(call: T, callback: grpc.sendUnaryData<U>, serviceMethod: Function) => {
-    try {
-      const rawResponse: U = await serviceMethod(call);
-      const response = serializeDateProperties(rawResponse);
-      callback(null, response);
-    } catch (err) {
-      this.logger.error(err);
-
-      // if we recognize this error, return a proper gRPC ServiceError with a descriptive and appropriate code
-      let code: grpc.status | undefined;
-      switch (err.code) {
-        case serviceErrorCodes.INVALID_ARGUMENT:
-        case p2pErrorCodes.ATTEMPTED_CONNECTION_TO_SELF:
-          code = status.INVALID_ARGUMENT;
-          break;
-        case orderErrorCodes.INVALID_PAIR_ID:
-          code = status.NOT_FOUND;
-          break;
-        case orderErrorCodes.DUPLICATE_ORDER:
-        case p2pErrorCodes.NODE_ALREADY_CONNECTED:
-          code = status.ALREADY_EXISTS;
-          break;
-        case p2pErrorCodes.NOT_CONNECTED:
-          code = status.FAILED_PRECONDITION;
-          break;
-      }
-      // return grpcError if we've created one, otherwise pass along the caught error as UNKNOWN
-      callback(code ? { ...err, code } : err, null);
+  /**
+   * Convert an internal xud error type into a gRPC error.
+   * @param err an error object that should have code and message properties
+   * @return a gRPC error with a gRPC status code
+   */
+  private getGrpcError = (err: any) => {
+    // if we recognize this error, use a proper gRPC ServiceError with a descriptive and appropriate code
+    let code: grpc.status | undefined;
+    switch (err.code) {
+      case serviceErrorCodes.INVALID_ARGUMENT:
+      case p2pErrorCodes.ATTEMPTED_CONNECTION_TO_SELF:
+        code = status.INVALID_ARGUMENT;
+        break;
+      case orderErrorCodes.INVALID_PAIR_ID:
+        code = status.NOT_FOUND;
+        break;
+      case orderErrorCodes.DUPLICATE_ORDER:
+      case p2pErrorCodes.NODE_ALREADY_CONNECTED:
+        code = status.ALREADY_EXISTS;
+        break;
+      case p2pErrorCodes.NOT_CONNECTED:
+        code = status.FAILED_PRECONDITION;
+        break;
     }
+
+    // return a grpc error with the code if we've assigned one, otherwise pass along the caught error as UNKNOWN
+    const grpcError: grpc.ServiceError = {
+      code: code || status.UNKNOWN,
+      message: err.message,
+      name: err.name,
+    };
+    this.logger.error(grpcError);
+
+    return grpcError;
   }
 
   /**
    * See [[Service.cancelOrder]]
    */
-  public cancelOrder: grpc.handleUnaryCall<{ id: string, pairId: string }, string> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.cancelOrder);
+  public cancelOrder: grpc.handleUnaryCall<xudrpc.CancelOrderRequest, xudrpc.CancelOrderResponse> = async (call, callback) => {
+    try {
+      const cancelOrderResponse = await this.service.cancelOrder(call.request.toObject());
+      const response = new xudrpc.CancelOrderResponse();
+      response.setCanceled(cancelOrderResponse.canceled);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.connect]]
    */
-  public connect: grpc.handleUnaryCall<{ host: string, port: number }, string> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.connect);
+  public connect: grpc.handleUnaryCall<xudrpc.ConnectRequest, xudrpc.ConnectResponse> = async (call, callback) => {
+    try {
+      const connectResponse = await this.service.connect(call.request.toObject());
+      const response = new xudrpc.ConnectResponse();
+      response.setResult(connectResponse);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.disconnect]]
    */
-  public disconnect: grpc.handleUnaryCall<{ host: string, port: number }, string> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.disconnect);
+  public disconnect: grpc.handleUnaryCall<xudrpc.DisconnectRequest, xudrpc.DisconnectResponse> = async (call, callback) => {
+    try {
+      const disconnectResponse = await this.service.disconnect(call.request.toObject());
+      const response = new xudrpc.DisconnectResponse();
+      response.setResult(disconnectResponse);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.executeSwap]]
    */
-  public executeSwap: grpc.handleUnaryCall<{ target_address: string, payload: TokenSwapPayload, identifier: string }, {}> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.executeSwap);
+  public executeSwap: grpc.handleUnaryCall<xudrpc.ExecuteSwapRequest, xudrpc.ExecuteSwapResponse> = (call, callback) => {
+    try {
+      const executeSwapResponse = this.service.executeSwap(call.request.toObject());
+      const response = new xudrpc.ExecuteSwapResponse();
+      response.setResult(executeSwapResponse);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.getInfo]]
    */
-  public getInfo: grpc.handleUnaryCall<{}, {lnd: GetInfoResponse}> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.getInfo);
+  public getInfo: grpc.handleUnaryCall<xudrpc.GetInfoRequest, xudrpc.GetInfoResponse> = async (_, callback) => {
+    try {
+      const getInfoResponse = await this.service.getInfo();
+      const response = new xudrpc.GetInfoResponse();
+      response.setNumPairs(getInfoResponse.numPairs);
+      response.setNumPeers(getInfoResponse.numPeers);
+      response.setVersion(getInfoResponse.version);
+
+      const getLndInfo = ((lndInfo: LndInfo): xudrpc.LndInfo => {
+        const lnd = new xudrpc.LndInfo();
+        if (lndInfo.blockheight) lnd.setBlockheight(lndInfo.blockheight);
+        if (lndInfo.chains) lnd.setChainsList(lndInfo.chains);
+        if (lndInfo.channels) {
+          const channels = new xudrpc.LndChannels();
+          channels.setActive(lndInfo.channels.active);
+          channels.setPending(lndInfo.channels.pending);
+          if (lndInfo.channels.inactive) channels.setInactive(lndInfo.channels.inactive);
+          lnd.setChannels(channels);
+        }
+        if (lndInfo.error) lnd.setError(lndInfo.error);
+        if (lndInfo.uris) lnd.setUrisList(lndInfo.uris);
+        if (lndInfo.version) lnd.setVersion(lndInfo.version);
+        return lnd;
+      });
+      if (getInfoResponse.lndbtc) response.setLndbtc(getLndInfo(getInfoResponse.lndbtc));
+      if (getInfoResponse.lndltc) response.setLndltc(getLndInfo(getInfoResponse.lndltc));
+
+      if (getInfoResponse.raiden) {
+        const raiden = new xudrpc.RaidenInfo();
+        if (getInfoResponse.raiden.address) raiden.setAddress(getInfoResponse.raiden.address);
+        if (getInfoResponse.raiden.channels) raiden.setChannels(getInfoResponse.raiden.channels);
+        if (getInfoResponse.raiden.error) raiden.setError(getInfoResponse.raiden.error);
+        if (getInfoResponse.raiden.version) raiden.setVersion(getInfoResponse.raiden.version);
+        response.setRaiden(raiden);
+      }
+
+      const orders = new xudrpc.OrdersCount;
+      orders.setOwn(getInfoResponse.orders.own);
+      orders.setPeer(getInfoResponse.orders.peer);
+      response.setOrders(orders);
+
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.getOrders]]
    */
-  public getOrders: grpc.handleUnaryCall<{ pairId: string, maxResults: number }, Orders> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.getOrders);
+  public getOrders: grpc.handleUnaryCall<xudrpc.GetOrdersRequest, xudrpc.GetOrdersResponse> = (call, callback) => {
+    try {
+      const getOrdersResponse = this.service.getOrders(call.request.toObject());
+      const response = new xudrpc.GetOrdersResponse();
+
+      const getOrdersList = (orders: StampedOrder[]) => {
+        const ordersList: xudrpc.Order[] = [];
+        orders.forEach(order => ordersList.push(getOrder(order)));
+        return ordersList;
+      };
+
+      const getOrders = (orderArrays: OrderArrays) => {
+        const orders = new xudrpc.Orders();
+        orders.setBuyOrdersList(getOrdersList(orderArrays.buyOrders));
+        orders.setSellOrdersList(getOrdersList(orderArrays.sellOrders));
+        return orders;
+      };
+
+      response.setOwnOrders(getOrders(getOrdersResponse.ownOrders));
+      response.setPeerOrders(getOrders(getOrdersResponse.peerOrders));
+
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.getPairs]]
    */
-  public getPairs: grpc.handleUnaryCall<{}, PairInstance[]> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.getPairs);
+  public getPairs: grpc.handleUnaryCall<xudrpc.GetPairsRequest, xudrpc.GetPairsResponse> = (_, callback) => {
+    try {
+      const getPairsResponse = this.service.getPairs();
+      const response = new xudrpc.GetPairsResponse();
+
+      const pairs: xudrpc.Pair[] = [];
+      getPairsResponse.forEach((pairInstance) => {
+        const pair = new xudrpc.Pair();
+        pair.setBaseCurrency(pairInstance.baseCurrency);
+        pair.setId(pairInstance.id);
+        pair.setQuoteCurrency(pairInstance.quoteCurrency);
+        pair.setSwapProtocol(pairInstance.swapProtocol);
+        pairs.push(pair);
+      });
+      response.setPairsList(pairs);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.listPeers]]
    */
-  public listPeers: grpc.handleUnaryCall<{}, PeerInfo[]> = (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.listPeers);
+  public listPeers: grpc.handleUnaryCall<xudrpc.ListPeersRequest, xudrpc.ListPeersResponse> = (_, callback) => {
+    try {
+      const listPeersResponse = this.service.listPeers();
+      const response = new xudrpc.ListPeersResponse();
+      const peers: xudrpc.Peer[] = [];
+      listPeersResponse.forEach((peer) => {
+        const grpcPeer = new xudrpc.Peer();
+        grpcPeer.setAddress(peer.address);
+        grpcPeer.setInbound(peer.inbound);
+        grpcPeer.setNodePubKey(peer.nodePubKey || '');
+        grpcPeer.setPairsList(peer.pairs || []);
+        grpcPeer.setSecondsConnected(peer.secondsConnected);
+        grpcPeer.setXudVersion(peer.xudVersion || '');
+        peers.push(grpcPeer);
+      });
+      response.setPeersList(peers);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /**
    * See [[Service.placeOrder]]
    */
-  public placeOrder: grpc.handleUnaryCall<{ order: OwnOrder }, MatchingResult> = (call, callback) => {
-    this.unaryCall(call.request.order, callback, this.service.placeOrder);
+  public placeOrder: grpc.handleUnaryCall<xudrpc.PlaceOrderRequest, xudrpc.PlaceOrderResponse> = async (call, callback) => {
+    try {
+      const placeOrderResponse = await this.service.placeOrder(call.request.toObject());
+      const response = new xudrpc.PlaceOrderResponse();
+      const matchesList: xudrpc.OrderMatch[] = [];
+      placeOrderResponse.matches.forEach((match) => {
+        const orderMatch = new xudrpc.OrderMatch();
+        orderMatch.setMaker(getOrder(match.maker));
+        orderMatch.setTaker(getOrder(match.taker));
+        matchesList.push(orderMatch);
+      });
+      response.setMatchesList(matchesList);
+
+      if (placeOrderResponse.remainingOrder) {
+        response.setRemainingOrder(getOrder(placeOrderResponse.remainingOrder));
+      }
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
-  public shutdown: grpc.handleUnaryCall<{}, {}> = async (call, callback) => {
-    this.unaryCall(call.request, callback, this.service.shutdown);
+  public shutdown: grpc.handleUnaryCall<xudrpc.ShutdownRequest, xudrpc.ShutdownResponse> = async (_, callback) => {
+    try {
+      const shutdownResponse = await this.service.shutdown();
+      const response = new xudrpc.ShutdownResponse();
+      response.setResult(shutdownResponse);
+      callback(null, response);
+    } catch (err) {
+      callback(this.getGrpcError(err), null);
+    }
   }
 
   /*
    * See [[Service.subscribePeerOrders]]
    */
-  public subscribePeerOrders: grpc.handleServerStreamingCall<{}, {}> = (call) => {
+  public subscribePeerOrders: grpc.handleServerStreamingCall<xudrpc.SubscribePeerOrdersRequest, xudrpc.SubscribePeerOrdersResponse> = (call) => {
     this.service.subscribePeerOrders((order: StampedPeerOrder) => call.write({ order }));
   }
 
   /*
    * See [[Service.subscribeSwaps]]
    */
-  public subscribeSwaps: grpc.handleServerStreamingCall<{}, {}> = (call) => {
+  public subscribeSwaps: grpc.handleServerStreamingCall<xudrpc.SubscribeSwapsRequest, xudrpc.SubscribeSwapsResponse> = (call) => {
     this.service.subscribeSwaps((order: StampedOrder) => call.write({ order }));
   }
 }

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -33,6 +33,14 @@ type RaidenClientConfig = {
   port: number;
 };
 
+/** General information about the state of this raiden client. */
+type RaidenInfo = {
+  error?: string;
+  address?: string;
+  channels?: number;
+  version?: string;
+};
+
 /**
  * The payload for the [[tokenSwap]] call.
  */
@@ -111,7 +119,7 @@ class RaidenClient extends BaseClient {
   /**
    * Check for connectivity and get our Raiden account address
    */
-  public async init() {
+  public init = async () => {
     if (this.isDisabled()) {
       this.logger.error(`can't init raiden. raiden is disabled`);
       return;
@@ -122,6 +130,31 @@ class RaidenClient extends BaseClient {
     } catch (err) {
       this.logger.error('could not get raiden address', err);
     }
+  }
+
+  public getRaidenInfo = async (): Promise<RaidenInfo> => {
+    let channels: number | undefined;
+    let address: string | undefined;
+    let error: string | undefined;
+    const version = 'v0.3.0'; // Hardcoded for now until they expose it to their API;
+
+    if (this.isDisabled()) {
+      error = errors.RAIDEN_IS_DISABLED.message;
+    } else {
+      try {
+        channels = (await this.getChannels()).length;
+        address = this.address!;
+      } catch (err) {
+        error = err.message;
+      }
+    }
+
+    return {
+      channels,
+      address,
+      error,
+      version,
+    };
   }
 
   /**
@@ -298,4 +331,4 @@ class RaidenClient extends BaseClient {
 }
 
 export default RaidenClient;
-export { RaidenClientConfig, TokenSwapPayload, OpenChannelPayload };
+export { RaidenClientConfig, RaidenInfo, TokenSwapPayload, OpenChannelPayload };

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -55,6 +55,7 @@ type TokenSwapPayload = {
   receivingAmount: number;
   /** The address for the token being received */
   receivingToken: string;
+   // TODO: Either move this type definition out of RaidenClient or remove nodepubkey as it's not part of the actual raiden tokenswap payload
   /** The xud pubkey of the swap peer */
   nodePubKey: string;
 };


### PR DESCRIPTION
This aims to be at least an intermediate solution to #339.  It's in an unfinished state but I wanted feedback before I went and applied the same pattern to every call. `getInfo` is the main call to look at, you can ignore the others for the purposes of initial review. It works and can be tested. I also refactored `connect` and `cancelOrder`.

This uses our static generated files for creating the xud grpc server - doing so requires that we use the actual generated gRPC classes for the callback. Passing a plain javascript object with the right fields won't work. This restricts the code to only be able to return valid grpc responses.

The current structure is basically that Service.ts deals with our internal types and plain javascript objects but doesn't touch anything grpc-related. It passes values to the GrpcService.ts class which in turn creates the grpc response object and passes it to the callback - or if it encounters an error it passes the error to the callback. The logic to map internal errors to grpc errors is located within the `getServiceResponse` method. The functions in GrpcService.ts aim to follow the general structure shown below:

```javascript
function sayHello(call, callback) {
  var reply = new messages.HelloReply();
  reply.setMessage('Hello ' + call.request.getName());
  callback(null, reply);
}
````

I also refactored the getInfo logic itself a bit and moved some of it to the `LndClient` and `RaidenClient` classes.

If this looks good I'll apply the same approach to all the calls and update the PR.