### PR TITLE
feat(p2p): add reputation events

### DIFF
--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -1,9 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import assert from 'assert';
 import Sequelize from 'sequelize';
 import Bluebird from 'bluebird';
-
 import Logger from '../Logger';
 import { db } from '../types';
 import { SwapClients } from '../types/enums';
@@ -12,6 +10,7 @@ type Models = {
   Node: Sequelize.Model<db.NodeInstance, db.NodeAttributes>;
   Currency: Sequelize.Model<db.CurrencyInstance, db.CurrencyAttributes>;
   Pair: Sequelize.Model<db.PairInstance, db.PairAttributes>;
+  ReputationEvent: Sequelize.Model<db.ReputationEventInstance, db.ReputationEventAttributes>;
 };
 
 /** A class representing a connection to a SQL database. */
@@ -45,11 +44,12 @@ class DB {
       this.logger.error('unable to connect to the database', err);
       throw err;
     }
-    const { Node, Currency, Pair } = this.models;
+    const { Node, Currency, Pair, ReputationEvent } = this.models;
     // sync schemas with the database in phases, according to FKs dependencies
     await Promise.all([
       Node.sync(),
       Currency.sync(),
+      ReputationEvent.sync(),
     ]);
     await Promise.all([
       Pair.sync(),

--- a/lib/db/models/ReputationEvent.ts
+++ b/lib/db/models/ReputationEvent.ts
@@ -1,0 +1,26 @@
+import Sequelize from 'sequelize';
+import { db } from '../../types';
+
+export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) => {
+  const attributes: db.SequelizeAttributes<db.ReputationEventAttributes> = {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    event: { type: DataTypes.INTEGER, allowNull: false },
+    nodeId: { type: DataTypes.INTEGER, allowNull: false },
+  };
+
+  const options: Sequelize.DefineOptions<db.ReputationEventInstance> = {
+    tableName: 'reputationEvents',
+    timestamps: true,
+    updatedAt: false,
+  };
+
+  const ReputationEvent = sequelize.define<db.ReputationEventInstance, db.ReputationEventAttributes>('ReputationEvent', attributes, options);
+
+  ReputationEvent.associate = (models: Sequelize.Models) => {
+    models.ReputationEvent.belongsTo(models.Node, {
+      foreignKey: 'nodeId',
+    });
+  };
+
+  return ReputationEvent;
+};

--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -1,17 +1,29 @@
-import Logger from '../Logger';
 import { Models } from '../db/DB';
 import { db } from '../types';
+import { NodeInstance } from '../types/db';
 
 class P2PRepository {
 
-  constructor(private logger: Logger, private models: Models) {}
+  constructor(private models: Models) {}
 
   public getNodes = async (): Promise<db.NodeInstance[]> => {
     return this.models.Node.findAll();
   }
 
+  public getReputationEvents = async (node: NodeInstance): Promise<db.ReputationEventInstance[]> => {
+    return this.models.ReputationEvent.findAll({
+      where: {
+        nodeId: node.id,
+      },
+    });
+  }
+
   public addNode = (node: db.NodeFactory) => {
     return this.models.Node.create(<db.NodeAttributes>node);
+  }
+
+  public addReputationEvent = async (event: db.ReputationEventFactory) => {
+    return this.models.ReputationEvent.create(<db.ReputationEventAttributes>event);
   }
 
   public addNodes = async (nodes: db.NodeFactory[]) => {

--- a/lib/types/db.ts
+++ b/lib/types/db.ts
@@ -1,6 +1,7 @@
 import Sequelize, { DataTypeAbstract, DefineAttributeColumnOptions } from 'sequelize';
 import { Address, NodeConnectionInfo } from './p2p';
 import { Currency, Pair } from './orders';
+import { ReputationEvent } from './enums';
 
 export type SequelizeAttributes<T extends { [key: string]: any }> = {
   [P in keyof T]: string | DataTypeAbstract | DefineAttributeColumnOptions
@@ -34,7 +35,9 @@ export type NodeAttributes = NodeFactory & {
   lastAddress: Address;
 };
 
-export type NodeInstance = NodeAttributes & Sequelize.Instance<NodeAttributes>;
+export type NodeInstance = NodeAttributes & Sequelize.Instance<NodeAttributes> & {
+  reputationScore: number;
+};
 
 export type PairFactory = Pair;
 
@@ -43,3 +46,16 @@ export type PairAttributes = PairFactory & {
 };
 
 export type PairInstance = PairAttributes & Sequelize.Instance<PairAttributes>;
+
+export type ReputationEventFactory = {
+  event: ReputationEvent;
+  nodeId: number;
+};
+
+export type ReputationEventAttributes = ReputationEventFactory & {
+  id: number;
+};
+
+export type ReputationEventInstance = ReputationEventAttributes & Sequelize.Instance<ReputationEventAttributes> & {
+  createdAt: number;
+};

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -40,3 +40,11 @@ export enum SwapDealState {
   Error = 1,
   Completed = 2,
 }
+
+export enum ReputationEvent {
+  ManualBan = 0,
+  ManualUnban = 1,
+  PacketTimeout = 2,
+  SwapFailure = 3,
+  SwapSuccess = 4,
+}

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -24,7 +24,7 @@ describe('OrderBook', () => {
     await db.init();
 
     orderBookRepository = new OrderBookRepository(loggers.orderbook, db.models);
-    const p2pRepository = new P2PRepository(loggers.p2p, db.models);
+    const p2pRepository = new P2PRepository(db.models);
 
     await p2pRepository.addNode(
       { nodePubKey: nodeKey.nodePubKey, addresses: [] },


### PR DESCRIPTION
Closes #470 

This PR implements reputation events as described in issue #470. Those events track the history of the behaviour of a node and are stored in the database.

I decided to move the pruning of old events and informing nodes that they got banned into separate follow up PRs.