### PR TITLE
feat(SWAPS): cltv-delta

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -49,6 +49,10 @@ const { argv } = require('yargs')
       describe: 'Port of the lndBtc gRPC interface',
       type: 'number',
     },
+    'lndbtc.cltvdelta': {
+      describe: 'CLTV delta for the timelock of the final hop',
+      type: 'number',
+    },
     'lndltc.certpath': {
       describe: 'Path to the SSL certificate for lndLtc',
       type: 'string',
@@ -68,6 +72,10 @@ const { argv } = require('yargs')
     },
     'lndltc.port': {
       describe: 'Port of the lndLtc gRPC interface',
+      type: 'number',
+    },
+    'lndltc.cltvdelta': {
+      describe: 'CLTV delta for the timelock of the final hop',
       type: 'number',
     },
     'p2p.addresses': {

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -74,6 +74,7 @@ class Config {
       macaroonpath: path.join(lndDefaultDatadir, 'admin.macaroon'),
       host: 'localhost',
       port: 10009,
+      cltvdelta: 144,
     };
     this.lndltc = {
       disable: false,
@@ -81,6 +82,7 @@ class Config {
       macaroonpath: path.join(lndDefaultDatadir, 'admin.macaroon'),
       host: 'localhost',
       port: 10010,
+      cltvdelta: 576,
     };
     this.raiden = {
       disable: false,

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -354,7 +354,7 @@ class GrpcService {
    */
   public resolveHash: grpc.handleUnaryCall<ResolveRequest, ResolveResponse> = async (call, callback) => {
     try {
-      const resolveResponse = await this.service.resolveHash(call.request.toObject());
+      const resolveResponse = await this.service.resolveHash(call.request);
       const response = new ResolveResponse();
       if (resolveResponse) {
         response.setPreimage(resolveResponse);

--- a/lib/p2p/packets/types/SwapRequestPacket.ts
+++ b/lib/p2p/packets/types/SwapRequestPacket.ts
@@ -10,6 +10,7 @@ export type SwapRequestPacketBody = {
   makerCurrency: string;
   orderId: string;
   r_hash: string;
+  takerCltvDelta: number;
 };
 
 class SwapRequestPacket extends Packet<SwapRequestPacketBody> {

--- a/lib/p2p/packets/types/SwapResponsePacket.ts
+++ b/lib/p2p/packets/types/SwapResponsePacket.ts
@@ -5,6 +5,7 @@ import PacketType from '../PacketType';
 export type SwapResponsePacketBody = {
   r_hash: string;
   quantity: number;
+  makerCltvDelta: number;
 };
 
 class SwapResponsePacket extends Packet<SwapResponsePacketBody> {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -325,8 +325,8 @@ class Service extends EventEmitter {
   /**
    * resolveHash resolve hash to preimage.
    */
-  public resolveHash = async (args: { hash: string }) => {
-    return this.swaps.resolveHash(args);
+  public resolveHash = async (request: lndrpc.ResolveRequest) => {
+    return this.swaps.resolveHash(request);
   }
 }
 export default Service;


### PR DESCRIPTION
Both maker and taker can now specify via command line or configuration file a value for final hope cltv-delta. This value is used to calculate the cltv-delta when sending to the maker and to the taker. the maker's cltv-delta includes the taker's cltv-delta converted by the ration between the two cltv-deltas.

Both maker and taker now verify the received amount to make sure it matches the agreed amount.
In additon both take and maker verify the received cltv-delta time lock against the agreed one.

These checks are done as part of the resolver work. In case of a wrong value, the preImage is not discloused and error is raised.

Left to be done: cltv-delta in case of multi hops route.
