### PR TITLE
 Removed remainingOrder from market orders

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -142,7 +142,9 @@ class OrderBook extends EventEmitter {
 
   public addMarketOrder = (order: orders.OwnMarketOrder): matchingEngine.MatchingResult => {
     const price = order.quantity > 0 ? Number.MAX_VALUE : 0;
-    return this.addOwnOrder({ ...order, price }, true);
+    const result = this.addOwnOrder({ ...order, price }, true);
+    delete result.remainingOrder;
+    return result;
   }
 
   public removeOwnOrderByLocalId = (pairId: string, localId: string): { removed: boolean, globalId?: string } => {

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -99,11 +99,10 @@ describe('OrderBook', () => {
 
   it('should partially match new market order and discard remaining order', async () => {
     const order: orders.OwnMarketOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -10 };
-    const matches = await orderBook.addMarketOrder(order);
-    expect(matches.remainingOrder).to.not.be.undefined;
-    expect(matches.remainingOrder!.quantity).to.be.greaterThan(order.quantity);
-    expect(getOwnOrder(matches.remainingOrder!)).to.be.undefined;
-    expect((getOwnOrder(matches.remainingOrder!))).to.be.undefined;
+    const result = await orderBook.addMarketOrder(order);
+    const { taker } = result.matches[0];
+    expect(result.remainingOrder).to.be.undefined;
+    expect(getOwnOrder(taker)).to.be.undefined;
   });
 
   after(async () => {


### PR DESCRIPTION
Closes #353 by removing `remainingOrder` from market orders