### PR TITLE
chore: modify list of published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,11 +96,10 @@
   "files": [
     "bin",
     "dist",
-    "docs",
-    "proto",
     "tasks",
     ".env",
-    "*.md"
+    "README.md",
+    "LICENSE"
   ],
   "dependencies": {
     "@exchangeunion/grpc-dynamic-gateway": "^0.3.6",


### PR DESCRIPTION
This commit removes unnecessary/informational files from our list of published files. This is because users that install from npm won't be looking in their `node_modules` folder for documentation, but rather in
our GitHub repository and similar online resources. Proto files are not needed because we use the static, generated files instead. The README is needed for use in the npm website. The LICENSE should be included with all copies of the code.