### PR TITLE
Fix shutdown procedure

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -125,16 +125,22 @@ class Xud {
     // TODO: ensure we are not in the middle of executing any trades
     const msg = 'XUD shutdown gracefully';
     (async () => {
-      // we use an immediately invoked function here to close rpcServer and exit process AFTER the
+      // we use an immediately invoked function here exit the process AFTER the
       // shutdown method returns a response.
+      this.lndbtcClient.close();
+      this.lndltcClient.close();
+
+      const closePromises: Promise<void>[] = [];
       if (this.rpcServer) {
-        await this.rpcServer.close();
+        closePromises.push(this.rpcServer.close());
       }
       if (this.grpcAPIProxy) {
-        await this.grpcAPIProxy.close();
+        closePromises.push(this.grpcAPIProxy.close());
       }
+      await Promise.all(closePromises);
+
+      await this.db.close();
       this.logger.info(msg);
-      this.db.close();
     })();
 
     return msg;


### PR DESCRIPTION
This ensures that lnd clients are closed properly during shutdown and that we wait for the database to close. Previously, xud would never shutdown if it was attempting to reconnect to lnd.

I tested the `xucli shutdown` command both while connected to peers and while not connected to any peers and it works as expected with these changes.