### PR TITLE
Order match swap execution fixes

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -312,7 +312,7 @@ class GrpcService {
     try {
       const resolveResponse = await this.service.resolveHash(call.request.toObject());
       const response = new resolverrpc.ResolveResponse();
-      response.setPreimage(String(resolveResponse));
+      response.setPreimage(resolveResponse);
       callback(null, response);
     } catch (err) {
       callback(this.getGrpcError(err), null);

--- a/lib/orderbook/MatchesProcessor.ts
+++ b/lib/orderbook/MatchesProcessor.ts
@@ -39,18 +39,19 @@ class MatchesProcessor {
       let makerCurrency: string;
       let takerAmount: number;
       let makerAmount: number;
+       // TODO: use configurable amount of subunits/satoshis per token for each currency
       if (taker.quantity > 0) {
         // we are buying the base currency
         takerCurrency = baseCurrency;
         makerCurrency = quoteCurrency;
-        takerAmount = taker.quantity;
-        makerAmount = taker.quantity * maker.price;
+        takerAmount = taker.quantity * 100000000;
+        makerAmount = taker.quantity * maker.price * 100000000;
       } else {
         // we are selling the base currency
         takerCurrency = quoteCurrency;
         makerCurrency = baseCurrency;
-        takerAmount = taker.quantity * maker.price;
-        makerAmount = taker.quantity;
+        takerAmount = taker.quantity * maker.price * -100000000;
+        makerAmount = taker.quantity * -100000000;
       }
 
       const dealRequestBody: packets.DealRequestPacketBody = {
@@ -58,7 +59,7 @@ class MatchesProcessor {
         makerCurrency,
         takerAmount,
         makerAmount,
-        takerPubKey: this.pool.handshakeData.nodePubKey,
+        takerPubKey: takerCurrency === 'BTC' ? this.pool.handshakeData.lndbtcPubKey! : this.pool.handshakeData.lndltcPubKey!,
         takerDealId: uuidv1(),
         orderId: maker.id,
       };
@@ -66,6 +67,7 @@ class MatchesProcessor {
       const deal: SwapDeal = {
         ...dealRequestBody,
         myRole : SwapDealRole.Taker,
+        peerPubKey: this.pool.handshakeData.nodePubKey,
         createTime: Date.now(),
       };
 

--- a/lib/orderbook/SwapDeals.ts
+++ b/lib/orderbook/SwapDeals.ts
@@ -9,12 +9,16 @@ type SwapDeal = {
   takerAmount: number;
   /** The currency the taker is expecting to receive. */
   takerCurrency: string;
+  /** The lnd pub key of the taker. */
   takerPubKey: string;
   makerDealId?: string;
   makerAmount: number;
   /** The currency the maker is expecting to receive. */
   makerCurrency: string;
+  /** The lnd pub key of the maker. */
   makerPubKey?: string;
+  /** The xud node pub key of remote node. */
+  peerPubKey?: string; // TODO: make required
   /** The hash of the preimage. */
   r_hash?: string;
   r_preimage?: string;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -387,7 +387,7 @@ class Service extends EventEmitter {
         return 'Do not have r_preImage. Strange.';
       }
       this.logger.debug(('deal.preimage = ' + deal.r_preimage));
-      return String(deal.r_preimage);
+      return deal.r_preimage;
     }
 
   }


### PR DESCRIPTION
Edit: Closes #348

This fixes a bug to properly set the amounts and taker lnd pub key for swaps triggered by order book matches.

To perform this yourself, first setup lnd according to the instructions in #348. Once you have btcd, ltcd, and 2 running lnd instances for each, run two instances of xud listening for rpc requests on the same ports as specified in the `resolver.conf` files.

Connect the nodes to each other, then place matching orders (I'm using the default 8886 rpc port for exchange a, and 9886 for exchange b)

```bash
xucli limitorder LTC/BTC 1 .1 .01
{
  "matchesList": [],
  "remainingOrder": {
    "price": 0.01,
    "quantity": 0.1,
    "pairId": "LTC/BTC",
    "peerPubKey": "",
    "id": "ea55dc70-a86c-11e8-81de-35e735f1f1ab",
    "localId": "1",
    "createdAt": 1535204637623,
    "invoice": "",
    "canceled": false
  }
}

xucli marketorder LTC/BTC 2 -1 -p 9886
{
  "matchesList": [
    {
      "maker": {
        "price": 0.01,
        "quantity": 0,
        "pairId": "LTC/BTC",
        "peerPubKey": "029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345",
        "id": "ea55dc70-a86c-11e8-81de-35e735f1f1ab",
        "localId": "",
        "createdAt": 1535204637631,
        "invoice": "",
        "canceled": false
      },
      "taker": {
        "price": 0,
        "quantity": -0.1,
        "pairId": "LTC/BTC",
        "peerPubKey": "",
        "id": "ee06d680-a86c-11e8-839d-5747ad4f1ba9",
        "localId": "3",
        "createdAt": 1535204643816,
        "invoice": "",
        "canceled": false
      }
    }
  ]
}
```

This will trigger the swap, you'll be able to see the results from the xud log output and the new `listchannels` lnd output.