### PR TITLE
style(lint): add space-before-function-paren rule

### DIFF
--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -314,7 +314,7 @@ class RaidenClient extends BaseClient {
    * @param channel_address the address of the channel to deposit to
    * @param balance the amount to deposit to the channel
    */
-  public depositToChannel = async(channel_address: string, balance: number): Promise<void> => {
+  public depositToChannel = async (channel_address: string, balance: number): Promise<void> => {
     const endpoint = `channels/${channel_address}`;
     const res = await this.sendRequest(endpoint, 'PATCH', { balance });
   }

--- a/tslint.json
+++ b/tslint.json
@@ -56,6 +56,15 @@
     "jsdoc-format": true,
     "no-unnecessary-type-assertion": true,
     "await-promise": [true, "Bluebird"],
-    "no-inferrable-types": true
+    "no-inferrable-types": true,
+    "space-before-function-paren": [true,
+      {
+        "anonymous": "always",
+        "named": "never",
+        "constructor": "never",
+        "asyncArrow": "always",
+        "method": "never"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This adds an automatically fixable rule to enforce style regarding a space before function parentheses. This style was already unofficially enforced and only one line in the code required fixing.