### PR TITLE
Service tests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -607,7 +607,7 @@
 | GetOrders | [GetOrdersRequest](#xudrpc.GetOrdersRequest) | [GetOrdersResponse](#xudrpc.GetOrdersResponse) | Get a list of standing orders from the order book. |
 | ListPeers | [ListPeersRequest](#xudrpc.ListPeersRequest) | [ListPeersResponse](#xudrpc.ListPeersResponse) | Get a list of connected peers. |
 | PlaceOrder | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderResponse](#xudrpc.PlaceOrderResponse) | Add an order to the order book. If price is zero or unspecified a market order will get added. |
-| Shutdown | [ShutdownRequest](#xudrpc.ShutdownRequest) | [ShutdownResponse](#xudrpc.ShutdownResponse) | Shutdown the xud daemon. |
+| Shutdown | [ShutdownRequest](#xudrpc.ShutdownRequest) | [ShutdownResponse](#xudrpc.ShutdownResponse) | Begin shutting down xud. |
 | SubscribePeerOrders | [SubscribePeerOrdersRequest](#xudrpc.SubscribePeerOrdersRequest) | [SubscribePeerOrdersResponse](#xudrpc.SubscribePeerOrdersResponse) | Subscribe to peer order events. |
 | SubscribeSwaps | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SubscribeSwapsResponse](#xudrpc.SubscribeSwapsResponse) | Subscribe executed swaps. |
 

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -277,9 +277,9 @@ class GrpcService {
     }
   }
 
-  public shutdown: grpc.handleUnaryCall<xudrpc.ShutdownRequest, xudrpc.ShutdownResponse> = async (_, callback) => {
+  public shutdown: grpc.handleUnaryCall<xudrpc.ShutdownRequest, xudrpc.ShutdownResponse> = (_, callback) => {
     try {
-      const shutdownResponse = await this.service.shutdown();
+      const shutdownResponse = this.service.shutdown();
       const response = new xudrpc.ShutdownResponse();
       response.setResult(shutdownResponse);
       callback(null, response);

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -113,8 +113,8 @@ class Pool extends EventEmitter {
     await this.connectNodes(this.nodes);
 
     if (this.server && this.listenPort) {
-      this.bindServer();
       await this.listen(this.listenPort);
+      this.bindServer();
     }
 
     this.connected = true;
@@ -125,6 +125,7 @@ class Pool extends EventEmitter {
       return;
     }
 
+    // ensure we stop listening for new peers before disconnecting from peers
     if (this.server && this.server.listening) {
       await this.unlisten();
     }

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -237,7 +237,7 @@
     },
     "/v1/shutdown": {
       "post": {
-        "summary": "Shutdown the xud daemon.",
+        "summary": "Begin shutting down xud.",
         "operationId": "Shutdown",
         "responses": {
           "200": {

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -380,7 +380,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_PlaceOrderResponse,
     responseDeserialize: deserialize_xudrpc_PlaceOrderResponse,
   },
-  // Shutdown the xud daemon. 
+  // Begin shutting down xud. 
   shutdown: {
     path: '/xudrpc.Xud/Shutdown',
     requestStream: false,

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -22,10 +22,10 @@ export type ServiceComponents = {
   raidenClient: RaidenClient;
   pool: Pool;
   config: Config
-  /** The function to be called to shutdown the parent process */
-  shutdown: () => Promise<string>;
   /** The version of the local xud instance. */
   version: string;
+  /** The function to be called to shutdown the parent process */
+  shutdown: () => string;
 };
 
 type XudInfo = {
@@ -58,7 +58,7 @@ const argChecks = {
 
 /** Class containing the available RPC methods for XUD */
 class Service extends EventEmitter {
-  public shutdown: () => Promise<string>;
+  public shutdown: () => string;
   private orderBook: OrderBook;
   private lndBtcClient: LndClient;
   private lndLtcClient: LndClient;

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -75,7 +75,7 @@ service Xud {
     };
   }
   
-  /* Shutdown the xud daemon. */
+  /* Begin shutting down xud. */
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse) {
     option (google.api.http) = {
       post: "/v1/shutdown"

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -1,5 +1,4 @@
 import chai, { expect } from 'chai';
-import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import Pool from '../../lib/p2p/Pool';
 import Logger from '../../lib/Logger';
@@ -33,17 +32,17 @@ describe('P2P Pool Tests', () => {
 
   before(async () => {
     const config = new Config();
-    config.load({ p2p: {
-      listen: false,
-    },
-      db: {
-        database: 'xud_test',
+    config.load({
+      p2p: {
+        listen: false,
       },
     });
     db = new DB(config.testDb, loggers.db);
+    await db.init();
+    await db.models.Node.truncate();
+
     pool = new Pool(config.p2p, loggers.p2p, db);
 
-    await db.init();
     await pool.init({
       nodePubKey: 'test',
       version: 'test',
@@ -100,7 +99,7 @@ describe('P2P Pool Tests', () => {
   });
 
   after(async () => {
-    await db.models.Node.truncate(); // clean up the db
+    await db.models.Node.truncate();
     await db.close();
     await pool.disconnect();
   });

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -1,0 +1,83 @@
+import chai, { expect } from 'chai';
+import Xud from '../../lib/Xud';
+import chaiAsPromised from 'chai-as-promised';
+import Logger from '../../lib/Logger';
+import Service from '../../lib/service/Service';
+
+chai.use(chaiAsPromised);
+
+describe('API Service', () => {
+  let xud: Xud;
+  let service: Service;
+
+  const placeOrderArgs = {
+    orderId: '1',
+    pairId: 'BTC/LTC',
+    price: 100,
+    quantity: 1,
+  };
+
+  before(async () => {
+    const loggers = Logger.createLoggers();
+    const config = {
+      p2p: {
+        listen: false,
+      },
+      rpc: {
+        disable: true,
+      },
+      lndbtc: {
+        disable: true,
+      },
+      lndltc: {
+        disable: true,
+      },
+      raiden: {
+        disable: true,
+      },
+      db: {
+        database: 'xud_test',
+      },
+    };
+
+    xud = new Xud();
+    await xud.start(config);
+    service = xud.service;
+  });
+
+  it('should place an order', () => {
+    expect(service.placeOrder(placeOrderArgs)).to.be.fulfilled;
+  });
+
+  it('should get orders', async () => {
+    const args = {
+      pairId: 'BTC/LTC',
+      maxResults: 0,
+    };
+    const orders = service.getOrders(args);
+    expect(orders.ownOrders.buyOrders).to.have.length(1);
+    expect(orders.ownOrders.buyOrders[0].price).to.equal(placeOrderArgs.price);
+    expect(orders.ownOrders.buyOrders[0].quantity).to.equal(placeOrderArgs.quantity);
+    expect(orders.ownOrders.buyOrders[0].pairId).to.equal(placeOrderArgs.pairId);
+  });
+
+  it('should cancel an order', async () => {
+    const args = {
+      pairId: 'BTC/LTC',
+      orderId: '1',
+    };
+    const cancelOrderPromise = service.cancelOrder(args);
+    expect(cancelOrderPromise).to.be.fulfilled;
+    const canceledOrder = await cancelOrderPromise;
+    expect(canceledOrder.canceled).to.be.true;
+  });
+
+  it('should shutdown', async () => {
+    service.shutdown();
+    const shutdownPromise = new Promise((resolve) => {
+      xud.on('shutdown', () => resolve());
+    });
+    expect(shutdownPromise).to.be.fulfilled;
+    await shutdownPromise;
+  });
+});

--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -44,6 +44,6 @@ describe('WebProxy', () => {
   });
 
   after(async () => {
-    await xud.shutdown();
+    await xud['shutdown']();
   });
 });

--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -13,6 +13,9 @@ describe('WebProxy', () => {
         disable: false,
         port: 8080,
       },
+      p2p: {
+        listen: false,
+      },
       lndbtc: {
         disable: true,
       },


### PR DESCRIPTION
This creates a test suite with a sampling of some test cases for our API service methods which are exposed via gRPC, and is a step towards resolving #119.

Running these tests actually revealed a bug with the shutdown call, which I actually accidentally introduced myself in #332. As part of that PR I added an `await` statement to the shutdown procedure to wait on the grpc server (among other things) to close before returning, but the grpc server wouldn't close until the method returned a response, thus they were waiting on each other and would hang. The first commit fixes that and adds a `shutdown` event for the `Xud` class to notify listeners when the server has completely shut down, it's used in the service shutdown test.