### PR TITLE
Fixing travis build for PR 461

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
 
 before_install:
   - npm install node-pre-gyp
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,4 @@ script:
   - npm run test
 
 before_install:
-  - mysql -e 'CREATE USER 'xud'@'localhost'';
-  - mysql -e 'GRANT ALL PRIVILEGES ON `xud\_%`.* TO `xud`@`%`;'
+  - npm install node-pre-gyp


### PR DESCRIPTION
Hello just removed mysql configuration from travis and added a pre-required npm install to make travis build possible, somehow travis operating system wasn't able to find `node-pre-gyp` I just added it as a `before_install` condition to the configuration.

Also I've just tried to run with sqlite with your development seems okay to me, you're way better than me since that's your creation mostly so I didn't check codes in detail just checked how you implemented it :+1: 