### PR TITLE
Bind socket after connection

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -39,7 +39,7 @@ interface Peer {
 
 /** Represents a remote XU peer */
 class Peer extends EventEmitter {
-  public socketAddress!: Address;
+  // TODO: properties documentation
   public inbound!: boolean;
   public connected = false;
   private opened = false;
@@ -82,7 +82,7 @@ class Peer extends EventEmitter {
 
   public get info(): PeerInfo {
     return {
-      address: addressUtils.toString(this.socketAddress),
+      address: addressUtils.toString(this.address),
       nodePubKey: this.handshakeState ? this.handshakeState.nodePubKey : undefined,
       inbound: this.inbound,
       pairs: this.handshakeState ? this.handshakeState.pairs : undefined,
@@ -91,22 +91,23 @@ class Peer extends EventEmitter {
     };
   }
 
-  constructor(private logger: Logger) {
+  constructor(private logger: Logger, public address: Address) {
     super();
 
     this.bindParser(this.parser);
   }
 
-  /** Create an outbound connection to a node. */
-  public static fromOutbound(address: Address, logger: Logger): Peer {
-    const peer = new Peer(logger);
-    peer.connect(address);
-    return peer;
-  }
+  /**
+   * Creates a Peer from an inbound socket connection.
+   */
+  public static fromInbound = (socket: Socket, logger: Logger): Peer => {
+    const peer = new Peer(logger, addressUtils.fromSocket(socket));
 
-  public static fromInbound(socket: Socket, logger: Logger): Peer {
-    const peer = new Peer(logger);
-    peer.accept(socket);
+    peer.inbound = true;
+    peer.connected = true;
+
+    peer.bindSocket(socket);
+
     return peer;
   }
 
@@ -115,7 +116,7 @@ class Peer extends EventEmitter {
     if (this.connected) {
       status = this.nodePubKey ?
         `Connected to peer ${this.nodePubKey}` :
-        `Connected pre-handshake to peer ${addressUtils.toString(this.socketAddress)}`;
+        `Connected pre-handshake to peer ${addressUtils.toString(this.address)}`;
     } else {
       status = 'Not connected';
     }
@@ -145,7 +146,7 @@ class Peer extends EventEmitter {
     if (nodePubKey) {
       if (this.nodePubKey !== nodePubKey) {
         this.close();
-        throw errors.UNEXPECTED_NODE_PUB_KEY(this.nodePubKey!, nodePubKey, addressUtils.toString(this.socketAddress));
+        throw errors.UNEXPECTED_NODE_PUB_KEY(this.nodePubKey!, nodePubKey, addressUtils.toString(this.address));
       } else if (this.nodePubKey === handshakeData.nodePubKey) {
         this.close();
         throw errors.ATTEMPTED_CONNECTION_TO_SELF;
@@ -243,9 +244,9 @@ class Peer extends EventEmitter {
    * and set the [[connectTime]] timestamp. If an outbound connection attempt errors or times out, throw an error.
    */
   private initConnection = async (retry = false) => {
-    assert(this.socket);
-
     if (this.connected) {
+      // in case of an inbound peer, we will already be connected
+      assert(this.socket);
       assert(this.inbound);
       this.connectTime = Date.now();
       this.logger.debug(this.getStatus());
@@ -253,25 +254,28 @@ class Peer extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      const address: Address = { port: this.socketAddress.port, host: this.socketAddress.host };
       const startTime = Date.now();
       let retryDelay = Peer.CONNECTION_RETRIES_MIN_DELAY;
       let retries = 0;
+
+      const socket = net.connect(this.address.port, this.address.host);
+      this.inbound = false;
 
       const cleanup = () => {
         if (this.connectTimeout) {
           clearTimeout(this.connectTimeout);
           this.connectTimeout = undefined;
         }
-        if (this.socket) {
-          this.socket.removeListener('error', onError);
-          this.socket.removeListener('connect', onConnect);
-        }
+        socket.removeListener('error', onError);
+        socket.removeListener('connect', onConnect);
       };
 
       const onConnect = () => {
         this.connectTime = Date.now();
         this.connected = true;
+
+        this.bindSocket(socket);
+
         this.logger.debug(this.getStatus());
         this.emit('connect');
 
@@ -295,21 +299,21 @@ class Peer extends EventEmitter {
         }
 
         this.logger.debug(
-          `Connection attempt #${retries + 1} to peer (${addressUtils.toString(this.socketAddress)}) ` +
+          `Connection attempt #${retries + 1} to peer (${addressUtils.toString(this.address)}) ` +
           `failed: ${err.message}. retrying in ${retryDelay / 1000} sec...`,
         );
 
         setTimeout(() => {
           retryDelay = Math.min(Peer.CONNECTION_RETRIES_MAX_DELAY, retryDelay * 2);
           retries = retries + 1;
-          this.socket!.connect(address);
+          socket.connect(this.address);
           bind();
         }, retryDelay);
       };
 
       const bind = () => {
-        this.socket!.once('connect', onConnect);
-        this.socket!.once('error', onError);
+        socket.once('connect', onConnect);
+        socket.once('error', onError);
         this.connectTimeout = setTimeout(() => onError(new Error('Connection timed out')), Peer.CONNECTION_TIMEOUT);
       };
 
@@ -420,55 +424,29 @@ class Peer extends EventEmitter {
     return true;
   }
 
-  private connect = (address: Address): void => {
-    assert(!this.socket);
-
-    const socket = net.connect(address.port, address.host);
-
-    this.socketAddress = address;
-    this.inbound = false;
-    this.connected = false;
-
-    this.bindSocket(socket);
-  }
-
-  private accept = (socket: Socket): void => {
-    assert(!this.socket);
-
-    this.socketAddress = addressUtils.fromSocket(socket);
-    this.inbound = true;
-    this.connected = true;
-
-    this.bindSocket(socket);
-  }
-
+  /**
+   * Binds listeners to a newly connected socket for `error`, `close`, and `data` events.
+   */
   private bindSocket = (socket: Socket) => {
     assert(!this.socket);
 
     this.socket = socket;
 
     this.socket.once('error', (err) => {
-      if (!this.connected) {
-        return;
-      }
-
       this.error(err);
       // socket close event will be called immediately after the socket error
     });
 
     this.socket.once('close', (hadError) => {
       // emitted once the socket is fully closed
-      if (this.connected) {
-        // don't log anything on close if we've never connected as the connection failure is logged elsewhere
-        if (this.nodePubKey === undefined) {
-          this.logger.info(`Socket closed prior to handshake (${addressUtils.toString(this.socketAddress)})`);
-        } else if (hadError) {
-          this.logger.warn(`Peer ${this.nodePubKey} socket closed due to error`);
-        } else {
-          this.logger.info(`Peer ${this.nodePubKey} socket closed`);
-        }
-        this.close();
+      if (this.nodePubKey === undefined) {
+        this.logger.info(`Socket closed prior to handshake (${addressUtils.toString(this.address)})`);
+      } else if (hadError) {
+        this.logger.warn(`Peer ${this.nodePubKey} socket closed due to error`);
+      } else {
+        this.logger.info(`Peer ${this.nodePubKey} socket closed`);
       }
+      this.close();
     });
 
     this.socket.on('data', (data) => {
@@ -477,7 +455,7 @@ class Peer extends EventEmitter {
       if (this.nodePubKey !== undefined) {
         this.logger.trace(`Received data (${this.nodePubKey}): ${dataStr}`);
       } else {
-        this.logger.trace(`Received data (${addressUtils.toString(this.socketAddress)}): ${data.toString()}`);
+        this.logger.trace(`Received data (${addressUtils.toString(this.address)}): ${data.toString()}`);
       }
       this.parser.feed(dataStr);
     });

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -17,8 +17,7 @@ describe('P2P Pool Tests', () => {
   const nodePubKeyOne = NodeKey['generate']().nodePubKey;
 
   const createPeer = (nodePubKey: string, addresses: Address[]) => {
-    const peer = new Peer(loggers.p2p);
-    peer.socketAddress = addresses[0];
+    const peer = new Peer(loggers.p2p, addresses[0]);
     peer['handshakeState'] = {
       addresses,
       nodePubKey,


### PR DESCRIPTION
This commit delays calling the `bindSocket` method until after an outgoing connection is established. It also moves beginning an outgoing peer socket connection from the `fromOutbound` method to the `initConnection` method. This ensures that we bind the `connection` listener immediately after beginning the connection.