### PR TITLE
Chore: add nodejs current and lts travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - "8"
+  - "node"
+  - "lts/*"
 
 cache:
   directories:


### PR DESCRIPTION
Travis finally works with node 10! I made this build the latest stable node version as well as the long term support version. I figure it makes sense to keep pace with node releases and stop supporting any versions once they lose support from nodejs.