### PR TITLE
Chore: fixing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
 before_install:
   - mysql -e 'CREATE USER 'xud'@'localhost'';
   - mysql -e 'GRANT ALL PRIVILEGES ON `xud\_%`.* TO `xud`@`%`;'
+  - npm install node-pre-gyp


### PR DESCRIPTION
This fixes an issue that was causing travis builds to fail by installing `node-pre-gyp`. It also removes mysql queries that are obsolete after the transition to sqlite.

Credit to @rsercano.