### PR TITLE
Fix cancelorder invalid pair false positive

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -315,17 +315,19 @@ class OrderBook extends EventEmitter {
   }
 
   private removeOrder = (ordersMap: OrdersMap, orderId: string, pairId: string): boolean => {
-    const orders = ordersMap.get(pairId);
-
-    if (!orders) {
+    if (!this.pairIds.includes(pairId)) {
       throw errors.INVALID_PAIR_ID(pairId);
     }
-    if (orders.buyOrders.has(orderId)) {
-      orders.buyOrders.delete(orderId);
-      return true;
-    } else if (orders.sellOrders.has(orderId)) {
-      orders.sellOrders.delete(orderId);
-      return true;
+    const orders = ordersMap.get(pairId);
+
+    if (orders) {
+      if (orders.buyOrders.has(orderId)) {
+        orders.buyOrders.delete(orderId);
+        return true;
+      } else if (orders.sellOrders.has(orderId)) {
+        orders.sellOrders.delete(orderId);
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
This fixes logic that would throw an `INVALID_PAIR_ID` error when there are no orders for a given pair id, even though that pair id is supported.