### PR TITLE
Update winston

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -59,7 +59,7 @@ class Logger {
   private level: string;
   private logDir: string;
   private context: Context;
-  private logger?: any;
+  private logger?: winston.Logger;
   private instanceId: number;
 
   private static defaultLogDir = 'logs';
@@ -79,12 +79,12 @@ class Logger {
     if (!fs.existsSync(this.logDir)) {
       fs.mkdirSync(this.logDir);
     }
+
     this.logger = winston.createLogger({
       levels: LevelPriorities,
       transports: [
         new winston.transports.Console({
           level: this.level,
-          colorize: true,
           format: this.getLogFormat(true),
         }),
         new winston.transports.File({
@@ -112,10 +112,10 @@ class Logger {
     const { format } = winston;
 
     if (this.instanceId > 0) {
-      return format.printf((info: any) => `${getTsString()} [${this.context}][${this.instanceId}]` +
+      return format.printf(info => `${getTsString()} [${this.context}][${this.instanceId}]` +
         `${this.getLevel(info.level, colorize)}: ${info.message}`);
     } else {
-      return format.printf((info: any) => `${getTsString()} [${this.context}] ${this.getLevel(info.level, colorize)}: ${info.message}`);
+      return format.printf(info => `${getTsString()} [${this.context}] ${this.getLevel(info.level, colorize)}: ${info.message}`);
     }
   }
 

--- a/lib/winston.d.ts
+++ b/lib/winston.d.ts
@@ -1,1 +1,0 @@
-declare module 'winston';

--- a/package-lock.json
+++ b/package-lock.json
@@ -739,11 +739,18 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
       }
     },
     "async-done": {
@@ -1441,19 +1448,12 @@
       }
     },
     "color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
-        "color-convert": "^0.5.0",
-        "color-string": "^0.3.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-        }
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -1470,11 +1470,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "color-support": {
@@ -1483,9 +1484,9 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.3.2",
@@ -1493,12 +1494,12 @@
       "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
     },
     "colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
+      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
       "requires": {
-        "color": "0.8.x",
-        "text-hex": "0.0.x"
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
       }
     },
     "colour": {
@@ -2018,13 +2019,13 @@
       "dev": true
     },
     "diagnostics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
-      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
       "requires": {
-        "colorspace": "1.0.x",
+        "colorspace": "1.1.x",
         "enabled": "1.0.x",
-        "kuler": "0.0.x"
+        "kuler": "1.0.x"
       }
     },
     "diff": {
@@ -2622,6 +2623,11 @@
         "color-support": "^1.1.3",
         "time-stamp": "^1.0.0"
       }
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
     },
     "fastpriorityqueue": {
       "version": "0.6.1",
@@ -5177,7 +5183,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -5297,11 +5304,11 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.0.tgz",
+      "integrity": "sha512-oyy6pu/yWRjiVfCoJebNUKFL061sNtrs9ejKTbirIwY3oiHmENVCSkHhxDV85Dkm7JYR/czMCBeoM87WilTdSg==",
       "requires": {
-        "colornames": "0.0.2"
+        "colornames": "^1.1.1"
       }
     },
     "last-run": {
@@ -5409,12 +5416,22 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "logform": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-1.4.0.tgz",
-      "integrity": "sha512-1NT2VkhmDcVZD8+IHz0tEwymjEQCbY5YFHPani8t5Lo5ZO2fI2a448gIZ+kWIzk69EBfC1S1u/TZ5AjcWW/NFA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-1.9.1.tgz",
+      "integrity": "sha512-ZHrZE8VSf7K3xKxJiQ1aoTBp2yK+cEbFcgarsjzI3nt3nE/3O0heNSppoOQMUJVMZo/xiVwCxiXIabaZApsKNQ==",
       "requires": {
-        "colors": "^1.2.0",
-        "fecha": "^2.3.2"
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "logging-helpers": {
@@ -7187,6 +7204,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7758,9 +7790,9 @@
       }
     },
     "text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "through": {
       "version": "2.3.8",
@@ -7893,9 +7925,9 @@
       "dev": true
     },
     "triple-beam": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.1.0.tgz",
-      "integrity": "sha1-KsOHyMS9BL0mxh34kaYHn4WS/hA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-node": {
       "version": "6.0.2",
@@ -8565,24 +8597,77 @@
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "winston": {
-      "version": "3.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0-rc3.tgz",
-      "integrity": "sha512-KPvs53IB5m6wMHAm4j5DgL8MkgfXZKjwNqzTr3IA8SijHTXeN6l8ebyR24rlCSVotuqtXhooFHvYLbA3fAViSw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.1.0.tgz",
+      "integrity": "sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==",
       "requires": {
         "async": "^2.6.0",
-        "diagnostics": "^1.0.1",
-        "isstream": "0.1.x",
-        "logform": "^1.2.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^1.9.1",
         "one-time": "0.0.4",
+        "readable-stream": "^2.3.6",
         "stack-trace": "0.0.x",
-        "triple-beam": "^1.0.1",
-        "winston-transport": "^3.0.1"
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "winston-transport": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-3.0.1.tgz",
-      "integrity": "sha1-gAixXu9WYMT7P6CU1YzL0IUoxY0="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
+      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "wkx": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "swagger-ui-express": "^3.0.10",
     "toml": "^2.3.3",
     "uuid": "^3.2.1",
-    "winston": "^3.0.0-rc3",
+    "winston": "^3.1.0",
     "yargs": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates winston to a post-release candidate version with included type definitions. It removes the dummy type declaration file for winston, fixes a minor compile issue of a superfluous field, and replaces several uses of `any`.