### PR TITLE
Refactor placeOrder

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -446,7 +446,10 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| order | [Order](#xudrpc.Order) |  |  |
+| price | [double](#double) |  | The price of the order, precise to 6 decimal places. |
+| quantity | [double](#double) |  | The quantity of the order, precise to 6 decimal places. |
+| pair_id | [string](#string) |  | The trading pair that the order is for |
+| order_id | [string](#string) |  | The local id to assign to the order |
 
 
 

--- a/lib/cli/commands/orders/limitorder.ts
+++ b/lib/cli/commands/orders/limitorder.ts
@@ -24,13 +24,10 @@ export const builder = {
 export const handler = (argv: Arguments) => {
   const request = new PlaceOrderRequest();
 
-  const order = new Order();
-  order.setPairId(argv.pair_id);
-  order.setLocalId(argv.order_id);
-  order.setQuantity(argv.quantity);
-  order.setPrice(argv.price);
-
-  request.setOrder(order);
+  request.setPairId(argv.pair_id);
+  request.setOrderId(argv.order_id);
+  request.setQuantity(argv.quantity);
+  request.setPrice(argv.price);
 
   loadXudClient(argv).placeOrder(request, callback);
 };

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -632,8 +632,23 @@
     "xudrpcPlaceOrderRequest": {
       "type": "object",
       "properties": {
-        "order": {
-          "$ref": "#/definitions/xudrpcOrder"
+        "price": {
+          "type": "number",
+          "format": "double",
+          "description": "The price of the order, precise to 6 decimal places."
+        },
+        "quantity": {
+          "type": "number",
+          "format": "double",
+          "description": "The quantity of the order, precise to 6 decimal places."
+        },
+        "pair_id": {
+          "type": "string",
+          "title": "The trading pair that the order is for"
+        },
+        "order_id": {
+          "type": "string",
+          "title": "The local id to assign to the order"
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -695,11 +695,17 @@ export namespace Peer {
 }
 
 export class PlaceOrderRequest extends jspb.Message { 
+    getPrice(): number;
+    setPrice(value: number): void;
 
-    hasOrder(): boolean;
-    clearOrder(): void;
-    getOrder(): Order | undefined;
-    setOrder(value?: Order): void;
+    getQuantity(): number;
+    setQuantity(value: number): void;
+
+    getPairId(): string;
+    setPairId(value: string): void;
+
+    getOrderId(): string;
+    setOrderId(value: string): void;
 
 
     serializeBinary(): Uint8Array;
@@ -714,7 +720,10 @@ export class PlaceOrderRequest extends jspb.Message {
 
 export namespace PlaceOrderRequest {
     export type AsObject = {
-        order?: Order.AsObject,
+        price: number,
+        quantity: number,
+        pairId: string,
+        orderId: string,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -4778,7 +4778,10 @@ proto.xudrpc.PlaceOrderRequest.prototype.toObject = function(opt_includeInstance
  */
 proto.xudrpc.PlaceOrderRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    order: (f = msg.getOrder()) && proto.xudrpc.Order.toObject(includeInstance, f)
+    price: +jspb.Message.getFieldWithDefault(msg, 1, 0.0),
+    quantity: +jspb.Message.getFieldWithDefault(msg, 2, 0.0),
+    pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
+    orderId: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -4816,9 +4819,20 @@ proto.xudrpc.PlaceOrderRequest.deserializeBinaryFromReader = function(msg, reade
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = new proto.xudrpc.Order;
-      reader.readMessage(value,proto.xudrpc.Order.deserializeBinaryFromReader);
-      msg.setOrder(value);
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setPrice(value);
+      break;
+    case 2:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setQuantity(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPairId(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOrderId(value);
       break;
     default:
       reader.skipField();
@@ -4849,44 +4863,94 @@ proto.xudrpc.PlaceOrderRequest.prototype.serializeBinary = function() {
  */
 proto.xudrpc.PlaceOrderRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getOrder();
-  if (f != null) {
-    writer.writeMessage(
+  f = message.getPrice();
+  if (f !== 0.0) {
+    writer.writeDouble(
       1,
-      f,
-      proto.xudrpc.Order.serializeBinaryToWriter
+      f
+    );
+  }
+  f = message.getQuantity();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      2,
+      f
+    );
+  }
+  f = message.getPairId();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+  f = message.getOrderId();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
     );
   }
 };
 
 
 /**
- * optional Order order = 1;
- * @return {?proto.xudrpc.Order}
+ * optional double price = 1;
+ * @return {number}
  */
-proto.xudrpc.PlaceOrderRequest.prototype.getOrder = function() {
-  return /** @type{?proto.xudrpc.Order} */ (
-    jspb.Message.getWrapperField(this, proto.xudrpc.Order, 1));
+proto.xudrpc.PlaceOrderRequest.prototype.getPrice = function() {
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 1, 0.0));
 };
 
 
-/** @param {?proto.xudrpc.Order|undefined} value */
-proto.xudrpc.PlaceOrderRequest.prototype.setOrder = function(value) {
-  jspb.Message.setWrapperField(this, 1, value);
-};
-
-
-proto.xudrpc.PlaceOrderRequest.prototype.clearOrder = function() {
-  this.setOrder(undefined);
+/** @param {number} value */
+proto.xudrpc.PlaceOrderRequest.prototype.setPrice = function(value) {
+  jspb.Message.setField(this, 1, value);
 };
 
 
 /**
- * Returns whether this field is set.
- * @return {!boolean}
+ * optional double quantity = 2;
+ * @return {number}
  */
-proto.xudrpc.PlaceOrderRequest.prototype.hasOrder = function() {
-  return jspb.Message.getField(this, 1) != null;
+proto.xudrpc.PlaceOrderRequest.prototype.getQuantity = function() {
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 2, 0.0));
+};
+
+
+/** @param {number} value */
+proto.xudrpc.PlaceOrderRequest.prototype.setQuantity = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string pair_id = 3;
+ * @return {string}
+ */
+proto.xudrpc.PlaceOrderRequest.prototype.getPairId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.PlaceOrderRequest.prototype.setPairId = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * optional string order_id = 4;
+ * @return {string}
+ */
+proto.xudrpc.PlaceOrderRequest.prototype.getOrderId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.PlaceOrderRequest.prototype.setOrderId = function(value) {
+  jspb.Message.setField(this, 4, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -270,14 +270,20 @@ class Service extends EventEmitter {
    * Add an order to the order book.
    * If price is zero or unspecified a market order will get added.
    */
-  public placeOrder = async (args: { order?: OwnOrder }) => {
-    const { order } = args;
-    // TODO: change placeOrder api call to not use an order object and remove assertions below
-    argChecks.PRICE_NON_NEGATIVE(order!);
-    argChecks.NON_ZERO_QUANTITY(order!);
-    argChecks.HAS_PAIR_ID(order!);
+  public placeOrder = async (args: { pairId: string, price: number, quantity: number, orderId: string }) => {
+    const { pairId, price, quantity, orderId } = args;
+    argChecks.PRICE_NON_NEGATIVE(args);
+    argChecks.NON_ZERO_QUANTITY(args);
+    argChecks.HAS_PAIR_ID(args);
 
-    return order!.price > 0 ? this.orderBook.addLimitOrder(order!) : this.orderBook.addMarketOrder(order!);
+    const order = {
+      pairId,
+      price,
+      quantity,
+      localId: orderId,
+    };
+
+    return price > 0 ? this.orderBook.addLimitOrder(order) : this.orderBook.addMarketOrder(order);
   }
 
   /*

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -244,7 +244,14 @@ message Peer {
 }
 
 message PlaceOrderRequest {
-  Order order = 1 [json_name = "order"];
+  // The price of the order, precise to 6 decimal places.
+  double price = 1 [json_name = "price"];
+  // The quantity of the order, precise to 6 decimal places.
+  double quantity = 2 [json_name = "quantity"];
+  // The trading pair that the order is for
+  string pair_id = 3 [json_name = "pair_id"];
+  // The local id to assign to the order
+  string order_id = 4 [json_name = "order_id"];
 }
 message PlaceOrderResponse {
   // A list of orders matching the newly placed order


### PR DESCRIPTION
This changes the placeOrder proto definition to only have fields that are used for placing orders.