### PR TITLE
Add tslint circular import rule

### DIFF
--- a/lib/types/p2p.ts
+++ b/lib/types/p2p.ts
@@ -1,12 +1,13 @@
-import { NodeFactory } from './db';
-
 export type Address = {
   host: string;
   port: number;
 };
 
 /** Information used for connecting to a remote node. */
-export type NodeConnectionInfo = NodeFactory;
+export type NodeConnectionInfo = {
+  nodePubKey: string;
+  addresses: Address[];
+};
 
 export type HandshakeState = {
   version: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8010,6 +8010,12 @@
         "tsutils": "^2.12.1 <2.29.0"
       }
     },
+    "tslint-no-circular-imports": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tslint-no-circular-imports/-/tslint-no-circular-imports-0.5.0.tgz",
+      "integrity": "sha1-3OZZwCQWX8G905pvAUeetL4zz/4=",
+      "dev": true
+    },
     "tsutils": {
       "version": "2.26.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.1.tgz",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "ts-node": "^6.0.2",
     "tslint": "^5.10.0",
     "tslint-config-airbnb": "^5.10.0",
+    "tslint-no-circular-imports": "^0.5.0",
     "typedoc": "^0.11.1",
     "typescript": "^2.9.1"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tslint-config-airbnb",
+  "extends": ["tslint-config-airbnb", "tslint-no-circular-imports"],
   "rules": {
     "variable-name": false,
     "import-name": false,


### PR DESCRIPTION
This adds a tslint plug-in and rule to check for circular imports, which we have been trying to avoid in our codebase. The rule caught one violation, a minor one with the `NodeConnectionInfo` for `NodeFactory`. I corrected it just by respecifying the type from scratch, which is not too bad because it's a short type definition.