### PR TITLE
Add aliases for db name and webproxy port

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -17,6 +17,7 @@ const { argv } = require('yargs')
     'db.database': {
       describe: 'SQL database name',
       type: 'string',
+      alias: 'd',
     },
     'db.host': {
       describe: 'Hostname for SQL database',
@@ -116,6 +117,7 @@ const { argv } = require('yargs')
     'webproxy.port': {
       describe: 'Port for web proxy server',
       type: 'number',
+      alias: 'w',
     },
   });
 


### PR DESCRIPTION
Closes #356. This adds aliases for `db.database` and `webproxy.port`, the other common arguments you'd need to set when wanting to run two xud instances on the same machine. By default running `xud` will use p2p port 8885, rpc port 8886, db name xud, and web proxy port 8080. With this you can run `xud -p 9885 -r 9886 -d xud2 -w 9080` on separate ports and a different database without needing to do too much typing.

Edit: You'd actually need to specify the xud directory too, where the node key is stored, which already has its own alias. So something like `xud -p 9885 -r 9886 -d xud2 -w 9080 -x ~/.xud2` would work. 