### PR TITLE
Swap orderbook integration

### DIFF
--- a/lib/orderbook/MatchesProcessor.ts
+++ b/lib/orderbook/MatchesProcessor.ts
@@ -1,38 +1,85 @@
 import Logger from '../Logger';
 import { OrderMatch } from '../types/matchingEngine';
-import { isPeerOrder } from '../types/orders';
+import { isPeerOrder, StampedPeerOrder, StampedOwnOrder } from '../types/orders';
 import RaidenClient from '../raidenclient/RaidenClient';
 import Pool from '../p2p/Pool';
+import * as packets from '../p2p/packets';
+import uuidv1 from 'uuid/v1';
+import { SwapDeal } from './SwapDeals';
+import { SwapDealRole } from '../types/enums';
 
 class MatchesProcessor {
-  private buffer: any[];
+  constructor(private logger: Logger, private pool?: Pool, private raidenClient?: RaidenClient) { }
 
-  constructor(private logger: Logger, private pool?: Pool, private raidenClient?: RaidenClient) {
-    this.buffer = [];
-  }
-
-  public add(match: OrderMatch) {
-    this.buffer.push(match);
-
+  public process = (match: OrderMatch) => {
     if (isPeerOrder(match.maker)) {
-      this.notifyPeer(match);
-    } else if (isPeerOrder(match.taker)) {
       this.executeSwap(match);
     } else {
+      // internal match
       this.notifyClient(match);
     }
   }
 
-  public notifyPeer(_args: any) {
-    // TODO: notify the peer to trigger swap execution from his side
-  }
-
-  public notifyClient(_args: any) {
+  private notifyClient(_match: OrderMatch) {
     // TODO: notify the local exchange client on the match
   }
 
-  public executeSwap(_args: any) {
-    // TODO: execute the swap procedure
+  private executeSwap = (match: OrderMatch) => {
+    if (this.pool) {
+      /** The remote maker order we are filling. */
+      const maker = match.maker as StampedPeerOrder;
+      /** Our local taker order. */
+      const taker = match.taker as StampedOwnOrder;
+
+      const peer = this.pool.getPeer(maker.peerPubKey);
+
+      const [baseCurrency, quoteCurrency] = maker.pairId.split('/');
+
+      let takerCurrency: string;
+      let makerCurrency: string;
+      let takerAmount: number;
+      let makerAmount: number;
+      if (taker.quantity > 0) {
+        // we are buying the base currency
+        takerCurrency = baseCurrency;
+        makerCurrency = quoteCurrency;
+        takerAmount = taker.quantity;
+        makerAmount = taker.quantity * maker.price;
+      } else {
+        // we are selling the base currency
+        takerCurrency = quoteCurrency;
+        makerCurrency = baseCurrency;
+        takerAmount = taker.quantity * maker.price;
+        makerAmount = taker.quantity;
+      }
+
+      const dealRequestBody: packets.DealRequestPacketBody = {
+        takerCurrency,
+        makerCurrency,
+        takerAmount,
+        makerAmount,
+        takerPubKey: this.pool.handshakeData.nodePubKey,
+        takerDealId: uuidv1(),
+        orderId: maker.id,
+      };
+
+      const deal: SwapDeal = {
+        ...dealRequestBody,
+        myRole : SwapDealRole.Taker,
+        createTime: Date.now(),
+      };
+
+      // TODO: Put swapped amount on hold
+
+      this.pool.swapDeals.add(deal);
+      this.logger.debug('Initiating swap deal: ' + JSON.stringify(deal));
+
+      // TODO: Subscribe to swap events to handle swap resolution
+
+      const packet = new packets.DealRequest(dealRequestBody);
+
+      peer.sendPacket(packet);
+    }
   }
 }
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -235,7 +235,7 @@ class OrderBook extends EventEmitter {
    * Add peer order
    * @returns false if it's a duplicated order or with an invalid pair id, otherwise true
    */
-  private addPeerOrder = (order: orders.PeerOrder): boolean => {
+  private addPeerOrder = (order: orders.StampedPeerOrder): boolean => {
     const matchingEngine = this.matchingEngines.get(order.pairId);
     if (!matchingEngine) {
       this.logger.debug(`incoming peer order invalid pairId: ${order.pairId}`);
@@ -374,10 +374,7 @@ class OrderBook extends EventEmitter {
   }
 
   private createOutgoingOrder = (order: orders.StampedOwnOrder): orders.OutgoingOrder => {
-    // TODO: Remove functionality of attaching invoices to orders per new swap approach.
-    const invoice = 'dummyInvoice'; // temporarily testing invoices while lnd is not available
-
-    const { createdAt, localId, ...outgoingOrder } = { ...order, invoice };
+    const { createdAt, localId, ...outgoingOrder } = order;
     return outgoingOrder;
   }
 
@@ -393,7 +390,7 @@ class OrderBook extends EventEmitter {
         });
       }
     }
-    this.matchesProcessor.add(match);
+    this.matchesProcessor.process(match);
   }
 }
 

--- a/lib/orderbook/SwapDeals.ts
+++ b/lib/orderbook/SwapDeals.ts
@@ -3,8 +3,8 @@ import { SwapDealRole } from '../types/enums';
 type SwapDeal = {
   /** The role of the local node in the swap. */
   myRole: SwapDealRole; // TODO: consider changing myRole to boolean named isTaker or isMaker
-  /** Global order id in the XU network. */
-  orderId?: string;
+  /** The global XU order id for the maker's order. */
+  orderId?: string; // TODO: make this non-nullable and remove amount/currency
   takerDealId: string;
   takerAmount: number;
   /** The currency the taker is expecting to receive. */
@@ -20,7 +20,7 @@ type SwapDeal = {
   r_preimage?: string;
   createTime: number;
   executeTime?: number;
-  competionTime?: number
+  completeTime?: number
 };
 
 export class SwapDeals {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -7,7 +7,7 @@ import PeerList from './PeerList';
 import P2PRepository from './P2PRepository';
 import * as packets from './packets/types';
 import { Packet, PacketType } from './packets';
-import { PeerOrder, OutgoingOrder, OrderIdentifier } from '../types/orders';
+import { OutgoingOrder, OrderIdentifier, StampedPeerOrder } from '../types/orders';
 import DB from '../db/DB';
 import Logger from '../Logger';
 import { HandshakeState, Address, NodeConnectionInfo } from '../types/p2p';
@@ -24,11 +24,11 @@ type PoolConfig = {
 };
 
 interface Pool {
-  on(event: 'packet.order', listener: (order: PeerOrder) => void): this;
+  on(event: 'packet.order', listener: (order: StampedPeerOrder) => void): this;
   on(event: 'packet.getOrders', listener: (peer: Peer, reqId: string) => void): this;
   on(event: 'packet.orderInvalidation', listener: (orderInvalidation: OrderIdentifier) => void): this;
   on(event: 'peer.close', listener: (peer: Peer) => void): this;
-  emit(event: 'packet.order', order: PeerOrder): boolean;
+  emit(event: 'packet.order', order: StampedPeerOrder): boolean;
   emit(event: 'packet.getOrders', peer: Peer, reqId: string): boolean;
   emit(event: 'packet.orderInvalidation', orderInvalidation: OrderIdentifier): boolean;
   emit(event: 'peer.close', peer: Peer): boolean;
@@ -227,6 +227,14 @@ class Pool extends EventEmitter {
     peer.sendPacket(packet);
   }
 
+  public getPeer = (nodePubKey: string) => {
+    const peer = this.peers.get(nodePubKey);
+    if (!peer) {
+      throw errors.NOT_CONNECTED(nodePubKey);
+    }
+    return peer;
+  }
+
   public broadcastOrder = (order: OutgoingOrder) => {
     const orderPacket = new packets.OrderPacket(order);
     this.peers.forEach(peer => peer.sendPacket(orderPacket));
@@ -266,7 +274,7 @@ class Pool extends EventEmitter {
     switch (packet.type) {
       case PacketType.ORDER: {
         const order = (packet as packets.OrderPacket).body!;
-        this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey } as PeerOrder);
+        this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey } as StampedPeerOrder);
         break;
       }
       case PacketType.ORDER_INVALIDATION: {
@@ -280,7 +288,7 @@ class Pool extends EventEmitter {
       case PacketType.ORDERS: {
         const orders = (packet as packets.OrdersPacket).body!;
         orders.forEach((order) => {
-          this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey } as PeerOrder);
+          this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey } as StampedPeerOrder);
         });
         break;
       }

--- a/lib/p2p/packets/types/DealRequestPacket.ts
+++ b/lib/p2p/packets/types/DealRequestPacket.ts
@@ -9,6 +9,7 @@ export type DealRequestPacketBody = {
   makerCurrency: string;
   /** Taker's lnd pubkey on the taker currency's network. */
   takerPubKey: string;
+  orderId?: string; // TODO: make this non-nullable and remove amount/currency
 };
 
 class DealRequestPacket extends Packet<DealRequestPacketBody> {

--- a/lib/p2p/packets/types/OrderPacket.ts
+++ b/lib/p2p/packets/types/OrderPacket.ts
@@ -1,15 +1,8 @@
 import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
+import { OutgoingOrder } from '../../../types/orders';
 
-type OrderPacketBody = {
-  id: string;
-  pairId: string;
-  quantity: number;
-  price: number;
-  invoice: string;
-};
-
-class OrderPacket extends Packet<OrderPacketBody> {
+class OrderPacket extends Packet<OutgoingOrder> {
   public get type() {
     return PacketType.ORDER;
   }

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -1,39 +1,45 @@
-export type MarketOrder = {
+type MarketOrder = {
+  /** The number of base currency tokens for the order. */
   quantity: number;
+  /** A trading pair symbol with the base currency first followed by a '/' separator and the quote currency */
   pairId: string;
 };
 
-export type OwnMarketOrder = MarketOrder & {
+/** A limit order with a specified price. */
+type Order = MarketOrder & {
+  /** The price for the order expressed in units of the quote currency. */
+  price: number;
+};
+
+type Local = {
+  /** A local identifier for the order. */
   localId: string;
 };
 
-export type OwnOrder = OwnMarketOrder & {
-  price: number;
-};
-
-export type PeerOrder = MarketOrder & {
-  price: number;
-  id: string;
+type Remote = {
+  /** The nodePubKey of the node which created this order. */
   peerPubKey: string;
-  invoice: string;
 };
 
-export type StampedOwnOrder = OwnOrder & {
+type Stamp = {
+  /** The global identifier for this order on the XU network. */
   id: string;
+  /** Epoch timestamp when this order was created. */
   createdAt: number;
 };
 
-export type StampedPeerOrder = PeerOrder & {
-  createdAt: number;
-};
+export type OwnMarketOrder = MarketOrder & Local;
+
+export type OwnOrder = Order & Local;
+
+export type StampedOwnOrder = OwnOrder & Stamp;
+
+export type StampedPeerOrder = Order & Remote & Stamp;
 
 export type StampedOrder = StampedOwnOrder | StampedPeerOrder;
 
-export type OutgoingOrder = MarketOrder & {
-  price: number;
-  id: string;
-  invoice: string;
-};
+/** An outgoing version of a local order without the localId and createdAt timestamp */
+export type OutgoingOrder = Pick<StampedOwnOrder, Exclude<keyof StampedOwnOrder, 'localId' | 'createdAt'>>;
 
 export type OrderIdentifier = {
   orderId: string;

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -26,7 +26,6 @@ peerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345
   peerPubKey,
   id: uuidv1(),
   pairId: PAIR_ID,
-  invoice: '',
 });
 
 describe('MatchingEngine.getMatchingQuantity', () => {


### PR DESCRIPTION
This is the first step towards integration of swaps with the orderbook. The initial DealRequest packet is now triggered by a match with a peer order with the deal specifics from the order.

This currently treats each swap attempt as a success, assuming the "happy path", but going forward it will need to track updates to the swap flow. I think that will depend partly on #380, where the new `Swaps` class can be an event emitter to emit events when a swap executes, fails, times out, etc... and the orderbook can listen to these events and update the orders accordingly.

I took the buffer/queue out of MatchesProcessor because I believe that all matches will be handled sequentially and synchronously. We might not need this file/class going forward since it currently doesn't have any state.

I left in the currency & amount fields in the deal packets to allow for the `executeSwap` rpc call to continue working, but we should remove these once we're past the demo/early testing stage.

I also did a bit of refactoring and commenting to our orders types class, but the types are unchanged aside from the removal of `invoice` which is not relevant to how we're doing swaps currently.