### PR TITLE
Update node addresses on handshake

### DIFF
--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -1,6 +1,6 @@
 import P2PRepository from './P2PRepository';
 import { NodeInstance, NodeFactory } from '../types/db';
-import { NodeConnectionInfo } from '../types/p2p';
+import { NodeConnectionInfo, Address } from '../types/p2p';
 
 /** Represents a list of nodes for managing network peers activity */
 class NodeList {
@@ -46,8 +46,8 @@ class NodeList {
     const node = this.nodes.get(nodePubKey);
     if (node) {
       node.banned = true;
-      const updatedNodes = await this.repository.updateNode(node);
-      return updatedNodes.length > 0;
+      await this.repository.updateNode(node);
+      return true;
     }
     return false;
   }
@@ -75,6 +75,21 @@ class NodeList {
     const node = await this.repository.addNode(nodeFactory);
     this.nodes.set(node.nodePubKey, node);
     return node;
+  }
+
+  /**
+   * Update a node's addresses.
+   * @return true if the specified node exists and was updated, false otherwise
+   */
+  public updateAddresses = async (nodePubKey: string, addresses: Address[] = []) => {
+    const node = this.nodes.get(nodePubKey);
+    if (node) {
+      node.addresses = addresses;
+      await this.repository.updateNode(node);
+      return true;
+    }
+
+    return false;
   }
 }
 

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -6,6 +6,10 @@ import { NodeConnectionInfo, Address } from '../types/p2p';
 class NodeList {
   private nodes = new Map<string, NodeInstance>();
 
+  public get count() {
+    return this.nodes.size;
+  }
+
   constructor(private repository: P2PRepository) {}
 
   /**

--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -13,7 +13,7 @@ class P2PRepository {
     return this.models.Node.findAll();
   }
 
-  public addNode = async (node: db.NodeFactory) => {
+  public addNode = (node: db.NodeFactory) => {
     return this.models.Node.create(<db.NodeAttributes>node);
   }
 
@@ -22,7 +22,7 @@ class P2PRepository {
   }
 
   public updateNode = async (node: db.NodeInstance) => {
-    return this.models.Node.update(node);
+    return node.save();
   }
 }
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -38,7 +38,7 @@ interface NodeConnectionIterator {
 class Pool extends EventEmitter {
   private nodes: NodeList;
   private peers: PeerList = new PeerList();
-  private server: Server = net.createServer();
+  private server?: Server;
   private connected = false;
   /** The local handshake data to be sent to newly connected peers. */
   private handshakeData!: HandshakeState;
@@ -52,6 +52,7 @@ class Pool extends EventEmitter {
 
     if (config.listen) {
       this.listenPort = config.port;
+      this.server = net.createServer();
       this.addresses = [];
       config.addresses.forEach((addressString) => {
         const address = addressUtils.fromString(addressString, config.port);
@@ -80,9 +81,9 @@ class Pool extends EventEmitter {
     await this.nodes.load();
     await this.connectNodes(this.nodes);
 
-    if (this.listenPort) {
-      this.bindServer(this.server);
-      this.listen(this.listenPort);
+    if (this.server && this.listenPort) {
+      this.bindServer();
+      await this.listen(this.listenPort);
     }
 
     this.connected = true;
@@ -93,7 +94,7 @@ class Pool extends EventEmitter {
       return;
     }
 
-    if (this.listenPort) {
+    if (this.server && this.server.listening) {
       await this.unlisten();
     }
 
@@ -180,7 +181,6 @@ class Pool extends EventEmitter {
   private openPeer = async (peer: Peer, nodePubKey?: string): Promise<void> => {
     this.bindPeer(peer);
     await peer.open(this.handshakeData, nodePubKey);
-    this.peers.add(peer);
   }
 
   public closePeer = async (nodePubKey: string): Promise<void> => {
@@ -270,6 +270,8 @@ class Pool extends EventEmitter {
       // TODO: Penalize peers that attempt to create duplicate connections to us
       peer.close();
     } else {
+      this.peers.add(peer);
+
       // request peer's orders and known nodes
       peer.sendPacket(new GetOrdersPacket());
       peer.sendPacket(new GetNodesPacket());
@@ -286,18 +288,13 @@ class Pool extends EventEmitter {
     }
   }
 
-  private bindServer = (server: Server) => {
-    server.on('error', (err) => {
-      console.log('err: ' + err);
+  private bindServer = () => {
+    this.server!.on('error', (err) => {
+      this.logger.error(err);
     });
 
-    server.on('connection', async (socket) => {
+    this.server!.on('connection', async (socket) => {
       await this.handleSocket(socket);
-    });
-
-    server.on('listening', () => {
-      const { address, port } = this.server.address();
-      this.logger.info(`p2p server listening on ${address}:${port}`);
     });
   }
 
@@ -336,12 +333,36 @@ class Pool extends EventEmitter {
     this.peers.forEach(peer => peer.close());
   }
 
-  private listen = (port: number): void => {
-    this.server.listen(port, '0.0.0.0');
+  /**
+   * Start listening for incoming p2p connections on the given port.
+   * @return a promise that resolves once the server is listening, or rejects if it fails to listen
+   */
+  private listen = (port: number) => {
+    return new Promise<void>((resolve, reject) => {
+      const listenErrHandler = (err: Error) => {
+        reject(err);
+      };
+
+      this.server!.listen(port, '0.0.0.0').on('listening', () => {
+        const { address, port } = this.server!.address();
+        this.logger.info(`p2p server listening on ${address}:${port}`);
+
+        this.server!.removeListener('error', listenErrHandler);
+        resolve();
+      }).on('error', listenErrHandler);
+    });
   }
 
-  private unlisten = async (): Promise<void> => {
-    this.server.close();
+  /**
+   * Stop listening for incoming p2p connections.
+   * @return a promise that resolves once the server is no longer listening
+   */
+  private unlisten = () => {
+    return new Promise<void>((resolve) => {
+      this.server!.close(() => {
+        resolve();
+      });
+    });
   }
 }
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -279,6 +279,9 @@ class Pool extends EventEmitter {
           nodePubKey: peer.nodePubKey!,
           addresses: peer.addresses!,
         });
+      } else {
+        // the node is known, update its listening addresses
+        await this.nodes.updateAddresses(peer.nodePubKey!, peer.addresses);
       }
     }
   }

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -1,0 +1,108 @@
+import chai, { expect } from 'chai';
+import Xud from '../../lib/Xud';
+import chaiAsPromised from 'chai-as-promised';
+import Pool from '../../lib/p2p/Pool';
+import Logger from '../../lib/Logger';
+import DB from '../../lib/db/DB';
+import Config from '../../lib/Config';
+import NodeKey from '../../lib/nodekey/NodeKey';
+import Peer from '../../lib/p2p/Peer';
+import { Address } from '../../lib/types/p2p';
+
+chai.use(chaiAsPromised);
+
+describe('P2P Pool Tests', () => {
+  let db: DB;
+  let pool: Pool;
+  const loggers = Logger.createLoggers();
+  const nodePubKeyOne = NodeKey['generate']().nodePubKey;
+
+  const createPeer = (nodePubKey: string, addresses: Address[]) => {
+    const peer = new Peer(loggers.p2p);
+    peer.socketAddress = addresses[0];
+    peer['handshakeState'] = {
+      addresses,
+      nodePubKey,
+      version: 'test',
+      pairs: [],
+    };
+    pool['bindPeer'](peer);
+
+    return peer;
+  };
+
+  before(async () => {
+    const config = new Config({
+      p2p: {
+        listen: false,
+      },
+      db: {
+        database: 'xud_test',
+      },
+    });
+    config.load();
+    db = new DB(config.testDb, loggers.db);
+    pool = new Pool(config.p2p, loggers.p2p, db);
+
+    await db.init();
+    await pool.init({
+      nodePubKey: 'test',
+      version: 'test',
+      pairs: [],
+    });
+  });
+
+  it('should handle an opened peer', async () => {
+    const currentNodeCount = pool['nodes'].count;
+
+    const addresses = [{ host: '123.123.123.123', port: 8885 }];
+    const peer = createPeer(nodePubKeyOne, addresses);
+
+    const handleOpenPromise = pool['handleOpen'](peer);
+    expect(handleOpenPromise).to.be.fulfilled;
+    await handleOpenPromise;
+    expect(pool['nodes'].count).to.equal(currentNodeCount + 1);
+    expect(pool['nodes'].has(nodePubKeyOne)).to.be.true;
+
+    expect(pool['peers'].has(nodePubKeyOne)).to.be.true;
+
+    const nodeInstance = await db.models.Node.find({
+      where: {
+        nodePubKey: nodePubKeyOne,
+      },
+    });
+    expect(nodeInstance).to.not.be.undefined;
+    expect(nodeInstance!.addresses!).to.have.length(1);
+    expect(nodeInstance!.addresses![0].host).to.equal(addresses[0].host);
+  });
+
+  it('should close a peer', async () => {
+    const closePromise = pool.closePeer(nodePubKeyOne);
+    expect(closePromise).to.be.fulfilled;
+    await closePromise;
+    expect(pool['peers'].has(nodePubKeyOne)).to.be.false;
+    expect(pool['peers']['peers'].size).to.equal(0);
+  });
+
+  it('should update a node on new handshake', async () => {
+    const addresses = [{ host: '86.75.30.9', port: 8885 }];
+    const peer = createPeer(nodePubKeyOne, addresses);
+
+    await pool['handleOpen'](peer);
+
+    const nodeInstance = await db.models.Node.find({
+      where: {
+        nodePubKey: nodePubKeyOne,
+      },
+    });
+    expect(nodeInstance).to.not.be.undefined;
+    expect(nodeInstance!.addresses!).to.have.length(1);
+    expect(nodeInstance!.addresses![0].host).to.equal(addresses[0].host);
+  });
+
+  after(async () => {
+    await db.models.Node.truncate(); // clean up the db
+    await db.close();
+    await pool.disconnect();
+  });
+});

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -80,6 +80,7 @@ describe('P2P Sanity Tests', () => {
   });
 
   after(async () => {
+    await nodeOne['db'].models.Node.truncate(); // clean up the db
     await Promise.all([nodeOne.shutdown(), nodeTwo.shutdown()]);
   });
 });


### PR DESCRIPTION
This makes it so the database is updated with listening addresses from a node after the handshake, even if we already had a record for that node in the db. Currently, once a row is written to the nodes table it won't be updated, but it makes sense that we should update with the freshest info we've received from a peer.

I also added a new test suite for `Pool` with a couple of test cases that test this new functionality.

Lastly I caught a few issues during testing with the way we were initializing and shutting down the Pool, the `listen` and `unlisten` methods were not resolving properly, and fixed those here as well.