### PR TITLE
chore: generate sample config on new version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ proto/xudrpc.proto linguist-vendored=false
 lib/proto/* linguist-generated
 package-lock.json linguist-generated
 docs/api.md linguist-generated
+sample-xud.conf linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,3 @@ dist/
 # typedoc
 typedoc/
 .DS_Store
-
-# example config
-sample-xud.conf

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "test:unit": "mocha -r ts-node/register test/unit/*",
     "test:unit:watch": "mocha -r ts-node/register test/unit/*  --watch --watch-extensions ts",
     "test:p2p": "mocha -r ts-node/register test/p2p/*",
-    "test:p2p:watch": "mocha -r ts-node/register test/p2p/*  --watch --watch-extensions ts"
+    "test:p2p:watch": "mocha -r ts-node/register test/p2p/*  --watch --watch-extensions ts",
+    "preversion": "npm run lintNoFix && npm test && npm run compile",
+    "version": "npm run config && git add sample-xud.conf"
   },
   "cross-os": {
     "postcompile": {

--- a/sample-xud.conf
+++ b/sample-xud.conf
@@ -1,0 +1,65 @@
+# Sample configuration file for xud
+#
+# This sample file contains the default values for all configuration
+# options for xud. Directories and file path options are platform &
+# user specific and are not included, but are explained below.
+#
+# 'xudir' is the directory for data stored by xud including logs,
+# keys, config and its database. Individual paths can be overridden
+# by settings such as 'logpath' and 'dbpath'.
+#
+# Each lnd config section will have 'macaroonpath' and 'certpath'
+# options specific to its chain.
+#
+# Default values:
+#
+# Linux
+# xudir = "/home/<user>/.xud"
+# certpath = "/home/<user>/.lnd/tls.cert"
+# macaroonpath = "/home/<user>/.lnd/data/chain/<currency>/<network>/admin.macaroon"
+#
+# Darwin (macOS)
+# xudir = "/Users/<user>/Library/Application Support/Xud"
+# certpath = "/Users/<user>/Library/Application Support/Lnd/tls.cert"
+# macaroonpath = "/Users/<user>/Library/Application Support/data/chain/<currency>/<network>/admin.macaroon"
+#
+# Windows
+# xudir = "C:\Users\<user>\AppData\Local\Xud"
+# certpath = "C:\Users\<user>\AppData\Local\Lnd\tls.cert"
+# macaroonpath = "C:\Users\<user>\AppData\Local\Lnd\data\chain\<currency>\<network>\admin.macaroon"
+
+initdb = true
+instanceid = 0
+loglevel = "debug"
+network = "testnet"
+
+[lndbtc]
+cltvdelta = 144
+disable = false
+host = "localhost"
+port = 10009
+
+[lndltc]
+cltvdelta = 576
+disable = false
+host = "localhost"
+port = 10010
+
+[p2p]
+addresses = []
+listen = true
+port = 8885
+
+[raiden]
+disable = false
+host = "localhost"
+port = 5001
+
+[rpc]
+disable = false
+host = "localhost"
+port = 8886
+
+[webproxy]
+disable = true
+port = 8080

--- a/tasks/config/sample.ts
+++ b/tasks/config/sample.ts
@@ -4,7 +4,37 @@ import fs from 'fs';
 import path from 'path';
 
 export default async () => {
-  let result = '';
+  let result = `# Sample configuration file for xud
+#
+# This sample file contains the default values for all configuration
+# options for xud. Directories and file path options are platform &
+# user specific and are not included, but are explained below.
+#
+# 'xudir' is the directory for data stored by xud including logs,
+# keys, config and its database. Individual paths can be overridden
+# by settings such as 'logpath' and 'dbpath'.
+#
+# Each lnd config section will have 'macaroonpath' and 'certpath'
+# options specific to its chain.
+#
+# Default values:
+#
+# Linux
+# xudir = "/home/<user>/.xud"
+# certpath = "/home/<user>/.lnd/tls.cert"
+# macaroonpath = "/home/<user>/.lnd/data/chain/<currency>/<network>/admin.macaroon"
+#
+# Darwin (macOS)
+# xudir = "/Users/<user>/Library/Application Support/Xud"
+# certpath = "/Users/<user>/Library/Application Support/Lnd/tls.cert"
+# macaroonpath = "/Users/<user>/Library/Application Support/data/chain/<currency>/<network>/admin.macaroon"
+#
+# Windows
+# xudir = "C:\\Users\\<user>\\AppData\\Local\\Xud"
+# certpath = "C:\\Users\\<user>\\AppData\\Local\\Lnd\\tls.cert"
+# macaroonpath = "C:\\Users\\<user>\\AppData\\Local\\Lnd\\data\\chain\\<currency>\\<network>\\admin.macaroon"
+
+`;
 
   const recursivelyConvertJsonToToml = (json: any, prefix: string) => {
     const nestedPairs: any = [];
@@ -12,9 +42,11 @@ export default async () => {
 
     if (!json) return;
 
-    Object.keys(json).sort().forEach((key: any) => {
-      if (Object.prototype.toString.call(json[key]) !== '[object Function]') {
-        (isPlainObject(json[key]) ? nestedPairs : simplePairs).push([key, json[key]]);
+    Object.keys(json).sort().forEach((key) => {
+      if (typeof json[key] !== 'function') {
+        if (!key.endsWith('path') && key !== 'xudir') {
+          (isPlainObject(json[key]) ? nestedPairs : simplePairs).push([key, json[key]]);
+        }
       }
     });
 


### PR DESCRIPTION
This commit updates the publish configuration to generate a sample config file before publishing and to include it among the published files.

Edit: The new approach generates the sample config file on the `npm version` script and checks it in via git. Closes #498.