### PR TITLE
Resolve peer-pool circular import

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -84,7 +84,7 @@ class Xud extends EventEmitter {
       if (!this.raidenClient.isDisabled()) {
         initPromises.push(this.raidenClient.init());
       }
-      this.pool = new Pool(this.config.p2p, loggers.p2p, this.db, this.lndbtcClient, this.lndltcClient);
+      this.pool = new Pool(this.config.p2p, loggers.p2p, this.db);
 
       this.orderBook = new OrderBook(this.logger, this.db.models, this.pool, this.lndbtcClient, this.raidenClient);
       initPromises.push(this.orderBook.init());

--- a/lib/orderbook/SwapDeals.ts
+++ b/lib/orderbook/SwapDeals.ts
@@ -1,24 +1,23 @@
-import Logger from '../Logger';
-import { CurrencyType, SwapDealRole } from '../types/enums';
+import { SwapDealRole } from '../types/enums';
 
-export type SwapDeal = {
-  // TODO: consider to change myRole to isTaker or is Maker and make it boolean
-  myRole: SwapDealRole;
-  /** global order it in XU network */
+type SwapDeal = {
+  /** The role of the local node in the swap. */
+  myRole: SwapDealRole; // TODO: consider changing myRole to boolean named isTaker or isMaker
+  /** Global order id in the XU network. */
   orderId?: string;
   takerDealId: string;
   takerAmount: number;
-  /** takerCoin is the name of the coin the taker is expecting to get */
-  takerCoin: CurrencyType;
+  /** The currency the taker is expecting to receive. */
+  takerCurrency: string;
   takerPubKey: string;
   makerDealId?: string;
   makerAmount: number;
-  /** makerCoin is the name of the coin the maker is expecting to get */
-  // TODO: consider to use currency instead of CurrencyType
-  makerCoin: CurrencyType;
+  /** The currency the maker is expecting to receive. */
+  makerCurrency: string;
   makerPubKey?: string;
+  /** The hash of the preimage. */
   r_hash?: string;
-  preImage?: string;
+  r_preimage?: string;
   createTime: number;
   executeTime?: number;
   competionTime?: number
@@ -26,9 +25,6 @@ export type SwapDeal = {
 
 export class SwapDeals {
   private deals: SwapDeal[] = [];
-
-  constructor(private logger: Logger) {
-  }
 
   public get = (role: SwapDealRole, dealId: string): SwapDeal | undefined => {
     for (const deal of this.deals) {
@@ -57,3 +53,4 @@ export class SwapDeals {
 }
 
 export default SwapDeals;
+export { SwapDeal };

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -10,11 +10,6 @@ import { Packet, PacketDirection, PacketType } from './packets';
 import { HandshakeState, Address, NodeConnectionInfo } from '../types/p2p';
 import errors from './errors';
 import addressUtils from '../utils/addressUtils';
-// TODO: avoid circular import
-import Pool from './Pool';
-import { CurrencyType, SwapDealRole } from '../types/enums';
-import { SwapDeal } from '../orderbook/SwapDeals';
-import { randomBytes, createHash } from 'crypto';
 
 /** Key info about a peer for display purposes */
 type PeerInfo = {
@@ -91,21 +86,21 @@ class Peer extends EventEmitter {
     };
   }
 
-  constructor(private logger: Logger, private pool: Pool) {
+  constructor(private logger: Logger) {
     super();
 
     this.bindParser(this.parser);
   }
 
   /** Create an outbound connection to a node. */
-  public static fromOutbound(address: Address, logger: Logger, pool: Pool): Peer {
-    const peer = new Peer(logger, pool);
+  public static fromOutbound(address: Address, logger: Logger): Peer {
+    const peer = new Peer(logger);
     peer.connect(address);
     return peer;
   }
 
-  public static fromInbound(socket: Socket, logger: Logger, pool: Pool): Peer {
-    const peer = new Peer(logger, pool);
+  public static fromInbound(socket: Socket, logger: Logger): Peer {
+    const peer = new Peer(logger);
     peer.accept(socket);
     return peer;
   }
@@ -500,22 +495,6 @@ class Peer extends EventEmitter {
           this.handlePing(packet);
           break;
         }
-        case PacketType.DEAL_REQUEST: {
-          this.handleDealRequest(packet);
-          break;
-        }
-        case PacketType.DEAL_RESPONSE: {
-          this.handleDealResponse(packet);
-          break;
-        }
-        case PacketType.SWAP_REQUEST: {
-          this.handleSwapRequest(packet);
-          break;
-        }
-        case PacketType.SWAP_RESPONSE: {
-          this.handleSwapResponse(packet);
-          break;
-        }
         default:
           this.emit('packet', packet);
           break;
@@ -568,116 +547,6 @@ class Peer extends EventEmitter {
 
   private handlePing = (packet: packets.PingPacket): void  => {
     this.sendPong(packet.header.id);
-  }
-
-  private handleDealRequest = (request: packets.DealRequest)  => {
-    this.logger.debug('Got this: ' + JSON.stringify(request));
-    const requestBody = request.body;
-    if (!requestBody) {
-      return;
-    }
-    const preImage = randomBytes(32).toString('hex');
-    const hash = createHash('sha256');
-    const r_hash = hash.update(preImage).digest('hex');
-    const makerDealId = randomBytes(32).toString('hex');
-    let makerPubKey: string | undefined;
-
-    switch (requestBody.makerCoin){
-      case CurrencyType.BTC:
-        makerPubKey = this.pool.lndBtcClient ? this.pool.lndBtcClient.pubKey : undefined;
-        break;
-      case CurrencyType.LTC:
-        makerPubKey = this.pool.lndLtcClient ? this.pool.lndLtcClient.pubKey : undefined;
-        break;
-      default:
-        return;
-    }
-
-    if (!makerPubKey) {
-      // TODO: proper error handling.
-      return;
-    }
-
-    const deal: SwapDeal = {
-      makerDealId,
-      makerPubKey,
-      preImage,
-      r_hash,
-      myRole: SwapDealRole.Maker,
-      takerAmount: requestBody.takerAmount,
-      takerCoin: requestBody.takerCoin,
-      takerPubKey: requestBody.takerPubKey,
-      takerDealId: requestBody.takerDealId,
-      makerAmount: requestBody.makerAmount,
-      makerCoin: requestBody.makerCoin,
-      createTime: Date.now(),
-    };
-
-    const body: packets.DealResponsePacketBody = {
-      makerPubKey,
-      makerDealId,
-      r_hash,
-      takerDealId: requestBody.takerDealId,
-    };
-
-    this.pool.swapDeals.add(deal);
-    this.logger.debug('swap deal: ' + JSON.stringify(deal));
-
-    this.logger.debug('sending back to peer: '  + JSON.stringify(body));
-
-    const packet = new packets.DealResponse(body, request.header.id);
-
-    this.sendPacket(packet);
-  }
-
-  private handleDealResponse = (response: packets.DealResponse): void  => {
-    if (!response.body) {
-      return;
-    }
-    const deal = this.pool.swapDeals.get(SwapDealRole.Taker, response.body.takerDealId);
-    if (!deal) {
-      return;
-    }
-
-    deal.makerPubKey = response.body.makerPubKey;
-    deal.makerDealId = response.body.makerDealId;
-    deal.r_hash = response.body.r_hash;
-    this.logger.debug('updated deal: ' + JSON.stringify(this.pool.swapDeals.get(SwapDealRole.Taker, response.body.takerDealId)));
-
-    const body: packets.SwapRequestPacketBody = {
-      makerDealId: deal.makerDealId,
-    };
-    const packet = new packets.SwapRequest(body);
-
-    this.sendPacket(packet);
-  }
-
-  private handleSwapRequest = (request: packets.SwapRequest): void  => {
-    if (!request.body) {
-      return;
-    }
-    const deal = this.pool.swapDeals.get(SwapDealRole.Maker, request.body.makerDealId);
-    if (!deal) {
-      return;
-    }
-    const body: packets.SwapResponsePacketBody = {
-      r_preimage: deal.preImage,
-    };
-    const packet = new packets.SwapResponse(body, request.header.id);
-
-    this.logger.debug('sending back to peer: '  + JSON.stringify(body));
-
-    this.sendPacket(packet);
-  }
-
-  private handleSwapResponse = (response: packets.SwapResponse): void  => {
-    if (!response) {
-      return;
-    }
-    if (!response.body) {
-      return;
-    }
-    this.logger.debug('Swap completed. r_preimage = ' + response.body.r_preimage);
   }
 
   private sendPong = (pingId: string): packets.PongPacket => {

--- a/lib/p2p/packets/types/DealRequestPacket.ts
+++ b/lib/p2p/packets/types/DealRequestPacket.ts
@@ -1,13 +1,12 @@
 import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
-import { CurrencyType } from '../../../types/enums';
 
 export type DealRequestPacketBody = {
   takerDealId: string;
   takerAmount: number;
-  takerCoin: CurrencyType;
+  takerCurrency: string;
   makerAmount: number;
-  makerCoin: CurrencyType;
+  makerCurrency: string;
   /** Taker's lnd pubkey on the taker currency's network. */
   takerPubKey: string;
 };

--- a/lib/p2p/packets/types/SwapResponsePacket.ts
+++ b/lib/p2p/packets/types/SwapResponsePacket.ts
@@ -1,9 +1,8 @@
 import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
-import { CurrencyType } from '../../../types/enums';
 
 export type SwapResponsePacketBody = {
-  r_preimage?: string;
+  r_preimage: string;
 };
 
 class SwapResponsePacket extends Packet<SwapResponsePacketBody> {

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -8,12 +8,6 @@ export enum OrderingDirection {
   ASC = 'ASC',
 }
 
-// TODO: consider to replace CurrencyType with currencies.
-export enum CurrencyType {
-  BTC = 0,
-  LTC = 1,
-}
-
 export enum SwapDealRole {
   Taker = 0,
   Maker = 1,

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -17,7 +17,7 @@ describe('P2P Pool Tests', () => {
   const nodePubKeyOne = NodeKey['generate']().nodePubKey;
 
   const createPeer = (nodePubKey: string, addresses: Address[]) => {
-    const peer = new Peer(loggers.p2p, pool);
+    const peer = new Peer(loggers.p2p);
     peer.socketAddress = addresses[0];
     peer['handshakeState'] = {
       addresses,


### PR DESCRIPTION
This is a follow-up to #359 to resolve a circular import, TODOs, and other unresolved issues as well as fix failing tests.

Reslolves a circular import between the Peer and Pool classes by moving swap packet handling logic into Pool. Also makes some minor naming and logging changes regarding the swap packets.