### PR TITLE
Set lnd pubkeys on handshake

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -61,14 +61,15 @@ class Xud {
       await this.db.init();
 
       const initPromises: Promise<void>[] = [];
+
       // setup LND clients and connect if configured
       this.lndbtcClient = new LndClient(this.config.lndbtc, loggers.lnd);
       if (!this.lndbtcClient.isDisabled()) {
-        initPromises.push(this.lndbtcClient.connect());
+        initPromises.push(this.lndbtcClient.verifyConnection());
       }
       this.lndltcClient = new LndClient(this.config.lndltc, loggers.lnd);
       if (!this.lndltcClient.isDisabled()) {
-        initPromises.push(this.lndltcClient.connect());
+        initPromises.push(this.lndltcClient.verifyConnection());
       }
 
       // setup raiden client and connect if configured
@@ -90,6 +91,8 @@ class Xud {
         pairs: this.orderBook.pairIds,
         nodePubKey: this.nodeKey.nodePubKey,
         raidenAddress: this.raidenClient.address,
+        lndbtcPubKey: this.lndbtcClient.pubKey,
+        lndltcPubKey: this.lndltcClient.pubKey,
       });
 
       this.service = new Service(loggers.global, {

--- a/lib/types/p2p.ts
+++ b/lib/types/p2p.ts
@@ -14,6 +14,8 @@ export type HandshakeState = {
   addresses?: Address[];
   pairs: string[];
   raidenAddress?: string;
+  lndbtcPubKey?: string;
+  lndltcPubKey?: string;
 };
 
 export function isHandshakeState(obj: any): obj is HandshakeState {


### PR DESCRIPTION
This refactors the lnd `connect` method to store the lnd server's pub key and renames it `verifyConnection`. It then saves the lnd pub key as part of the node's handshake info to be shared with peers.