### PR TITLE
p2p sanity config fix

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -92,7 +92,7 @@ class Config {
     };
   }
 
-  public load(args?: { [argName: string]: any }) {
+  public load(args?: { [argName: string]: any }): Config {
     if (args && args['xudir']) {
       this.xudir = args['xudir'];
     }
@@ -116,6 +116,8 @@ class Config {
       // override our config file with command line arguments
       deepMerge(this, args);
     }
+
+    return this;
   }
 }
 

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -7,7 +7,7 @@ import Config from '../../lib/Config';
 
 chai.use(chaiAsPromised);
 
-const createConfig = (instanceId: number, p2pPort: number) => ({
+const createConfig = (instanceId: number, p2pPort: number, config: Config) => ({
   instanceId,
   p2p: {
     listen: true,
@@ -26,7 +26,7 @@ const createConfig = (instanceId: number, p2pPort: number) => ({
     disable: true,
   },
   db: {
-    database: instanceId === 1 ? 'xud_test' : `xud_test${instanceId}`,
+    database: `${config.testDb.database}_${instanceId}`,
   },
 });
 
@@ -37,14 +37,14 @@ describe('P2P Sanity Tests', () => {
   let nodeTwo: Xud;
 
   before(async () => {
-    nodeOneConfig = createConfig(1, 9001);
-    nodeTwoConfig = createConfig(2, 9002);
+    const config = new Config().load();
+    nodeOneConfig = createConfig(1, 9001, config);
+    nodeTwoConfig = createConfig(2, 9002, config);
     const loggers = Logger.createLoggers();
 
     // make sure the nodes table is empty
-    const dbConfig = new Config().testDb;
-    const dbOne = new DB(dbConfig, loggers.db);
-    const dbTwo = new DB({ ...dbConfig, database: 'xud_test2' }, loggers.db);
+    const dbOne = new DB({ ...config.testDb, ...nodeOneConfig.db }, loggers.db);
+    const dbTwo = new DB({ ...config.testDb, ...nodeTwoConfig.db }, loggers.db);
     await Promise.all([dbOne.init(), dbTwo.init()]);
     await Promise.all([dbOne.models.Node.truncate(), dbTwo.models.Node.truncate()]);
     await Promise.all([dbOne.close(), dbTwo.close()]);


### PR DESCRIPTION
The tests could not run on my env because config wasn't loaded, and in my case it's necessary, because i'm using a password for the database.

In addition to that, I changed a bit how we create the config for each xud instance in the test.