### PR TITLE
test(orderbook): add case to partly fill & cancel

### DIFF
--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -94,6 +94,14 @@ describe('OrderBook', () => {
     expect(getOwnOrder(<orders.StampedOwnOrder>taker)).to.be.undefined;
   });
 
+  it('should create, partially match, and cancel an order', async () => {
+    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 10 };
+    await orderBook.addLimitOrder(order);
+    const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: -5 };
+    await orderBook.addMarketOrder(takerOrder);
+    expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
+  });
+
   it('should not add a new own order with a duplicated localId', async () => {
     const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: -10, price: 100 };
 


### PR DESCRIPTION
This adds a test case to the order book integration tests to simulate adding, partially filling, and then canceling the remaining portion of the order.

#506 made me realize we don't have any logic like this and it seemd like a worthwhile case to have.