### PR TITLE
chore: let Travis compile TypeScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     - "node_modules"
 
 script:
+  - npm run compile
   - npm run lintNoFix
   - npm run test
 


### PR DESCRIPTION
This commit lets Travis compile TypeScript to JavaScript from now on. I
think this makes sense because we are not compiling when
installing anymore.