### PR TITLE
Docs: add contribution and git commit guidelines

### DIFF
--- a/.git-commit-template.txt
+++ b/.git-commit-template.txt
@@ -1,0 +1,31 @@
+# HEADER
+# |<----  Using a Maximum Of 50 Characters  ---->|
+<type>(<scope>): <subject>
+# Type can be 
+#    feat     (A new feature)
+#    fix      (A bug fix)
+#    docs     (Documentation only changes)
+#    style    (Changes that do not affect the meaning of the code e.g. white-space, formatting, missing semi-colons, etc)
+#    refactor (A code change that neither fixes a bug nor adds a feature)
+#    perf     (A code change that improves performance)
+#    test     (Adding missing or correcting existing tests)
+#    chore    (Changes to the build process or auxiliary tools and libraries such as documentation generation)
+# An optional scope specifies the place of the commit change, e.g. orderbook, p2p, proto, swaps, etc...
+# You can use * when the change affects more than a single scope.
+# The subject contains succinct description of the change:
+#    Use the imperative, present tense: "change" not "changed" nor "changes"
+#    Don't capitalize first letter
+#    No dot (.) at the end
+
+# BODY
+# Just as in the subject, use the imperative, present tense: "change" not "changed" nor "changes".
+# The body should include the motivation for the change and contrast this with previous behavior.
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->
+
+
+# FOOTER
+# The footer should contain any information about Breaking Changes and is also the place to reference GitHub issues that this commit closes.
+# Breaking Changes should start with the word BREAKING CHANGE: with a space or two newlines. The rest of the commit message is then used for this.
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->
+
+# --- COMMIT END ---

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -2,4 +2,38 @@
 
 By contributing code to this project, you affirm that it is your original work and implicitly grant permission for it to be distributed under the [AGPL-3.0](LICENSE) license.
 
-Read more about contribution guidelines and how you can earn XUC for your contributions in our [how-to guide](https://github.com/ExchangeUnion/Docs/blob/master/How-to-contribute.md).
+Read about how you can earn XUC for your contributions in our [how-to guide](https://github.com/ExchangeUnion/Docs/blob/master/How-to-contribute.md).
+
+## Contribution Guidelines
+
+If you are new to contributing to open sources projects on GitHub, check out [this how-to](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github/).
+
+### Feature Branches & Pull Requests
+
+We use [feature branches](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) for development. Each branch and pull request should focus on a particular feature or issue. Ensure that new branches are created from the latest code in `master`. A branch must be approved by a user with commit access and must pass automated regression tests and lint checks before it can be merged into `master`.
+
+Pull requests will be reviewed and changes may be requested. If changes are required, make new commits directly to the feature branch. If there have been conflicting commits to `master` since a feature branch was created, either merge master into the branch or rebase the branch onto master using `git rebase`.
+
+When multiple commmits pertain to the same issue or feature, uou should squash then into a single commit or a maintainer will squash them before merging. For more complex pull requests that touch many parts of the code or implement multiple distinct changes to the code, please collapse commits according to their scope and affected changes. This can be performed through an interactive rebase with `git rebase -i`. Use `git commit --amend` when fixing minor typos or bugs with the most recent commit. These practices help maintain a clean and coherent commit history while preserving contribution authorship.
+
+### Commit Messages
+
+Commit messages should follow the [AngularJS Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines). The message header should start by specifying the type of change the commit implements, followed by the scope of the change in parentheses, and then a subject message summarizing the change. For example: `fix(orderbook): remove orders with 0 quantity`. The body of the commit message should elaborate on the changes and explain the motivation for the change.
+
+A git commit template is provided to assist with crafting proper commit messsages. You can enable it by running the following command in the folder where you have cloned `xud`:
+
+```shell
+git config commit.template .git-commit-template.txt
+```
+
+### Linting & Testing
+
+New test cases are appreciated for any pull requests that changes or adds new functionality. Although the current test suites are in early stages, thorough testing and code coverage is an important long term goal.
+
+All code is linted with [tslint](https://github.com/palantir/tslint) using a slightly modified [tslint adaptation](https://github.com/progre/tslint-config-airbnb) of [Airbnb's javascript style guide](https://github.com/airbnb/javascript). Ensure that your contributions pass all linting rules by running `npm run lint` or using a code editor with a tslint plugin. Per-line or per-file exceptions to linting rules are allowable in certain cases.
+
+### Commenting & Documentation
+
+Make your code legible by using descriptive variable, function, and class names. For blocks of codes, variables, and methods whose purpose is not readily apparent, add comments explaining what they do.
+
+Xud uses [TypeDoc](http://typedoc.org/guides/doccomments/) and follows the [Oracle Javadoc Style Guide](https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#styleguide) - any comments documenting specific classes, methods, properties should follow this convention.


### PR DESCRIPTION
Closes #432

This PR introduces guidelines for crafting commit messages, with the goal of making the commit history easier to read and allowing for automated changelog generation for releases. It also puts general
contribution guidelines directly in CONTRIBUTING.md.

I'm proposing following the AngularJS commit message guidelines, as they are recommended by https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli for generating changelogs automatically.

