### PR TITLE
fix(config): use custom config file path

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -90,10 +90,10 @@ class Config {
   }
 
   public load(args?: { [argName: string]: any }): Config {
-    const configPath = path.join(this.xudir, 'xud.conf');
     if (args && args.xudir) {
       this.updateDefaultPaths(args.xudir);
     }
+    const configPath = path.join(this.xudir, 'xud.conf');
     if (!fs.existsSync(this.xudir)) {
       fs.mkdirSync(this.xudir);
     } else if (fs.existsSync(configPath)) {


### PR DESCRIPTION
This fixes a bug where passing a custom `xudir` argument does not load the config file from that directory, but rather the default `xudir` directory.

Fixes bug introduced in #502.