### PR TITLE
feat(SWAPS): cltv-delta Part 2

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -293,6 +293,20 @@ class LndClient extends BaseClient {
   }
 
   /**
+   * List all routes to destination.
+   */
+  public queryRoutes = (request: lndrpc.QueryRoutesRequest): Promise<lndrpc.QueryRoutesResponse> => {
+    return this.unaryCallNative<lndrpc.QueryRoutesRequest, lndrpc.QueryRoutesResponse>('queryRoutes', request);
+  }
+
+  /**
+   * Send amount to destination using pre-defined routes.
+   */
+  public sendToRouteSync = (request: lndrpc.SendToRouteRequest): Promise<lndrpc.SendResponse> => {
+    return this.unaryCallNative<lndrpc.SendToRouteRequest, lndrpc.SendResponse>('sendToRouteSync', request);
+  }
+
+  /**
    * Attempt to close an open channel.
    */
   public closeChannel = (fundingTxId: string, outputIndex: number, force: boolean): void => {

--- a/lib/p2p/packets/types/SwapErrorPacket.ts
+++ b/lib/p2p/packets/types/SwapErrorPacket.ts
@@ -12,7 +12,11 @@ class SwapErrorPacket extends Packet<SwapErrorPacketBody> {
     return PacketType.SwapError;
   }
 
-  public get direction() {
+  public get direction(): PacketDirection {
+    // SwapErrorPacket may serve as a response to SwapRequest packet
+    if (this.header.reqId) {
+      return PacketDirection.Response;
+    }
     return PacketDirection.Unilateral;
   }
 }


### PR DESCRIPTION
closes #431 
closes #421
closes #413 (with the exception of RPC timeouts which deserve a separate issue)

Maker to Taker routes
Place holder for isOrderOnBook - checks by maker before accepting a swap
Place holder for checkAndHoldAmount - uses by maker before accepting a swap. currently can't return partial amount (all or nothing).
Verify LND setup - checks that peer has LNDs PubKeys for BTC and LTC
Queryroutes - use queryroutes to check if there is a route between the maker and the taker and the implication of the route on the maker's cltvDelta.
Maker's cltvDelta better calcualtion.