### PR TITLE
CLI enhancements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@
     - [GetInfoResponse](#xudrpc.GetInfoResponse)
     - [GetOrdersRequest](#xudrpc.GetOrdersRequest)
     - [GetOrdersResponse](#xudrpc.GetOrdersResponse)
+    - [GetOrdersResponse.OrdersEntry](#xudrpc.GetOrdersResponse.OrdersEntry)
     - [ListCurrenciesRequest](#xudrpc.ListCurrenciesRequest)
     - [ListCurrenciesResponse](#xudrpc.ListCurrenciesResponse)
     - [ListPairsRequest](#xudrpc.ListPairsRequest)
@@ -128,7 +129,6 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | order_id | [string](#string) |  | The local id of the order to cancel |
-| pair_id | [string](#string) |  | The trading pair that the order to cancel is for |
 
 
 
@@ -269,6 +269,7 @@
 | ----- | ---- | ----- | ----------- |
 | pair_id | [string](#string) |  | The trading pair for which to retrieve orders |
 | max_results | [uint32](#uint32) |  | The maximum number of orders to return from either side of the order book |
+| include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not |
 
 
 
@@ -283,8 +284,23 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| peer_orders | [Orders](#xudrpc.Orders) |  | A list of peer orders |
-| own_orders | [Orders](#xudrpc.Orders) |  | A list of orders placed locally |
+| orders | [GetOrdersResponse.OrdersEntry](#xudrpc.GetOrdersResponse.OrdersEntry) | repeated | A map between pair ids and their buy and sell orders |
+
+
+
+
+
+
+<a name="xudrpc.GetOrdersResponse.OrdersEntry"></a>
+
+### GetOrdersResponse.OrdersEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [Orders](#xudrpc.Orders) |  |  |
 
 
 
@@ -718,7 +734,7 @@
 | Connect | [ConnectRequest](#xudrpc.ConnectRequest) | [ConnectResponse](#xudrpc.ConnectResponse) | Connect to an XU node. |
 | Disconnect | [DisconnectRequest](#xudrpc.DisconnectRequest) | [DisconnectResponse](#xudrpc.DisconnectResponse) | Disconnect from a connected peer XU node. |
 | GetInfo | [GetInfoRequest](#xudrpc.GetInfoRequest) | [GetInfoResponse](#xudrpc.GetInfoResponse) | Get general information about this Exchange Union node. |
-| GetOrders | [GetOrdersRequest](#xudrpc.GetOrdersRequest) | [GetOrdersResponse](#xudrpc.GetOrdersResponse) | Get a list of standing orders from the order book. |
+| GetOrders | [GetOrdersRequest](#xudrpc.GetOrdersRequest) | [GetOrdersResponse](#xudrpc.GetOrdersResponse) | Get a map between pair ids and their buy and sell orders from the order book. |
 | ListCurrencies | [ListCurrenciesRequest](#xudrpc.ListCurrenciesRequest) | [ListCurrenciesResponse](#xudrpc.ListCurrenciesResponse) | Get the list of the order book&#39;s supported currencies. |
 | ListPairs | [ListPairsRequest](#xudrpc.ListPairsRequest) | [ListPairsResponse](#xudrpc.ListPairsResponse) | Get the list of the order book&#39;s suported trading pairs. |
 | ListPeers | [ListPeersRequest](#xudrpc.ListPeersRequest) | [ListPeersResponse](#xudrpc.ListPeersResponse) | Get a list of connected peers. |

--- a/lib/cli/commands/cancelorder.ts
+++ b/lib/cli/commands/cancelorder.ts
@@ -2,14 +2,11 @@ import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { CancelOrderRequest } from '../../proto/xudrpc_pb';
 
-export const command = 'cancelorder <pair_id> <order_id>';
+export const command = 'cancelorder <order_id>';
 
 export const describe = 'cancel an order';
 
 export const builder = {
-  pair_id: {
-    type: 'string',
-  },
   order_id: {
     type: 'string',
   },
@@ -17,7 +14,6 @@ export const builder = {
 
 export const handler = (argv: Arguments) => {
   const request = new CancelOrderRequest();
-  request.setPairId(argv.pair_id.toUpperCase());
   request.setOrderId(argv.order_id);
   loadXudClient(argv).cancelOrder(request, callback);
 };

--- a/lib/cli/commands/getorders.ts
+++ b/lib/cli/commands/getorders.ts
@@ -2,7 +2,7 @@ import { Arguments } from 'yargs';
 import { callback, loadXudClient } from '../command';
 import { GetOrdersRequest } from '../../proto/xudrpc_pb';
 
-export const command = 'getorders <pair_id> [max_results]';
+export const command = 'getorders [pair_id] [max_results]';
 
 export const describe = 'get orders from the order book';
 
@@ -19,7 +19,9 @@ export const builder = {
 
 export const handler = (argv: Arguments) => {
   const request = new GetOrdersRequest();
-  request.setPairId(argv.pair_id.toUpperCase());
+  const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
+  request.setPairId(pairId);
   request.setMaxResults(argv.max_results);
+  request.setIncludeOwnOrders(true);
   loadXudClient(argv).getOrders(request, callback);
 };

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -1,6 +1,5 @@
 import grpc, { Server } from 'grpc';
 import assert from 'assert';
-import path from 'path';
 import Logger from '../Logger';
 import GrpcService from './GrpcService';
 import Service from '../service/Service';

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -226,15 +226,14 @@ class GrpcService {
         return ordersList;
       };
 
-      const getOrders = <T extends StampedOrder>(orderArrays: OrderSidesArrays<T>) => {
+      const ordersMap = response.getOrdersMap();
+      getOrdersResponse.forEach((orderArrays, pairId) => {
         const orders = new xudrpc.Orders();
         orders.setBuyOrdersList(getOrdersList(orderArrays.buy));
         orders.setSellOrdersList(getOrdersList(orderArrays.sell));
-        return orders;
-      };
 
-      response.setOwnOrders(getOrders(getOrdersResponse.ownOrders));
-      response.setPeerOrders(getOrders(getOrdersResponse.peerOrders));
+        ordersMap.set(pairId, orders);
+      });
 
       callback(null, response);
     } catch (err) {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -212,7 +212,7 @@
     },
     "/v1/orders": {
       "get": {
-        "summary": "Get a list of standing orders from the order book.",
+        "summary": "Get a map between pair ids and their buy and sell orders from the order book.",
         "operationId": "GetOrders",
         "responses": {
           "200": {
@@ -237,6 +237,14 @@
             "required": false,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "include_own_orders",
+            "description": "Whether own orders should be included in result or not.",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "format": "boolean"
           }
         ],
         "tags": [
@@ -477,10 +485,6 @@
         "order_id": {
           "type": "string",
           "title": "The local id of the order to cancel"
-        },
-        "pair_id": {
-          "type": "string",
-          "title": "The trading pair that the order to cancel is for"
         }
       }
     },
@@ -564,13 +568,12 @@
     "xudrpcGetOrdersResponse": {
       "type": "object",
       "properties": {
-        "peer_orders": {
-          "$ref": "#/definitions/xudrpcOrders",
-          "title": "A list of peer orders"
-        },
-        "own_orders": {
-          "$ref": "#/definitions/xudrpcOrders",
-          "title": "A list of orders placed locally"
+        "orders": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/xudrpcOrders"
+          },
+          "title": "A map between pair ids and their buy and sell orders"
         }
       }
     },

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -465,7 +465,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_GetInfoResponse,
     responseDeserialize: deserialize_xudrpc_GetInfoResponse,
   },
-  // Get a list of standing orders from the order book. 
+  // Get a map between pair ids and their buy and sell orders from the order book. 
   getOrders: {
     path: '/xudrpc.Xud/GetOrders',
     requestStream: false,

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -154,9 +154,6 @@ export class CancelOrderRequest extends jspb.Message {
     getOrderId(): string;
     setOrderId(value: string): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
-
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CancelOrderRequest.AsObject;
@@ -171,7 +168,6 @@ export class CancelOrderRequest extends jspb.Message {
 export namespace CancelOrderRequest {
     export type AsObject = {
         orderId: string,
-        pairId: string,
     }
 }
 
@@ -359,6 +355,9 @@ export class GetOrdersRequest extends jspb.Message {
     getMaxResults(): number;
     setMaxResults(value: number): void;
 
+    getIncludeOwnOrders(): boolean;
+    setIncludeOwnOrders(value: boolean): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
@@ -374,21 +373,14 @@ export namespace GetOrdersRequest {
     export type AsObject = {
         pairId: string,
         maxResults: number,
+        includeOwnOrders: boolean,
     }
 }
 
 export class GetOrdersResponse extends jspb.Message { 
 
-    hasPeerOrders(): boolean;
-    clearPeerOrders(): void;
-    getPeerOrders(): Orders | undefined;
-    setPeerOrders(value?: Orders): void;
-
-
-    hasOwnOrders(): boolean;
-    clearOwnOrders(): void;
-    getOwnOrders(): Orders | undefined;
-    setOwnOrders(value?: Orders): void;
+    getOrdersMap(): jspb.Map<string, Orders>;
+    clearOrdersMap(): void;
 
 
     serializeBinary(): Uint8Array;
@@ -403,8 +395,8 @@ export class GetOrdersResponse extends jspb.Message {
 
 export namespace GetOrdersResponse {
     export type AsObject = {
-        peerOrders?: Orders.AsObject,
-        ownOrders?: Orders.AsObject,
+
+        ordersMap: Array<[string, Orders.AsObject]>,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -1046,8 +1046,7 @@ proto.xudrpc.CancelOrderRequest.prototype.toObject = function(opt_includeInstanc
  */
 proto.xudrpc.CancelOrderRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    orderId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    pairId: jspb.Message.getFieldWithDefault(msg, 2, "")
+    orderId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
 
   if (includeInstance) {
@@ -1088,10 +1087,6 @@ proto.xudrpc.CancelOrderRequest.deserializeBinaryFromReader = function(msg, read
       var value = /** @type {string} */ (reader.readString());
       msg.setOrderId(value);
       break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setPairId(value);
-      break;
     default:
       reader.skipField();
       break;
@@ -1128,13 +1123,6 @@ proto.xudrpc.CancelOrderRequest.serializeBinaryToWriter = function(message, writ
       f
     );
   }
-  f = message.getPairId();
-  if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
-  }
 };
 
 
@@ -1150,21 +1138,6 @@ proto.xudrpc.CancelOrderRequest.prototype.getOrderId = function() {
 /** @param {string} value */
 proto.xudrpc.CancelOrderRequest.prototype.setOrderId = function(value) {
   jspb.Message.setField(this, 1, value);
-};
-
-
-/**
- * optional string pair_id = 2;
- * @return {string}
- */
-proto.xudrpc.CancelOrderRequest.prototype.getPairId = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
-};
-
-
-/** @param {string} value */
-proto.xudrpc.CancelOrderRequest.prototype.setPairId = function(value) {
-  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -2411,7 +2384,8 @@ proto.xudrpc.GetOrdersRequest.prototype.toObject = function(opt_includeInstance)
 proto.xudrpc.GetOrdersRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     pairId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    maxResults: jspb.Message.getFieldWithDefault(msg, 2, 0)
+    maxResults: jspb.Message.getFieldWithDefault(msg, 2, 0),
+    includeOwnOrders: jspb.Message.getFieldWithDefault(msg, 3, false)
   };
 
   if (includeInstance) {
@@ -2456,6 +2430,10 @@ proto.xudrpc.GetOrdersRequest.deserializeBinaryFromReader = function(msg, reader
       var value = /** @type {number} */ (reader.readUint32());
       msg.setMaxResults(value);
       break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setIncludeOwnOrders(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -2499,6 +2477,13 @@ proto.xudrpc.GetOrdersRequest.serializeBinaryToWriter = function(message, writer
       f
     );
   }
+  f = message.getIncludeOwnOrders();
+  if (f) {
+    writer.writeBool(
+      3,
+      f
+    );
+  }
 };
 
 
@@ -2529,6 +2514,23 @@ proto.xudrpc.GetOrdersRequest.prototype.getMaxResults = function() {
 /** @param {number} value */
 proto.xudrpc.GetOrdersRequest.prototype.setMaxResults = function(value) {
   jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional bool include_own_orders = 3;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.xudrpc.GetOrdersRequest.prototype.getIncludeOwnOrders = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 3, false));
+};
+
+
+/** @param {boolean} value */
+proto.xudrpc.GetOrdersRequest.prototype.setIncludeOwnOrders = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -2579,8 +2581,7 @@ proto.xudrpc.GetOrdersResponse.prototype.toObject = function(opt_includeInstance
  */
 proto.xudrpc.GetOrdersResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    peerOrders: (f = msg.getPeerOrders()) && proto.xudrpc.Orders.toObject(includeInstance, f),
-    ownOrders: (f = msg.getOwnOrders()) && proto.xudrpc.Orders.toObject(includeInstance, f)
+    ordersMap: (f = msg.getOrdersMap()) ? f.toObject(includeInstance, proto.xudrpc.Orders.toObject) : []
   };
 
   if (includeInstance) {
@@ -2618,14 +2619,10 @@ proto.xudrpc.GetOrdersResponse.deserializeBinaryFromReader = function(msg, reade
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = new proto.xudrpc.Orders;
-      reader.readMessage(value,proto.xudrpc.Orders.deserializeBinaryFromReader);
-      msg.setPeerOrders(value);
-      break;
-    case 2:
-      var value = new proto.xudrpc.Orders;
-      reader.readMessage(value,proto.xudrpc.Orders.deserializeBinaryFromReader);
-      msg.setOwnOrders(value);
+      var value = msg.getOrdersMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readMessage, proto.xudrpc.Orders.deserializeBinaryFromReader);
+         });
       break;
     default:
       reader.skipField();
@@ -2656,82 +2653,28 @@ proto.xudrpc.GetOrdersResponse.prototype.serializeBinary = function() {
  */
 proto.xudrpc.GetOrdersResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getPeerOrders();
-  if (f != null) {
-    writer.writeMessage(
-      1,
-      f,
-      proto.xudrpc.Orders.serializeBinaryToWriter
-    );
-  }
-  f = message.getOwnOrders();
-  if (f != null) {
-    writer.writeMessage(
-      2,
-      f,
-      proto.xudrpc.Orders.serializeBinaryToWriter
-    );
+  f = message.getOrdersMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(1, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeMessage, proto.xudrpc.Orders.serializeBinaryToWriter);
   }
 };
 
 
 /**
- * optional Orders peer_orders = 1;
- * @return {?proto.xudrpc.Orders}
+ * map<string, Orders> orders = 1;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,!proto.xudrpc.Orders>}
  */
-proto.xudrpc.GetOrdersResponse.prototype.getPeerOrders = function() {
-  return /** @type{?proto.xudrpc.Orders} */ (
-    jspb.Message.getWrapperField(this, proto.xudrpc.Orders, 1));
+proto.xudrpc.GetOrdersResponse.prototype.getOrdersMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,!proto.xudrpc.Orders>} */ (
+      jspb.Message.getMapField(this, 1, opt_noLazyCreate,
+      proto.xudrpc.Orders));
 };
 
 
-/** @param {?proto.xudrpc.Orders|undefined} value */
-proto.xudrpc.GetOrdersResponse.prototype.setPeerOrders = function(value) {
-  jspb.Message.setWrapperField(this, 1, value);
-};
-
-
-proto.xudrpc.GetOrdersResponse.prototype.clearPeerOrders = function() {
-  this.setPeerOrders(undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {!boolean}
- */
-proto.xudrpc.GetOrdersResponse.prototype.hasPeerOrders = function() {
-  return jspb.Message.getField(this, 1) != null;
-};
-
-
-/**
- * optional Orders own_orders = 2;
- * @return {?proto.xudrpc.Orders}
- */
-proto.xudrpc.GetOrdersResponse.prototype.getOwnOrders = function() {
-  return /** @type{?proto.xudrpc.Orders} */ (
-    jspb.Message.getWrapperField(this, proto.xudrpc.Orders, 2));
-};
-
-
-/** @param {?proto.xudrpc.Orders|undefined} value */
-proto.xudrpc.GetOrdersResponse.prototype.setOwnOrders = function(value) {
-  jspb.Message.setWrapperField(this, 2, value);
-};
-
-
-proto.xudrpc.GetOrdersResponse.prototype.clearOwnOrders = function() {
-  this.setOwnOrders(undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {!boolean}
- */
-proto.xudrpc.GetOrdersResponse.prototype.hasOwnOrders = function() {
-  return jspb.Message.getField(this, 2) != null;
+proto.xudrpc.GetOrdersResponse.prototype.clearOrdersMap = function() {
+  this.getOrdersMap().clear();
 };
 
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -59,7 +59,7 @@ service Xud {
     };
   }
   
-  /* Get a list of standing orders from the order book. */
+  /* Get a map between pair ids and their buy and sell orders from the order book. */
   rpc GetOrders(GetOrdersRequest) returns (GetOrdersResponse) {
     option (google.api.http) = {
       get: "/v1/orders"
@@ -176,8 +176,6 @@ message ChannelBalanceResponse {
 message CancelOrderRequest {
   // The local id of the order to cancel
   string order_id = 1 [json_name = "order_id"];
-  // The trading pair that the order to cancel is for
-  string pair_id = 2 [json_name = "pair_id"];
 }
 message CancelOrderResponse { }
 
@@ -209,12 +207,12 @@ message GetOrdersRequest {
   string pair_id = 1 [json_name = "pair_id"];
   // The maximum number of orders to return from either side of the order book
   uint32 max_results = 2 [json_name = "max_results"];
+  // Whether own orders should be included in result or not
+  bool include_own_orders = 3 [json_name = "include_own_orders"];
 }
 message GetOrdersResponse {
-  // A list of peer orders
-  Orders peer_orders = 1 [json_name = "peer_orders"];
-  // A list of orders placed locally
-  Orders own_orders = 2 [json_name = "own_orders"];
+  // A map between pair ids and their buy and sell orders
+  map<string, Orders> orders = 1 [json_name = "orders"];
 }
 
 message ListCurrenciesRequest {}

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -101,9 +101,9 @@ describe('OrderBook', () => {
 
     expect(() => orderBook.addLimitOrder(order)).to.throw();
 
-    expect(() => orderBook.removeOwnOrderByLocalId(order.pairId, order.localId)).to.not.throw();
+    expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
 
-    expect(() => orderBook.removeOwnOrderByLocalId(order.pairId, order.localId)).to.throw();
+    expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
 
     expect(() => orderBook.addLimitOrder(order)).to.not.throw();
 

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -74,17 +74,23 @@ describe('API Service', () => {
     const args = {
       pairId,
       maxResults: 0,
+      includeOwnOrders: true,
     };
     const orders = service.getOrders(args);
-    expect(orders.ownOrders.buy).to.have.length(1);
-    expect(orders.ownOrders.buy[0].price).to.equal(placeOrderArgs.price);
-    expect(orders.ownOrders.buy[0].quantity).to.equal(placeOrderArgs.quantity);
-    expect(orders.ownOrders.buy[0].pairId).to.equal(placeOrderArgs.pairId);
+
+    const pairOrders = orders.get(args.pairId);
+    expect(pairOrders).to.not.be.undefined;
+
+    expect(pairOrders!.buy).to.have.length(1);
+
+    const order = pairOrders!.buy[0];
+    expect(order.price).to.equal(placeOrderArgs.price);
+    expect(order.quantity).to.equal(placeOrderArgs.quantity);
+    expect(order.pairId).to.equal(placeOrderArgs.pairId);
   });
 
   it('should cancel an order', async () => {
     const args = {
-      pairId,
       orderId: '1',
     };
     await expect(service.cancelOrder(args)).to.be.fulfilled;


### PR DESCRIPTION
Closes #424

I don't think that `OrderTypes` is a good for a gRPC message name but I couldn't come up with anything better so feel free to suggest something else.

It is still unclear if `getOrders` should be renamed to `listOrders`. Any decisions on that?