### PR TITLE
Fix rounding error on swap amounts

### DIFF
--- a/lib/orderbook/MatchesProcessor.ts
+++ b/lib/orderbook/MatchesProcessor.ts
@@ -44,14 +44,14 @@ class MatchesProcessor {
         // we are buying the base currency
         takerCurrency = baseCurrency;
         makerCurrency = quoteCurrency;
-        takerAmount = taker.quantity * 100000000;
-        makerAmount = taker.quantity * maker.price * 100000000;
+        takerAmount = Math.round(taker.quantity * 100000000);
+        makerAmount = Math.round(taker.quantity * maker.price * 100000000);
       } else {
         // we are selling the base currency
         takerCurrency = quoteCurrency;
         makerCurrency = baseCurrency;
-        takerAmount = taker.quantity * maker.price * -100000000;
-        makerAmount = taker.quantity * -100000000;
+        takerAmount = Math.round(taker.quantity * maker.price * -100000000);
+        makerAmount = Math.round(taker.quantity * -100000000);
       }
 
       const dealRequestBody: packets.DealRequestPacketBody = {


### PR DESCRIPTION
This PR attempts to fix a rounding error @offerm has observed on swaps executed via the orderbook. I have not seen this myself but below is a sample error message:

```bash
8/28/2018, 1:24:20 AM [P2P] error: Got exception from sendPaymentSync {"dest":"","destString":"02fe35d3c066601c5e9f3f5de0972e0c0b3478661544c0d0eb6991355c3e676926","amt":2000.0000000000002,"paymentHash":"","paymentHashString":"3e9df9798c2d5313896834dd0873b8f069d493e0c08c8f9294a9a655cb296391","paymentRequest":"","finalCltvDelta":0} AssertionError: Assertion failed`
```