### PR TITLE
Remove Docker image build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ cache:
   directories:
     - "node_modules"
 services:
-  - docker
   - mysql
 
 script:
   - npm run lint
   - npm run test
-  - cd docker/xud && docker build -t exchangeunion/xud .
 
 before_install:
   - mysql -e 'CREATE USER 'xud'@'localhost'';


### PR DESCRIPTION
Docker Image builds are now taken care by [Docker Hub](https://hub.docker.com/r/exchangeunion/xud/) builds are automatically triggered up on push / merge into the master branch. Hence, removed from Travis CI and this should also be speeding up our tests execution times.