### PR TITLE
connection retries

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -119,9 +119,9 @@ class GrpcService {
    */
   public disconnect: grpc.handleUnaryCall<xudrpc.DisconnectRequest, xudrpc.DisconnectResponse> = async (call, callback) => {
     try {
-      const disconnectResponse = await this.service.disconnect(call.request.toObject());
+      await this.service.disconnect(call.request.toObject());
       const response = new xudrpc.DisconnectResponse();
-      response.setResult(disconnectResponse);
+      response.setResult('success');
       callback(null, response);
     } catch (err) {
       callback(this.getGrpcError(err), null);

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -1,4 +1,6 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
+import { Address } from '../types/p2p';
+
 const codesPrefix = errorCodesPrefix.P2P;
 const errorCodes = {
   NODE_ALREADY_CONNECTED: codesPrefix.concat('.1'),
@@ -6,6 +8,7 @@ const errorCodes = {
   UNEXPECTED_NODE_PUB_KEY: codesPrefix.concat('.3'),
   ATTEMPTED_CONNECTION_TO_SELF: codesPrefix.concat('.4'),
   EXTERNAL_IP_UNRETRIEVABLE: codesPrefix.concat('.5'),
+  CONNECTING_RETRIES_MAX_PERIOD_EXCEEDED: codesPrefix.concat('.6'),
 };
 
 const errors = {
@@ -29,6 +32,10 @@ const errors = {
     message: `could not retrieve external IP: ${err.message}`,
     code: errorCodes.EXTERNAL_IP_UNRETRIEVABLE,
   }),
+  CONNECTING_RETRIES_MAX_PERIOD_EXCEEDED: {
+    message: `Connection retry attempts to peer exceeded maximum time allotment`,
+    code: errorCodes.CONNECTING_RETRIES_MAX_PERIOD_EXCEEDED,
+  },
 };
 
 export { errorCodes };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -143,7 +143,8 @@ class Service extends EventEmitter {
     argChecks.HAS_NODE_PUB_KEY({ nodePubKey });
     argChecks.HAS_HOST({ host });
     argChecks.VALID_PORT({ port });
-    const peer = await this.pool.addOutbound({ host, port }, nodePubKey);
+
+    const peer = await this.pool.addOutbound({ host, port }, nodePubKey, false);
     return peer.getStatus();
   }
 
@@ -154,7 +155,6 @@ class Service extends EventEmitter {
     const { nodePubKey } = args;
     argChecks.HAS_NODE_PUB_KEY(args);
     await this.pool.closePeer(nodePubKey);
-    return 'success';
   }
 
   /**

--- a/lib/types/p2p.ts
+++ b/lib/types/p2p.ts
@@ -1,6 +1,8 @@
 export type Address = {
   host: string;
   port: number;
+  /** Epoch timestamp of last successful connection with this address */
+  lastConnected?: number;
 };
 
 /** Information used for connecting to a remote node. */

--- a/lib/utils/addressUtils.ts
+++ b/lib/utils/addressUtils.ts
@@ -29,6 +29,9 @@ const addressUtils = {
 
   /** Convert an [[Address]] to a string in the "{host}:{port}" format. */
   toString: (address: Address) => `${address.host}:${address.port}`,
+
+  /** Checks whether two [[Address]] instances are equal, based solely on `host` and `port` fields */
+  areEqual: (a: Address, b: Address) => a.host === b.host && a.port === b.port,
 };
 
 export default addressUtils;

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -69,43 +69,48 @@ describe('P2P Sanity Tests', () => {
   });
 
   it('should connect successfully', async () => {
-    const result = await nodeOne.service.connect({ nodeUri: nodeTwoUri });
-    expect(result).to.be.equal(`Connected to peer ${nodeTwo.nodePubKey}`);
+    await expect(nodeOne.service.connect({ nodeUri: nodeTwoUri }))
+      .to.be.fulfilled;
+
     const listPeersResult = await nodeOne.service.listPeers();
     expect(listPeersResult.length).to.equal(1);
+    expect(listPeersResult[0].nodePubKey).to.equal(nodeTwo.nodePubKey);
   });
 
   it('should fail connecting to the same node', async () => {
     expect(nodeOne.service.connect({ nodeUri: nodeTwoUri }))
-    .to.be.rejectedWith('already connected');
+      .to.be.rejectedWith('already connected');
   });
 
   it('should disconnect successfully', async () => {
-    const result = await nodeOne.service.disconnect({ nodePubKey: nodeTwo.nodePubKey });
-    expect(result).to.be.equal(`success`);
+    await expect(nodeOne.service.disconnect({ nodePubKey: nodeTwo.nodePubKey }))
+      .to.be.fulfilled;
+
     const listPeersResult = await nodeOne.service.listPeers();
-    expect(listPeersResult.length).to.equal(0);
+    expect(listPeersResult).to.be.empty;
   });
 
   it('should fail when connecting to an unexpected node pub key', async () => {
-    const result = await nodeOne.service.connect({ nodeUri: getUri({
-      nodePubKey: 'thewrongpubkey',
-      host: 'localhost',
-      port: nodeTwoPort,
-    }) });
-    expect(result).to.be.equal('Not connected');
+    await expect(nodeOne.service.connect({
+      nodeUri: getUri({
+        nodePubKey: 'thewrongpubkey',
+        host: 'localhost',
+        port: nodeTwoPort,
+      }),
+    })).to.be.rejected;
+
     const listPeersResult = await nodeOne.service.listPeers();
-    expect(listPeersResult.length).to.equal(0);
+    expect(listPeersResult).to.be.empty;
   });
 
   it('should fail when connecting to self', async () => {
     expect(nodeOne.service.connect({ nodeUri: nodeOneUri }))
-    .to.be.rejectedWith('Cannot attempt connection to self');
+      .to.be.rejectedWith('Cannot attempt connection to self');
   });
 
   it('should fail connecting to a non-existing node', async () => {
-    const result = await nodeOne.service.connect({ nodeUri: getUri({ nodePubKey: 'notarealnodepubkey', host: 'localhost', port: 9003 }) });
-    expect(result).to.be.equal('Not connected');
+    expect(nodeOne.service.connect({ nodeUri: getUri({ nodePubKey: 'notarealnodepubkey', host: 'localhost', port: 9003 }) }))
+      .to.be.rejected;
   });
 
   after(async () => {


### PR DESCRIPTION
Solves #311 

* retries are blocking `initConnection`
* retries are not activated when manually trying to connect to a peer. if it would, the user won't get a response for a very long time upon failure, since the retries are blocking.
* if max retries period exceeds, and peer was previously connected (exists on `nodes` table)
peer supposed to get banned. Banning doesn't work now for pre-handshake peers, but can be fixed. I'm not sure banning is the right solution, because in the future it might also block inbound connections. Deleting or soft deleting the node entry might not be the right thing either. Perhaps penalizing, which we haven't implemented yet. 
Anyway - that will hardly happen, because it will trigger only after 1 week, and only for previously connected peers.
The main thing now is to verify that trying to retry over an entire week for every node we're hearing about is reasonable. I think it's too much for nodes we never successfully connected with. 


