### PR TITLE
Verify reachability of advertised addresses

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -57,17 +57,22 @@ class Logger {
   private level: string;
   private logDir: string;
   private context: Context;
-  private logger: any;
+  private logger?: any;
   private instanceId: number;
 
   private static defaultLogDir = 'logs';
 
-  constructor({ level, instanceId, logDir, context }: {level: string, instanceId?: number, logDir?: string, context: Context}) {
-    this.level = level;
+  constructor({ instanceId, level, logDir, context, dummy }:
+    {instanceId?: number, level: string, logDir?: string, context: Context, dummy?: boolean}) {
 
+    this.level = level;
     this.logDir = logDir || Logger.defaultLogDir;
     this.context = context || Context.GLOBAL;
     this.instanceId = instanceId || 0;
+
+    if (dummy) {
+      return;
+    }
 
     if (!fs.existsSync(this.logDir)) {
       fs.mkdirSync(this.logDir);
@@ -101,6 +106,10 @@ class Logger {
     };
   }
 
+  public static get dummyLogger(): Logger {
+    return new Logger({ level: Level.ERROR, context: Context.GLOBAL, dummy: true });
+  }
+
   private getLogFormat = (colorize: boolean) => {
     const { format } = winston;
 
@@ -127,7 +136,9 @@ class Logger {
   }
 
   private log = (level: string, msg: string) => {
-    this.logger.log(level, msg);
+    if (this.logger) {
+      this.logger.log(level, msg);
+    }
   }
 
   public error = (msg: Error | string, err?: Error) => {

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -62,15 +62,15 @@ class Logger {
 
   private static defaultLogDir = 'logs';
 
-  constructor({ instanceId, level, logDir, context, dummy }:
-    {instanceId?: number, level: string, logDir?: string, context: Context, dummy?: boolean}) {
+  constructor({ instanceId, level, logDir, context, disabled }:
+    {instanceId?: number, level?: string, logDir?: string, context?: Context, disabled?: boolean}) {
 
-    this.level = level;
+    this.level = level || Level.TRACE;
     this.logDir = logDir || Logger.defaultLogDir;
     this.context = context || Context.GLOBAL;
     this.instanceId = instanceId || 0;
 
-    if (dummy) {
+    if (disabled) {
       return;
     }
 
@@ -106,8 +106,8 @@ class Logger {
     };
   }
 
-  public static get dummyLogger(): Logger {
-    return new Logger({ level: Level.ERROR, context: Context.GLOBAL, dummy: true });
+  public static get disabledLogger(): Logger {
+    return new Logger({ disabled: true });
   }
 
   private getLogFormat = (colorize: boolean) => {

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -54,6 +54,8 @@ type Loggers = {
 };
 
 class Logger {
+  public static disabledLogger = new Logger({ disabled: true });
+
   private level: string;
   private logDir: string;
   private context: Context;
@@ -104,10 +106,6 @@ class Logger {
       lnd: new Logger({ instanceId, level, context: Context.LND }),
       raiden: new Logger({ instanceId, level, context: Context.RAIDEN }),
     };
-  }
-
-  public static get disabledLogger(): Logger {
-    return new Logger({ disabled: true });
   }
 
   private getLogFormat = (colorize: boolean) => {

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -134,9 +134,14 @@ class Peer extends EventEmitter {
     await this.initHello(handshakeData);
 
     // TODO: Check that the peer's version is compatible with ours
-    if (nodePubKey && this.nodePubKey !== nodePubKey) {
-      this.close();
-      throw errors.UNEXPECTED_NODE_PUB_KEY(this.nodePubKey!, nodePubKey, addressUtils.toString(this.socketAddress));
+    if (nodePubKey) {
+      if (this.nodePubKey !== nodePubKey) {
+        this.close();
+        throw errors.UNEXPECTED_NODE_PUB_KEY(this.nodePubKey!, nodePubKey, addressUtils.toString(this.socketAddress));
+      } else if (this.nodePubKey === handshakeData.nodePubKey) {
+        this.close();
+        throw errors.ATTEMPTED_CONNECTION_TO_SELF;
+      }
     }
 
     this.finalizeOpen();

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -144,14 +144,14 @@ class Pool extends EventEmitter {
       const externalAddress = addressUtils.toString(address);
       this.logger.debug(`Verifying reachability of advertised address: ${externalAddress}`);
       try {
-        const peer = Peer.fromOutbound(address, Logger.dummyLogger);
+        const peer = Peer.fromOutbound(address, Logger.disabledLogger);
         await peer.open(this.handshakeData, this.handshakeData.nodePubKey);
         assert(false, errors.ATTEMPTED_CONNECTION_TO_SELF.message);
       } catch (err) {
         if (err.code === errors.ATTEMPTED_CONNECTION_TO_SELF.code) {
           this.logger.verbose(`Verified reachability of advertised address: ${externalAddress}`);
         } else {
-          this.logger.warn(`Could not connect to advertised address: ${externalAddress}`);
+          this.logger.warn(`Could not verify reachability of advertised address: ${externalAddress}`);
         }
       }
     });
@@ -558,6 +558,8 @@ class Pool extends EventEmitter {
     });
 
     peer.on('error', (err) => {
+      // The only situation in which the node should be connected to itself is the
+      // reachability check of the advertised addresses and we don't have to log that
       if (peer.nodePubKey !== this.handshakeData.nodePubKey) {
         this.logger.error(`peer error (${peer.nodePubKey}): ${err.message}`);
       }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -18,6 +18,7 @@ import { randomBytes, createHash } from 'crypto';
 import { SwapDealRole } from '../types/enums';
 import LndClient from '../lndclient/LndClient';
 import * as lndrpc from '../proto/lndrpc_pb';
+import { assert } from 'chai';
 
 type PoolConfig = {
   listen: boolean;
@@ -87,7 +88,6 @@ class Pool extends EventEmitter {
       // Append the external IP if no address was specified by the user
       if (this.addresses.length === 0) {
         try {
-          // TODO: verify that this address is reachable
           const externlIp = await getExternalIp();
 
           this.logger.info(`retrieved external IP: ${externlIp}`);
@@ -119,6 +119,8 @@ class Pool extends EventEmitter {
       this.bindServer();
     }
 
+    this.verifyReachability();
+
     this.connected = true;
   }
 
@@ -135,6 +137,24 @@ class Pool extends EventEmitter {
     this.closePeers();
 
     this.connected = false;
+  }
+
+  private verifyReachability = () => {
+    this.handshakeData.addresses!.forEach(async (address) => {
+      const externalAddress = addressUtils.toString(address);
+      this.logger.debug(`Verifying reachability of advertised address: ${externalAddress}`);
+      try {
+        const peer = Peer.fromOutbound(address, Logger.dummyLogger);
+        await peer.open(this.handshakeData, this.handshakeData.nodePubKey);
+        assert(false, errors.ATTEMPTED_CONNECTION_TO_SELF.message);
+      } catch (err) {
+        if (err.code === errors.ATTEMPTED_CONNECTION_TO_SELF.code) {
+          this.logger.verbose(`Verified reachability of advertised address: ${externalAddress}`);
+        } else {
+          this.logger.warn(`Could not connect to advertised address: ${externalAddress}`);
+        }
+      }
+    });
   }
 
   /**
@@ -493,6 +513,10 @@ class Pool extends EventEmitter {
   }
 
   private handleOpen = async (peer: Peer): Promise<void> => {
+    if (peer.nodePubKey === this.handshakeData.nodePubKey) {
+      return;
+    }
+
     if (this.nodes.isBanned(peer.nodePubKey!)) {
       // TODO: Ban IP address for this session if banned peer attempts repeated connections.
       peer.close();
@@ -534,7 +558,9 @@ class Pool extends EventEmitter {
     });
 
     peer.on('error', (err) => {
-      this.logger.error(`peer error (${peer.nodePubKey}): ${err.message}`);
+      if (peer.nodePubKey !== this.handshakeData.nodePubKey) {
+        this.logger.error(`peer error (${peer.nodePubKey}): ${err.message}`);
+      }
     });
 
     peer.once('open', async () => {

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -14,6 +14,7 @@ const createConfig = (instanceId: number, p2pPort: number, config: Config) => ({
   p2p: {
     listen: true,
     port: p2pPort,
+    addresses: [`localhost:${p2pPort}`],
   },
   rpc: {
     disable: true,


### PR DESCRIPTION
Closes #182 

This PR takes care of verifying that the node's advertised addresses are reachable. If that is not the case the user is alerted with the message: `Could not connect to advertised address: <host>:<port>`