### PR TITLE
refactor: remove maxResults from getOrders

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -268,7 +268,6 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | pair_id | [string](#string) |  | The trading pair for which to retrieve orders |
-| max_results | [uint32](#uint32) |  | The maximum number of orders to return from either side of the order book |
 | include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not |
 
 

--- a/lib/cli/commands/getorders.ts
+++ b/lib/cli/commands/getorders.ts
@@ -2,7 +2,7 @@ import { Arguments } from 'yargs';
 import { callback, loadXudClient } from '../command';
 import { GetOrdersRequest } from '../../proto/xudrpc_pb';
 
-export const command = 'getorders [pair_id] [max_results]';
+export const command = 'getorders [pair_id]';
 
 export const describe = 'get orders from the order book';
 
@@ -10,18 +10,12 @@ export const builder = {
   pair_id: {
     type: 'string',
   },
-  max_results: {
-    default: 10,
-    description: 'max # of orders to return, 0 = no limit',
-    type: 'number',
-  },
 };
 
 export const handler = (argv: Arguments) => {
   const request = new GetOrdersRequest();
   const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
   request.setPairId(pairId);
-  request.setMaxResults(argv.max_results);
   request.setIncludeOwnOrders(true);
   loadXudClient(argv).getOrders(request, callback);
 };

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -214,19 +214,19 @@ class MatchingEngine {
     }
   }
 
-  private getOrders = <T extends orders.StampedOrder>(lists: OrderSidesLists<T>, limit?: number): OrderSidesArrays<T> => {
+  private getOrders = <T extends orders.StampedOrder>(lists: OrderSidesLists<T>): OrderSidesArrays<T> => {
     return {
-      buy: Array.from(lists.buy.values()).slice(0, limit || lists.buy.size),
-      sell: Array.from(lists.sell.values()).slice(0, limit || lists.sell.size),
+      buy: Array.from(lists.buy.values()),
+      sell: Array.from(lists.sell.values()),
     };
   }
 
-  public getPeerOrders = (limit?: number): OrderSidesArrays<StampedPeerOrder> => {
-    return this.getOrders(this.peerOrders, limit);
+  public getPeerOrders = () => {
+    return this.getOrders(this.peerOrders);
   }
 
-  public getOwnOrders = (limit?: number) => {
-    return this.getOrders(this.ownOrders, limit);
+  public getOwnOrders = () => {
+    return this.getOrders(this.ownOrders);
   }
 
   /**

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -90,25 +90,25 @@ class OrderBook extends EventEmitter {
   /**
    * Get lists of buy and sell orders of peers.
    */
-  public getPeerOrders = (pairId: string, limit: number) => {
+  public getPeerOrders = (pairId: string) => {
     const matchingEngine = this.matchingEngines.get(pairId);
     if (!matchingEngine) {
       throw errors.PAIR_DOES_NOT_EXIST(pairId);
     }
 
-    return matchingEngine.getPeerOrders(limit);
+    return matchingEngine.getPeerOrders();
   }
 
   /**
    * Get lists of this node's own buy and sell orders.
    */
-  public getOwnOrders = (pairId: string, limit?: number) => {
+  public getOwnOrders = (pairId: string) => {
     const matchingEngine = this.matchingEngines.get(pairId);
     if (!matchingEngine) {
       throw errors.PAIR_DOES_NOT_EXIST(pairId);
     }
 
-    return matchingEngine.getOwnOrders(limit);
+    return matchingEngine.getOwnOrders();
   }
 
   public addPair = async (pair: Pair) => {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -231,14 +231,6 @@
             "type": "string"
           },
           {
-            "name": "max_results",
-            "description": "The maximum number of orders to return from either side of the order book.",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
             "name": "include_own_orders",
             "description": "Whether own orders should be included in result or not.",
             "in": "query",

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -352,9 +352,6 @@ export class GetOrdersRequest extends jspb.Message {
     getPairId(): string;
     setPairId(value: string): void;
 
-    getMaxResults(): number;
-    setMaxResults(value: number): void;
-
     getIncludeOwnOrders(): boolean;
     setIncludeOwnOrders(value: boolean): void;
 
@@ -372,7 +369,6 @@ export class GetOrdersRequest extends jspb.Message {
 export namespace GetOrdersRequest {
     export type AsObject = {
         pairId: string,
-        maxResults: number,
         includeOwnOrders: boolean,
     }
 }

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -2384,8 +2384,7 @@ proto.xudrpc.GetOrdersRequest.prototype.toObject = function(opt_includeInstance)
 proto.xudrpc.GetOrdersRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     pairId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    maxResults: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    includeOwnOrders: jspb.Message.getFieldWithDefault(msg, 3, false)
+    includeOwnOrders: jspb.Message.getFieldWithDefault(msg, 2, false)
   };
 
   if (includeInstance) {
@@ -2427,10 +2426,6 @@ proto.xudrpc.GetOrdersRequest.deserializeBinaryFromReader = function(msg, reader
       msg.setPairId(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readUint32());
-      msg.setMaxResults(value);
-      break;
-    case 3:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setIncludeOwnOrders(value);
       break;
@@ -2470,17 +2465,10 @@ proto.xudrpc.GetOrdersRequest.serializeBinaryToWriter = function(message, writer
       f
     );
   }
-  f = message.getMaxResults();
-  if (f !== 0) {
-    writer.writeUint32(
-      2,
-      f
-    );
-  }
   f = message.getIncludeOwnOrders();
   if (f) {
     writer.writeBool(
-      3,
+      2,
       f
     );
   }
@@ -2503,34 +2491,19 @@ proto.xudrpc.GetOrdersRequest.prototype.setPairId = function(value) {
 
 
 /**
- * optional uint32 max_results = 2;
- * @return {number}
- */
-proto.xudrpc.GetOrdersRequest.prototype.getMaxResults = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
-};
-
-
-/** @param {number} value */
-proto.xudrpc.GetOrdersRequest.prototype.setMaxResults = function(value) {
-  jspb.Message.setField(this, 2, value);
-};
-
-
-/**
- * optional bool include_own_orders = 3;
+ * optional bool include_own_orders = 2;
  * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
  * You should avoid comparisons like {@code val === true/false} in those cases.
  * @return {boolean}
  */
 proto.xudrpc.GetOrdersRequest.prototype.getIncludeOwnOrders = function() {
-  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 3, false));
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 2, false));
 };
 
 
 /** @param {boolean} value */
 proto.xudrpc.GetOrdersRequest.prototype.setIncludeOwnOrders = function(value) {
-  jspb.Message.setField(this, 3, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -48,9 +48,6 @@ const argChecks = {
     if (nodePubKey === '') throw errors.INVALID_ARGUMENT('nodePubKey must be specified');
   },
   HAS_PAIR_ID: ({ pairId }: { pairId: string }) => { if (pairId === '') throw errors.INVALID_ARGUMENT('pairId must be specified'); },
-  MAX_RESULTS_NOT_NEGATIVE: ({ maxResults }: { maxResults: number }) => {
-    if (maxResults < 0) throw errors.INVALID_ARGUMENT('maxResults cannot be negative');
-  },
   NON_ZERO_QUANTITY: ({ quantity }: { quantity: number }) => { if (quantity === 0) throw errors.INVALID_ARGUMENT('quantity must not equal 0'); },
   PRICE_NON_NEGATIVE: ({ price }: { price: number }) => { if (price < 0) throw errors.INVALID_ARGUMENT('price cannot be negative'); },
   VALID_CURRENCY: ({ currency }: { currency: string }) => {
@@ -186,8 +183,8 @@ class Service extends EventEmitter {
     let ownOrdersCount = 0;
     let numPairs = 0;
     for (const pairId of this.orderBook.pairIds) {
-      const peerOrders = this.orderBook.getPeerOrders(pairId, 0);
-      const ownOrders = this.orderBook.getOwnOrders(pairId, 0);
+      const peerOrders = this.orderBook.getPeerOrders(pairId);
+      const ownOrders = this.orderBook.getOwnOrders(pairId);
 
       peerOrdersCount += Object.keys(peerOrders.buy).length + Object.keys(peerOrders.sell).length;
       ownOrdersCount += Object.keys(ownOrders.buy).length + Object.keys(ownOrders.sell).length;
@@ -218,16 +215,15 @@ class Service extends EventEmitter {
   /**
    * Get a map between pair ids and its orders from the order book.
    */
-  public getOrders = (args: { pairId: string, maxResults: number, includeOwnOrders: boolean }): Map<string, OrderSidesArrays<any>> => {
-    const { pairId, maxResults, includeOwnOrders } = args;
-    argChecks.MAX_RESULTS_NOT_NEGATIVE(args);
+  public getOrders = (args: { pairId: string, includeOwnOrders: boolean }): Map<string, OrderSidesArrays<any>> => {
+    const { pairId, includeOwnOrders } = args;
 
     const result = new Map<string, OrderSidesArrays<any>>();
     const getOrderTypes = (pairId: string) => {
-      const orders = this.orderBook.getPeerOrders(pairId, maxResults);
+      const orders = this.orderBook.getPeerOrders(pairId);
 
       if (includeOwnOrders) {
-        const ownOrders: OrderSidesArrays<any> = this.orderBook.getOwnOrders(pairId, maxResults);
+        const ownOrders: OrderSidesArrays<any> = this.orderBook.getOwnOrders(pairId);
 
         orders.buy = [...orders.buy, ...ownOrders.buy];
         orders.sell = [...orders.sell, ...ownOrders.sell];

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -205,10 +205,8 @@ message GetInfoResponse {
 message GetOrdersRequest {
   // The trading pair for which to retrieve orders
   string pair_id = 1 [json_name = "pair_id"];
-  // The maximum number of orders to return from either side of the order book
-  uint32 max_results = 2 [json_name = "max_results"];
   // Whether own orders should be included in result or not
-  bool include_own_orders = 3 [json_name = "include_own_orders"];
+  bool include_own_orders = 2 [json_name = "include_own_orders"];
 }
 message GetOrdersResponse {
   // A map between pair ids and their buy and sell orders

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -45,7 +45,7 @@ describe('OrderBook', () => {
   });
 
   const getOwnOrder = (order: orders.StampedOwnOrder): orders.StampedOwnOrder | undefined => {
-    const ownOrders = orderBook.getOwnOrders(order.pairId, 0);
+    const ownOrders = orderBook.getOwnOrders(order.pairId);
     const arr = order.quantity > 0 ? ownOrders.buy : ownOrders.sell;
 
     for (const orderItem of arr) {

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -73,7 +73,6 @@ describe('API Service', () => {
   it('should get orders', async () => {
     const args = {
       pairId,
-      maxResults: 0,
       includeOwnOrders: true,
     };
     const orders = service.getOrders(args);


### PR DESCRIPTION
This PR removes `maxResults` and `limit` from the `getOrders` rpc call and all related internal calls. The reason for this is because orders are not ordered according to price internally - limiting the
number of orders returned simply picks an arbitrary set of orders rather than the orders with the best price. It is up to the client to sort and discard orders after they've been retrieved from `xud`.

I left a `max_results` argument on the cli call for now in case we want the cli itself to limit the number of orders displayed, which seems like a desirable feature.