### PR TITLE
Update tslint-config-airbnb

### DIFF
--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -84,10 +84,9 @@ abstract class Packet<T = any> implements PacketInterface {
    * @returns JSON string representing the packet
    */
   public toRaw(): string {
-    const { body } = this;
     // explicitly set the type on the header before serializing
     const header: PacketHeader = { ...this.header, type: this.type };
-    return body ? JSON.stringify({ header, body }) : JSON.stringify({ header });
+    return this.body ? JSON.stringify({ header, body: this.body }) : JSON.stringify({ header });
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,20 +100,21 @@
       }
     },
     "@fimbul/bifrost": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.6.0.tgz",
-      "integrity": "sha512-BJ19rjnFFCeopEhbyK2Chg3Tq+o5xkjd6dtKxmFhfjwLH1Il2G7Ha4Jel2hpbyZL2Fh9/vrM9U0bpkANAL3pjA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.11.0.tgz",
+      "integrity": "sha512-GspMaQafpaUoXWWOUgNLQ4vsV52tIHUt0zpKPeJUYEyMvOSp7FIcZ1eQa7SK3GTusrEiksjMrDX/fwanigC3nQ==",
       "dev": true,
       "requires": {
-        "@fimbul/ymir": "^0.6.0",
+        "@fimbul/ymir": "^0.11.0",
         "get-caller-file": "^1.0.2",
-        "tslib": "^1.8.1"
+        "tslib": "^1.8.1",
+        "tsutils": "^2.24.0"
       }
     },
     "@fimbul/ymir": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fimbul/ymir/-/ymir-0.6.0.tgz",
-      "integrity": "sha512-iyh/8OiZlzjlPytdjdodA86d38YtRL0sSAx169SMgqP4dsouH2rtctf4Nrg4FYvWoG0e9y9XT3iWL+mjTgYNRw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fimbul/ymir/-/ymir-0.11.0.tgz",
+      "integrity": "sha512-aIYQMCWbBXe7DIofgu+4DLCPDCfqbKhPjBg4ajskJdq6CAJgySz6KyhGLNnKiDYZMF93ZsaEB/y3SafyMi98Mg==",
       "dev": true,
       "requires": {
         "inversify": "^4.10.0",
@@ -7946,56 +7947,67 @@
       }
     },
     "tslint-config-airbnb": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/tslint-config-airbnb/-/tslint-config-airbnb-5.9.2.tgz",
-      "integrity": "sha512-7hT9VoPxT64Xk68+Ak4rhHCaVja6jHFIE6koeHCbZTz1XKUUVX4qZTHUZBLVS/0CmuyDJ1U/8ALyqn+gFxZgbQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-airbnb/-/tslint-config-airbnb-5.10.0.tgz",
+      "integrity": "sha512-66CeYrF+8cHc5HdwOeYYYV7hNauyWKyKJRdPaXRW5hB4m2ofcxDQbuEbhw7TC4sPhar/6BbE/TtrJp58NeI+ag==",
       "dev": true,
       "requires": {
-        "tslint-consistent-codestyle": "^1.10.0",
-        "tslint-eslint-rules": "^5.3.1",
-        "tslint-microsoft-contrib": "~5.0.1"
+        "tslint-consistent-codestyle": "^1.13.3",
+        "tslint-eslint-rules": "^5.4.0",
+        "tslint-microsoft-contrib": "~5.2.0"
       }
     },
     "tslint-consistent-codestyle": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.13.0.tgz",
-      "integrity": "sha512-7fcstphFz9Rw2+SAe32VjtnQEHYEQVSGgEOea9hN/8JMJQGpGkxvVbqxhsXew9vkRtvPQuoj1pQoZ5Eadp4B6A==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.13.3.tgz",
+      "integrity": "sha512-+ocXSNGHqUCUyTJsPhS7xqcC3qf6FyP4vd1jEaXaWaJ5NNN36gKZhqNt3nAWH/YgSV0tYaapjSWMbJQJmn/5MQ==",
       "dev": true,
       "requires": {
-        "@fimbul/bifrost": "^0.6.0",
+        "@fimbul/bifrost": "^0.11.0",
         "tslib": "^1.7.1",
-        "tsutils": "^2.24.0"
+        "tsutils": "^2.27.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "tslint-eslint-rules": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz",
-      "integrity": "sha512-qq2H/AU/FlFbQJKXuxhtIk+ni/nQu9jHHhsFKa6hnA0/n3zl1/RWRc3TVFlL8HfWFMzkST350VeTrFpy1u4OUg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
       "dev": true,
       "requires": {
         "doctrine": "0.7.2",
         "tslib": "1.9.0",
-        "tsutils": "2.8.0"
+        "tsutils": "^3.0.0"
       },
       "dependencies": {
         "tsutils": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
-          "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.0.0.tgz",
+          "integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
           "dev": true,
           "requires": {
-            "tslib": "^1.7.1"
+            "tslib": "^1.8.1"
           }
         }
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.3.tgz",
-      "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.0.tgz",
+      "integrity": "sha512-gHVEIkTcMB9lS6UPEgEznV5ZmyhDs/aHyBS9E89S8aJiK1qLv22DmfCcda53S024T+WQkGAhLHUQF4Qn4nzCAA==",
       "dev": true,
       "requires": {
-        "tsutils": "^2.12.1"
+        "tsutils": "^2.12.1 <2.29.0"
       }
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "nodemon": "^1.17.5",
     "ts-node": "^6.0.2",
     "tslint": "^5.10.0",
-    "tslint-config-airbnb": "^5.9.2",
+    "tslint-config-airbnb": "^5.10.0",
     "typedoc": "^0.11.1",
     "typescript": "^2.9.1"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "max-line-length": [true, 150],
     "no-else-after-return": false,
     "function-name": false,
-    "no-this-assignment": [true, {"allow-destructuring": true}],
+    "no-unused-variable": false, // TODO: rule disabled during early development stages, should be reenabled later
     "align": false,
     "typedef-whitespace": [
       true, {


### PR DESCRIPTION
This includes some linting updates that will be helpful for when we switch to typescript 3.x, and also adds two missing rules from the base airbnb guide, one of which was explicitly defined in our tslint.json and is now removed because it's inherited. Linting unused variables is still disabled for now but a TODO indicates that it should be reenabled once development is relatively stable.