### PR TITLE
Add tslint whitespace rules

### DIFF
--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -75,7 +75,7 @@ describe('P2P Sanity Tests', () => {
   });
 
   it('should fail connecting to a non-existing node', async () => {
-    const result = await nodeOne.service.connect({ host:'localhost', port: 9003, nodePubKey: 'notarealnodepubkey' });
+    const result = await nodeOne.service.connect({ host: 'localhost', port: 9003, nodePubKey: 'notarealnodepubkey' });
     expect(result).to.be.equal('Not connected');
   });
 

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,22 @@
         "parameter": "nospace",
         "property-declaration": "nospace",
         "variable-declaration": "nospace"
+      },
+      {
+        "call-signature": "onespace",
+        "index-signature": "onespace",
+        "parameter": "onespace",
+        "property-declaration": "onespace",
+        "variable-declaration": "onespace"
       }
+    ],
+    "whitespace": [true,
+      "check-type-operator",
+      "check-module",
+      "check-rest-spread",
+      "check-type",
+      "check-preblock",
+      "check-branch", "check-decl", "check-operator", "check-preblock", "check-separator" // preserved from tslint-config-airbnb
     ],
     "member-access": true,
     "member-ordering": [


### PR DESCRIPTION
This adds some tslint rules around whitespace that were already de facto rules - as you can see there was only one place in the entire codebase that needed to be corrected - so that they will be enforced automatically going forward.