### PR TITLE
Make pairs & currencies upper case for cli

### DIFF
--- a/lib/cli/commands/cancelorder.ts
+++ b/lib/cli/commands/cancelorder.ts
@@ -17,7 +17,7 @@ export const builder = {
 
 export const handler = (argv: Arguments) => {
   const request = new CancelOrderRequest();
-  request.setPairId(argv.pair_id);
+  request.setPairId(argv.pair_id.toUpperCase());
   request.setOrderId(argv.order_id);
   loadXudClient(argv).cancelOrder(request, callback);
 };

--- a/lib/cli/commands/channelbalance.ts
+++ b/lib/cli/commands/channelbalance.ts
@@ -15,6 +15,6 @@ export const builder = {
 
 export const handler = (argv: Arguments) => {
   const request = new ChannelBalanceRequest();
-  request.setCurrency(argv.currency);
+  request.setCurrency(argv.currency.toUpperCase());
   loadXudClient(argv).channelBalance(request, callback);
 };

--- a/lib/cli/commands/getorders.ts
+++ b/lib/cli/commands/getorders.ts
@@ -19,7 +19,7 @@ export const builder = {
 
 export const handler = (argv: Arguments) => {
   const request = new GetOrdersRequest();
-  request.setPairId(argv.pair_id);
+  request.setPairId(argv.pair_id.toUpperCase());
   request.setMaxResults(argv.max_results);
   loadXudClient(argv).getOrders(request, callback);
 };

--- a/lib/cli/utils.ts
+++ b/lib/cli/utils.ts
@@ -29,7 +29,7 @@ export const orderHandler = (argv: Arguments, isSell = false) => {
   const priceStr = argv.price.toLowerCase();
 
   request.setQuantity(isSell ? argv.quantity * -1 : argv.quantity);
-  request.setPairId(argv.pair_id);
+  request.setPairId(argv.pair_id.toUpperCase());
 
   if (!isNaN(numericPrice)) {
     request.setPrice(numericPrice);


### PR DESCRIPTION
This commit makes all pair and currency arguments from cli upper case before passing them to xud. As all currencies are represented in upper case strings internally, this prevents xucli errors when arguments are not typed in all upper case.