### PR TITLE
feat: check order book before accepting swap

### DIFF
--- a/lib/p2p/packets/types/SwapResponsePacket.ts
+++ b/lib/p2p/packets/types/SwapResponsePacket.ts
@@ -4,6 +4,7 @@ import PacketType from '../PacketType';
 // TODO: proper error handling
 export type SwapResponsePacketBody = {
   r_hash: string;
+  /** Specifies the accepted quantity (which may be less than the proposed quantity). */
   quantity: number;
   makerCltvDelta: number;
 };

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -15,9 +15,9 @@ type SwapDeal = {
   myRole: SwapDealRole;
   /** The most updated deal phase */
   phase: SwapDealPhase;
-  /** The most updated deal state. State works
-   * together with the phase to indicates the phase of the deal in it's
-   * life cycle and if the deal is active, errored or completed.
+  /**
+   * The most updated deal state. State works together with phase to indicate where the
+   * deal is in its life cycle and if the deal is active, errored, or completed.
    */
   state: SwapDealState;
   /** The reason for being in the current state. */
@@ -29,7 +29,6 @@ type SwapDeal = {
   /** The local id for the order being executed. */
   localOrderId: string;
   /** The quantity of the order to execute as proposed by the taker. */
-  // TODO: is it needed here? if yes, should be in satoshis
   proposedQuantity: number;
   /** The accepted quantity of the order to execute as accepted by the maker. */
   quantity?: number;
@@ -49,6 +48,8 @@ type SwapDeal = {
   makerCurrency: string;
   /** The CLTV delta from the current height that should be used to set the timelock for the final hop when sending to maker. */
   makerCltvDelta?: number;
+  /** The price of the order that's being executed. */
+  price: number;
   /** The hash of the preimage. */
   r_hash: string;
   r_preimage?: string;
@@ -59,14 +60,15 @@ type SwapDeal = {
   competionTime?: number
 };
 
+type OrderToAccept = {
+  quantityToAccept: number;
+  price: number;
+  localId: string;
+};
+
 interface Swaps {
-  // TODO: put swap.rejected and swap.accepted to work or delete them.
-  on(event: 'swap.rejected', listener: (deal: SwapDeal) => void): this;
-  on(event: 'swap.accepted', listener: (deal: SwapDeal, quantity: number) => void): this;
-  on(event: 'swap.paid', listener: (deal: SwapResult) => void): this;
+  on(event: 'swap.paid', listener: (swapResult: SwapResult) => void): this;
   on(event: 'swap.failed', listener: (deal: SwapDeal) => void): this;
-  emit(event: 'swap.rejected', deal: SwapDeal): boolean;
-  emit(event: 'swap.accepted', deal: SwapDeal, quantity: number): boolean;
   emit(event: 'swap.paid', swapResult: SwapResult): boolean;
   emit(event: 'swap.failed', deal: SwapDeal): boolean;
 }
@@ -95,7 +97,6 @@ class Swaps extends EventEmitter {
   }
 
   private bind() {
-    this.pool.on('packet.swapRequest', this.handleSwapRequest);
     this.pool.on('packet.swapResponse', this.handleSwapResponse);
     this.pool.on('packet.swapComplete', this.handleSwapComplete);
     this.pool.on('packet.swapError', this.handleSwapError);
@@ -234,10 +235,12 @@ class Swaps extends EventEmitter {
    * @param taker our local taker order
    * @returns the r_hash for the swap
    */
-  private beginSwap = (maker: StampedPeerOrder, taker: StampedOwnOrder): string | undefined => {
-    // do we create another order which has the same orderId?
-
+  public beginSwap = (maker: StampedPeerOrder, taker: StampedOwnOrder) => {
     const peer = this.pool.getPeer(maker.peerPubKey);
+
+    // TODO: check route to peer. Maybe there is no route or no capacity to send the amount
+    // TODO: check that pairID is LTC/BTC or handleSwapResponse fails
+
     const [baseCurrency, quoteCurrency] = maker.pairId.split('/');
 
     let takerCurrency: string;
@@ -280,6 +283,7 @@ class Swaps extends EventEmitter {
       ...swapRequestBody,
       peerPubKey: peer.nodePubKey!,
       localOrderId: taker.localId,
+      price: maker.price,
       phase: SwapDealPhase.SwapCreated,
       state: SwapDealState.Active,
       stateReason: '',
@@ -305,35 +309,29 @@ class Swaps extends EventEmitter {
   }
 
   /**
-   * Handles a request from a peer to create a swap deal. Creates a deal,
-   * and stores the deal in the local collection of deals. Responds to the peer with a swap response packet.
+   * Accepts a proposed deal for a specified amount if a route and CLTV delta could be determined
+   * for the swap. Stores the deal in the local collection of deals.
+   * @returns A promise resolving to `true` if the deal was accepted, `false` otherwise.
    */
-  private handleSwapRequest = async (requestPacket: packets.SwapRequestPacket, peer: Peer)  => {
-    assert(requestPacket.body, 'SwapRequestPacket does not contain a body');
-    const requestBody = requestPacket.body!;
-
-    // TODO: consider reduced quantity
+  public acceptDeal = async (orderToAccept: OrderToAccept, requestPacket: packets.SwapRequestPacket, peer: Peer): Promise<boolean> => {
     // TODO: max cltv to limit routes
     // TODO: consider the time gap between taking the routes and using them.
-    // TODO: multi route support (currenlt only 1)
+    // TODO: multi route support (currently only 1)
+    // TODO: check to make sure we don't already have a deal for the requested r_hash
+    const requestBody = requestPacket.body!;
 
-    // check that we have such an order on book. If not, issue an error and forget
-    if (!this.isOrderOnBook(requestBody.pairId, requestBody.orderId)) {
-      this.sendErrorToPeer(peer, requestBody.r_hash,
-          'order does not exist on book', requestPacket.header.id);
-      return;
-    }
+    const takerPubKey = peer.getLndPubKey(requestBody.takerCurrency)!;
 
-    // accept the deal
     const deal: SwapDeal = {
       ...requestBody,
+      takerPubKey,
       peerPubKey: peer.nodePubKey!,
-      localOrderId: '', // TODO: get local id from order book
-      quantity: requestBody.proposedQuantity,
+      price: orderToAccept.price,
+      localOrderId: orderToAccept.localId,
+      quantity: orderToAccept.quantityToAccept,
       phase: SwapDealPhase.SwapCreated,
       state: SwapDealState.Active,
       stateReason: '',
-      takerPubKey: peer.getLndPubKey(requestBody.takerCurrency),
       r_hash: requestBody.r_hash,
       myRole: SwapDealRole.Maker,
       createTime: Date.now(),
@@ -348,16 +346,7 @@ class Swaps extends EventEmitter {
     if (errMsg) {
       this.setDealState(deal, SwapDealState.Error, errMsg);
       this.sendErrorToPeer(peer, deal.r_hash, deal.stateReason, requestPacket.header.id);
-      return;
-    }
-
-    const heldAmount = this.checkAndHoldAmount(deal);
-    assert(heldAmount === 0 || heldAmount === deal.takerAmount,
-        'Partial amount is not yet supported');
-    if (heldAmount === 0) {
-      this.setDealState(deal, SwapDealState.Error, 'Can not swap. No capacity is available');
-      this.sendErrorToPeer(peer, deal.r_hash, deal.stateReason, requestPacket.header.id);
-      return;
+      return false;
     }
 
     let lndclient: LndClient;
@@ -369,9 +358,9 @@ class Swaps extends EventEmitter {
         lndclient = this.lndLtcClient;
         break;
       default:
-        this.setDealState(deal, SwapDealState.Error, 'Can not swap. Unsupported Taker currency.');
+        this.setDealState(deal, SwapDealState.Error, 'Can not swap. Unsupported taker currency.');
         this.sendErrorToPeer(peer, deal.r_hash, deal.stateReason, requestPacket.header.id);
-        return;
+        return false;
     }
 
     let height: number;
@@ -387,12 +376,12 @@ class Swaps extends EventEmitter {
       if (deal.makerToTakerRoutes.length === 0) {
         this.setDealState(deal, SwapDealState.Error, 'Can not swap. unable to find route to destination.');
         this.sendErrorToPeer(peer, deal.r_hash, deal.stateReason, requestPacket.header.id);
-        return;
+        return false;
       }
     } catch (err) {
       this.setDealState(deal, SwapDealState.Error, 'Can not swap. unable to find route to destination: ' + err.message);
       this.sendErrorToPeer(peer, deal.r_hash, deal.stateReason, requestPacket.header.id);
-      return;
+      return false;
     }
 
     try {
@@ -402,7 +391,7 @@ class Swaps extends EventEmitter {
     } catch (err) {
       this.setDealState(deal, SwapDealState.Error, 'Can not swap. Unable to fetch block height: ' + err.message);
       this.sendErrorToPeer(peer, deal.r_hash, deal.stateReason, requestPacket.header.id);
-      return;
+      return false;
     }
 
     const routeCltvDelta = deal.makerToTakerRoutes[0].getTotalTimeLock() - height;
@@ -428,6 +417,7 @@ class Swaps extends EventEmitter {
 
     peer.sendPacket(new packets.SwapResponsePacket(responseBody, requestPacket.header.id));
     this.setDealPhase(deal, SwapDealPhase.SwapAgreed);
+    return true;
   }
 
   /**
@@ -447,11 +437,17 @@ class Swaps extends EventEmitter {
     deal.makerCltvDelta = makerCltvDelta;
 
     if (quantity) {
-      // TODO: require a non-zero quantity value on accepted swap responses
-      if (quantity > deal.proposedQuantity) {
-        // TODO: this should not happen, abort deal and penalize peer
+      deal.quantity = quantity; // set the accepted quantity for the deal
+      if (quantity <= 0) {
+        // TODO: accepted quantity must be a positive number, abort deal and penalize peer
+      } else if (quantity > deal.proposedQuantity) {
+        // TODO: accepted quantity should not be greater than proposed quantity, abort deal and penalize peer
       } else if (quantity < deal.proposedQuantity) {
-        // TODO: the maker accepted only part of our swap request, adjust the deal amounts with Swaps.calculateSwapAmounts
+        // TODO: handle partial acceptance
+        // the maker accepted only part of our swap request, adjust the deal amounts
+        // const { takerAmount, makerAmount } = Swaps.calculateSwapAmounts(quantity, deal.price);
+        // deal.takerAmount = takerAmount;
+        // deal.makerAmount = makerAmount;
       }
     }
 

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -48,3 +48,10 @@ export enum ReputationEvent {
   SwapFailure = 3,
   SwapSuccess = 4,
 }
+
+export enum SwapFailureReason {
+  /** Could not find the order specified by a swap request. */
+  OrderNotFound,
+  /** The order specified by a swap request is on hold for a different ongoing swap. */
+  OrderUnavailable,
+}

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -18,6 +18,8 @@ type Order = MarketOrder & {
 type Local = {
   /** A local identifier for the order. */
   localId: string;
+  /** The amount of an order that is on hold pending swap exectuion. */
+  hold?: number;
 };
 
 type Remote = {


### PR DESCRIPTION
This PR moves much of the swap request handling logic to the order book where new checks verify that the order being swapped is available. If an order is unavailable, the swap requested is rejected with a
reason. If the order is at least partly available, the swap is accepted for the available amount. On partial accepts, the taker will readjust the swap amounts for the partly accepted quantity. This also removes
the unused `swap.accepted` and `swap.rejected` events.

Some functionality that will be needed to follow this up:

- Actually call queryRoutes (I have a separate commit ready to open after this PR, just didn't think it was best to put this in the same PR).
- Don't always invalidate the full order when an order is swapped, instead check how much quantity the swap was for and adjust the order, including freeing any holds. (I have a good idea of what needs to be done for this as well)
- Release the order on hold amount from the maker side on a swap failure.

Edit: I believe this Closes #421. Although I should probably make a separate issue for the next steps above.