### PR TITLE
 Make p2p sanity tests use dynamic ports

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -30,7 +30,7 @@ class Xud extends EventEmitter {
   private lndbtcClient!: LndClient;
   private lndltcClient!: LndClient;
   private raidenClient!: RaidenClient;
-  private pool?: Pool;
+  private pool!: Pool;
   private orderBook!: OrderBook;
   private rpcServer?: GrpcServer;
   private nodeKey!: NodeKey;

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -40,11 +40,12 @@ describe('P2P Sanity Tests', () => {
   let nodeTwoConfig: any;
   let nodeTwo: Xud;
   let nodeTwoUri: string;
+  let nodeTwoPort: number;
 
   before(async () => {
     const config = new Config().load();
-    nodeOneConfig = createConfig(1, 9001, config);
-    nodeTwoConfig = createConfig(2, 9002, config);
+    nodeOneConfig = createConfig(1, 0, config);
+    nodeTwoConfig = createConfig(2, 0, config);
     const loggers = Logger.createLoggers(Level.WARN);
 
     // make sure the nodes table is empty
@@ -61,8 +62,9 @@ describe('P2P Sanity Tests', () => {
 
     await nodeOne['db'].models.Node.truncate();
 
-    nodeOneUri = getUri({ nodePubKey: nodeOne.nodePubKey, host: 'localhost', port: nodeOneConfig.p2p.port });
-    nodeTwoUri = getUri({ nodePubKey: nodeTwo.nodePubKey, host: 'localhost', port: nodeTwoConfig.p2p.port });
+    nodeTwoPort = nodeTwo['pool']['listenPort']!;
+    nodeOneUri = getUri({ nodePubKey: nodeOne.nodePubKey, host: 'localhost', port: nodeOne['pool']['listenPort']! });
+    nodeTwoUri = getUri({ nodePubKey: nodeTwo.nodePubKey, host: 'localhost', port: nodeTwoPort });
   });
 
   it('should connect successfully', async () => {
@@ -88,7 +90,7 @@ describe('P2P Sanity Tests', () => {
     const result = await nodeOne.service.connect({ nodeUri: getUri({
       nodePubKey: 'thewrongpubkey',
       host: 'localhost',
-      port: nodeTwoConfig.p2p.port,
+      port: nodeTwoPort,
     }) });
     expect(result).to.be.equal('Not connected');
     const listPeersResult = await nodeOne.service.listPeers();


### PR DESCRIPTION
Solves #369 (I hope, @offerm can confirm). The p2p tests started failing out of the blue for me and after some digging it turns out that one of the hardcoded ports (9002 in my case) was in use. This PR makes the sanity tests use a random available port, and also adds the option to configure xud to use a dynamic p2p listening port during normal operation.  It fixed the failing tests for me.