### PR TITLE
Fix custom folder config

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -125,6 +125,6 @@ delete argv.version;
 delete argv.help;
 delete argv.$0;
 
-const xud = new Xud(argv);
+const xud = new Xud();
 
-xud.start();
+xud.start(argv);

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -10,7 +10,6 @@ import GrpcWebProxyServer from './grpc/webproxy/GrpcWebProxyServer';
 import Pool from './p2p/Pool';
 import NodeKey from './nodekey/NodeKey';
 import Service from './service/Service';
-import { Arguments } from 'yargs';
 
 const version: string = require('../package.json').version;
 
@@ -37,17 +36,17 @@ class Xud {
 
   /**
    * Create an Exchange Union daemon.
-   * @param args optional command line arguments to override configuration parameters.
    */
-  constructor(args?: Arguments | Object)  {
-    this.config = new Config(args);
+  constructor()  {
+    this.config = new Config();
   }
 
   /**
    * Start all processes necessary for the operation of an Exchange Union node.
+   * @param args optional arguments to override configuration parameters.
    */
-  public start = async () => {
-    this.config.load();
+  public start = async (args?: { [argName: string]: any }) => {
+    this.config.load(args);
     const loggers = Logger.createLoggers(this.config.instanceId);
     this.logger = loggers.global;
     this.logger.info('config loaded');

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -32,15 +32,14 @@ describe('P2P Pool Tests', () => {
   };
 
   before(async () => {
-    const config = new Config({
-      p2p: {
-        listen: false,
-      },
+    const config = new Config();
+    config.load({ p2p: {
+      listen: false,
+    },
       db: {
         database: 'xud_test',
       },
     });
-    config.load();
     db = new DB(config.testDb, loggers.db);
     pool = new Pool(config.p2p, loggers.p2p, db);
 

--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -27,8 +27,8 @@ describe('WebProxy', () => {
       },
     };
 
-    xud = new Xud(config);
-    await xud.start();
+    xud = new Xud();
+    await xud.start(config);
   });
 
   it('should respond with http status 200', (done) => {

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -35,12 +35,12 @@ describe('P2P Sanity Tests', () => {
 
   before(async () => {
     nodeOneConfig = createConfig(1, 9001);
-    nodeOne = new Xud(nodeOneConfig);
+    nodeOne = new Xud();
 
     nodeTwoConfig = createConfig(2, 9002);
-    nodeTwo = new Xud(nodeTwoConfig);
+    nodeTwo = new Xud();
 
-    await Promise.all([nodeTwo.start(), nodeOne.start()]);
+    await Promise.all([nodeOne.start(nodeOneConfig), nodeTwo.start(nodeTwoConfig)]);
   });
 
   it('should connect successfully', async () => {


### PR DESCRIPTION
This ensures that if a custom xudir is specified via the command line, the config file from that folder will be loaded rather than the config file in the default location. Currently, the config file in the default location will always be used.