### PR TITLE
parser unit tests

### DIFF
--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -8,6 +8,7 @@ chai.use(chaiAsPromised);
 
 describe('Parser', () => {
   const delimiter = Packet.PROTOCOL_DELIMITER;
+  const timeoutError = 'timeout'
   let parser: Parser;
 
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe('Parser', () => {
 
   function wait(num = 1): Promise<Packet[]> {
     return new Promise((resolve, reject) => {
-      setTimeout(() => reject('timeout'), 0); // expecting results to be fulfilled synchronously
+      setTimeout(() => reject(timeoutError), 0); // expecting results to be fulfilled synchronously
       const parsedPackets: Packet[] = [];
       parser.on('packet', (parsedPacket: Packet) => {
         parsedPackets.push(parsedPacket);
@@ -109,7 +110,7 @@ describe('Parser', () => {
   testConcatenatedAndSplitOnTheDelimiter([pingPacket, helloPacket, pingPacket]);
 
   it(`should not try to parse an empty string`, () => {
-    expect(wait()).to.eventually.be.rejectedWith('timeout');
+    expect(wait()).to.eventually.be.rejectedWith(timeoutError);
 
     parser.feed('');
   });
@@ -122,7 +123,7 @@ describe('Parser', () => {
 
   it(`should buffer a max buffer length`, () => {
     parser = new Parser(delimiter, 10);
-    expect(wait()).to.eventually.be.rejectedWith('timeout');
+    expect(wait()).to.eventually.be.rejectedWith(timeoutError);
 
     parser.feed(Buffer.allocUnsafe(10).toString());
   });

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -8,7 +8,7 @@ chai.use(chaiAsPromised);
 
 describe('Parser', () => {
   const delimiter = Packet.PROTOCOL_DELIMITER;
-  const timeoutError = 'timeout'
+  const timeoutError = 'timeout';
   let parser: Parser;
 
   beforeEach(() => {

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -110,7 +110,7 @@ describe('Parser', () => {
   testConcatenatedAndSplitOnTheDelimiter([pingPacket, helloPacket, pingPacket]);
 
   it(`should not try to parse an empty string`, () => {
-    expect(wait()).to.eventually.be.rejectedWith(timeoutError);
+    expect(wait()).to.be.rejected;
 
     parser.feed('');
   });
@@ -123,7 +123,7 @@ describe('Parser', () => {
 
   it(`should buffer a max buffer length`, () => {
     parser = new Parser(delimiter, 10);
-    expect(wait()).to.eventually.be.rejectedWith(timeoutError);
+    expect(wait()).to.be.rejected;
 
     parser.feed(Buffer.allocUnsafe(10).toString());
   });


### PR DESCRIPTION
addressing #373 

The result of this test isn't consistent for some reason. I saw the problem, fixed it, but when I revoked my changes, the problem didn't reproduce.

I expect it to be a problem with `chai-as-promised` comparing thrown exception object.
I made a fix, so please check it on your env.
If that wouldn't work, i'll change the the expectation for `wait()` to simply get rejected, without any expected error.

If that wouldn't work, then the only think I can think of now is that emitting events isn't always synchronous, so line 20 isn't stable.
