### PR TITLE
test: prevent loading local config

### DIFF
--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import uuidv1 from 'uuid/v1';
-import Config from '../../lib/Config';
 import DB from '../../lib/db/DB';
 import OrderBook from '../../lib/orderbook/OrderBook';
 import OrderBookRepository from '../../lib/orderbook/OrderBookRepository';
@@ -16,13 +15,11 @@ describe('OrderBook', () => {
   let orderBookRepository: OrderBookRepository;
 
   before(async () => {
-    const config = new Config();
-    await config.load();
     const loggers = Logger.createLoggers(Level.WARN);
 
     db = new DB(loggers.db);
 
-    const nodeKey = NodeKey.load(config.xudir);
+    const nodeKey = NodeKey['generate']();
 
     await db.init();
 

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -31,11 +31,7 @@ describe('P2P Pool Tests', () => {
 
   before(async () => {
     const config = new Config();
-    config.load({
-      p2p: {
-        listen: false,
-      },
-    });
+    config.p2p.listen = false;
     db = new DB(loggers.db);
     await db.init();
 

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -1,9 +1,7 @@
 import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
-import DB from '../../lib/db/DB';
 import Logger, { Level } from '../../lib/Logger';
-import Config from '../../lib/Config';
 import { getUri } from '../../lib/utils/utils';
 
 chai.use(chaiAsPromised);
@@ -43,10 +41,8 @@ describe('P2P Sanity Tests', () => {
   let nodeTwoPort: number;
 
   before(async () => {
-    const config = new Config().load();
     nodeOneConfig = createConfig(1, 0);
     nodeTwoConfig = createConfig(2, 0);
-    const loggers = Logger.createLoggers(Level.WARN);
 
     nodeOne = new Xud();
     nodeTwo = new Xud();


### PR DESCRIPTION
This commit prevents the tests from loading the local configuration file. It also prevents loading the local node pub key from disk. This is unnecessary after the sqlite migration since we no longer may depend
on the local config to provide mysql connection info. Rather, errors in the local config file could cause tests to fail, and should no longer be a dependency for tests to pass.

I think a next step would be to stop the p2p simulation from reading & writing its node keys to disk. This could be done a couple of ways, one way would be to store the node key in the database (since tests use temporary databases stored only in memory), which I know we've discussed a bit and maybe should revisit.