### PR TITLE
fix: remove reference to db in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     depends_on:
       - btc
       - lnd
-      - db
     entrypoint: "npm start"
   # btc is an image of bitcoin node which used as base image for btcd and
   # btccli. The environment variables default values determined on stage of


### PR DESCRIPTION
This commit removes reference to `db` container removed by @sangaman in `docker-compose.yml` file.