### PR TITLE
Fix BTC/LTC ticker to LTC/BTC

### DIFF
--- a/instructions-for-devs.md
+++ b/instructions-for-devs.md
@@ -119,13 +119,13 @@ Examples:
 ./xucli connect xud1.test.exchangeunion.com 8885
 # Manually connect to another xud instance
 
-./xucli placeorder BTC/LTC 1337 1 99
+./xucli placeorder LTC/BTC 1337 1 99
 # Places a new limit order BUYING 1 BTC for 99 LTC, assigning the orderId 1337
 
-./xucli placeorder BTC/LTC 1338 -1 99
+./xucli placeorder LTC/BTC 1338 -1 99
 # Places a new limit order SELLING 1 BTC for 99 LTC, assigning the orderId 1338
 
-./xucli placeorder BTC/LTC 1339 1
+./xucli placeorder LTC/BTC 1339 1
 # Places a new market order BUYING 1 BTC for the best LTC market price, assigning the orderId 1339
 
 ```

--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -93,7 +93,7 @@ class DB {
       ]);
 
       await Pair.bulkCreate(<db.PairAttributes[]>[
-        { baseCurrency: 'BTC', quoteCurrency: 'LTC', swapProtocol: SwapProtocol.LND },
+        { baseCurrency: 'LTC', quoteCurrency: 'BTC', swapProtocol: SwapProtocol.LND },
         { baseCurrency: 'ZRX', quoteCurrency: 'GNT', swapProtocol: SwapProtocol.RAIDEN },
       ]);
     }

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -38,7 +38,7 @@ describe('OrderBook', () => {
       { id: 'LTC' },
     ]);
     await orderBookRepository.addPairs([
-      { baseCurrency: 'BTC', quoteCurrency: 'LTC', swapProtocol: SwapProtocol.LND },
+      { baseCurrency: 'LTC', quoteCurrency: 'BTC', swapProtocol: SwapProtocol.LND },
     ]);
 
     orderBook = new OrderBook(loggers.orderbook, db.models);
@@ -74,13 +74,13 @@ describe('OrderBook', () => {
   });
 
   it('should append two new ownOrder', async () => {
-    const order = { pairId: 'BTC/LTC', quantity: 5, price: 55 };
+    const order = { pairId: 'LTC/BTC', quantity: 5, price: 55 };
     await orderBook.addLimitOrder({ localId: uuidv1(), ...order });
     await orderBook.addLimitOrder({ localId: uuidv1(), ...order });
   });
 
   it('should fully match new ownOrder and remove matches', async () => {
-    const order: orders.OwnOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -6, price: 55 };
+    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: -6, price: 55 };
     const matches = await orderBook.addLimitOrder(order);
     expect(matches.remainingOrder).to.be.undefined;
 
@@ -98,7 +98,7 @@ describe('OrderBook', () => {
   });
 
   it('should partially match new market order and discard remaining order', async () => {
-    const order: orders.OwnMarketOrder = { pairId: 'BTC/LTC', localId: uuidv1(), quantity: -10 };
+    const order: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: -10 };
     const result = await orderBook.addMarketOrder(order);
     const { taker } = result.matches[0];
     expect(result.remainingOrder).to.be.undefined;

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -11,7 +11,7 @@ describe('API Service', () => {
 
   const placeOrderArgs = {
     orderId: '1',
-    pairId: 'BTC/LTC',
+    pairId: 'LTC/BTC',
     price: 100,
     quantity: 1,
   };
@@ -50,7 +50,7 @@ describe('API Service', () => {
 
   it('should get orders', async () => {
     const args = {
-      pairId: 'BTC/LTC',
+      pairId: 'LTC/BTC',
       maxResults: 0,
     };
     const orders = service.getOrders(args);
@@ -62,7 +62,7 @@ describe('API Service', () => {
 
   it('should cancel an order', async () => {
     const args = {
-      pairId: 'BTC/LTC',
+      pairId: 'LTC/BTC',
       orderId: '1',
     };
     const cancelOrderPromise = service.cancelOrder(args);

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -6,7 +6,7 @@ import { orders } from '../../lib/types';
 import { OrderingDirection } from '../../lib/types/enums';
 import { ms } from '../../lib/utils/utils';
 
-const PAIR_ID = 'BTC/LTC';
+const PAIR_ID = 'LTC/BTC';
 const loggers = Logger.createLoggers(Level.WARN);
 
 const createOwnOrder = (price: number, quantity: number, createdAt = ms()): orders.StampedOwnOrder => ({

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -98,7 +98,7 @@ describe('Parser', () => {
     version: '1.0.0',
     nodePubKey: '0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F8179',
     addresses: [{ host: '1.1.1.1', port: 8885 }],
-    pairs: ['BTC/LTC'],
+    pairs: ['LTC/BTC'],
     raidenAddress: '8483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8',
   });
 


### PR DESCRIPTION
I realized we'd been using the `BTC/LTC` ticker everywhere, when in fact the ticker that's in use across every exchange I checked used the `LTC/BTC` ticker which prices LTC in terms of BTC. This fixes all references to that ticker, for further testing one must either manually add `LTC/BTC` to the pairs database, or delete the database and it will be added automatically when it's recreated.