### PR TITLE
feat(CLI): getinfo presents LND's alias

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -412,6 +412,7 @@
 | blockheight | [int32](#int32) |  |  |
 | uris | [string](#string) | repeated |  |
 | version | [string](#string) |  |  |
+| alias | [string](#string) |  |  |
 
 
 

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -187,6 +187,7 @@ class GrpcService {
         if (lndInfo.error) lnd.setError(lndInfo.error);
         if (lndInfo.uris) lnd.setUrisList(lndInfo.uris);
         if (lndInfo.version) lnd.setVersion(lndInfo.version);
+        if (lndInfo.alias) lnd.setAlias(lndInfo.alias);
         return lnd;
       });
       if (getInfoResponse.lndbtc) response.setLndbtc(getLndInfo(getInfoResponse.lndbtc));

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -23,6 +23,7 @@ type LndInfo = {
   blockheight?: number;
   uris?: string[];
   version?: string;
+  alias?: string;
 };
 
 type ChannelCount = {
@@ -126,6 +127,7 @@ class LndClient extends BaseClient {
     let uris: string[] | undefined;
     let version: string | undefined;
     let error: string | undefined;
+    let alias: string | undefined;
     if (this.isDisabled()) {
       error = errors.LND_IS_DISABLED.message;
     } else if (!this.isConnected()) {
@@ -141,6 +143,7 @@ class LndClient extends BaseClient {
         blockheight = lnd.blockHeight,
         uris = lnd.urisList,
         version = lnd.version;
+        alias = lnd.alias;
       } catch (err) {
         this.logger.error(`LND error: ${err}`);
         error = err.message;
@@ -148,11 +151,13 @@ class LndClient extends BaseClient {
     }
 
     return {
+      error,
       channels,
       chains,
       blockheight,
       uris,
       version,
+      alias,
     };
   }
 

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -648,6 +648,9 @@
         },
         "version": {
           "type": "string"
+        },
+        "alias": {
+          "type": "string"
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -571,6 +571,9 @@ export class LndInfo extends jspb.Message {
     getVersion(): string;
     setVersion(value: string): void;
 
+    getAlias(): string;
+    setAlias(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): LndInfo.AsObject;
@@ -590,6 +593,7 @@ export namespace LndInfo {
         blockheight: number,
         urisList: Array<string>,
         version: string,
+        alias: string,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -3748,7 +3748,8 @@ proto.xudrpc.LndInfo.toObject = function(includeInstance, msg) {
     chainsList: jspb.Message.getRepeatedField(msg, 3),
     blockheight: jspb.Message.getFieldWithDefault(msg, 4, 0),
     urisList: jspb.Message.getRepeatedField(msg, 5),
-    version: jspb.Message.getFieldWithDefault(msg, 6, "")
+    version: jspb.Message.getFieldWithDefault(msg, 6, ""),
+    alias: jspb.Message.getFieldWithDefault(msg, 7, "")
   };
 
   if (includeInstance) {
@@ -3809,6 +3810,10 @@ proto.xudrpc.LndInfo.deserializeBinaryFromReader = function(msg, reader) {
     case 6:
       var value = /** @type {string} */ (reader.readString());
       msg.setVersion(value);
+      break;
+    case 7:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setAlias(value);
       break;
     default:
       reader.skipField();
@@ -3879,6 +3884,13 @@ proto.xudrpc.LndInfo.serializeBinaryToWriter = function(message, writer) {
   if (f.length > 0) {
     writer.writeString(
       6,
+      f
+    );
+  }
+  f = message.getAlias();
+  if (f.length > 0) {
+    writer.writeString(
+      7,
       f
     );
   }
@@ -4015,6 +4027,21 @@ proto.xudrpc.LndInfo.prototype.getVersion = function() {
 /** @param {string} value */
 proto.xudrpc.LndInfo.prototype.setVersion = function(value) {
   jspb.Message.setField(this, 6, value);
+};
+
+
+/**
+ * optional string alias = 7;
+ * @return {string}
+ */
+proto.xudrpc.LndInfo.prototype.getAlias = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 7, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.LndInfo.prototype.setAlias = function(value) {
+  jspb.Message.setField(this, 7, value);
 };
 
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -243,6 +243,7 @@ message LndInfo {
   int32 blockheight = 4 [json_name = "blockheight"];
   repeated string uris = 5 [json_name = "uris"];
   string version = 6 [json_name = "version"];
+  string alias = 7 [json_name = "alias"];
 }
 
 message Order {


### PR DESCRIPTION
For ease of navigation, getinfo response for lndbtc and lndltc includes  the LND's alias.
Also fix a bug that error is not being provided in case LND is disable or not connected.