### PR TITLE
feat: update handshake on lnd pubkey change

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -12,7 +12,6 @@ import NodeKey from './nodekey/NodeKey';
 import Service from './service/Service';
 import { EventEmitter } from 'events';
 import Swaps from './swaps/Swaps';
-import path from 'path';
 
 const version: string = require('../package.json').version;
 
@@ -141,9 +140,24 @@ class Xud extends EventEmitter {
       } else {
         this.logger.warn('RPC server is disabled.');
       }
+
+      this.bind();
     } catch (err) {
       this.logger.error(err);
     }
+  }
+
+  private bind = () => {
+    this.lndbtcClient.on('connectionVerified', (newPubKey) => {
+      if (newPubKey) {
+        this.pool.updateHandshake({ lndbtcPubKey: newPubKey });
+      }
+    });
+    this.lndltcClient.on('connectionVerified', (newPubKey) => {
+      if (newPubKey) {
+        this.pool.updateHandshake({ lndltcPubKey: newPubKey });
+      }
+    });
   }
 
   private shutdown = async () => {

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -558,6 +558,15 @@ class Peer extends EventEmitter {
   }
 
   private handleHello = (packet: packets.HelloPacket): void => {
+    const helloBody = packet.body!;
+    this.logger.verbose(`received hello packet from ${this.nodePubKey || addressUtils.toString(this.address)}: ${JSON.stringify(helloBody)}`);
+    if (this.nodePubKey && this.nodePubKey !== helloBody.nodePubKey) {
+      // peers cannot change their nodepubkey while we are connected to them
+      // TODO: penalize?
+      this.close();
+      return;
+    }
+
     this.handshakeState = packet.body;
 
     const entry = this.responseMap.get(PacketType.Hello);
@@ -628,4 +637,4 @@ class Job {
 }
 
 export default Peer;
-export { HandshakeState, PeerInfo };
+export { PeerInfo };

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -10,7 +10,7 @@ import { Packet, PacketType } from './packets';
 import { OutgoingOrder, OrderPortion, StampedPeerOrder } from '../types/orders';
 import { Models } from '../db/DB';
 import Logger from '../Logger';
-import { HandshakeState, Address, NodeConnectionInfo } from '../types/p2p';
+import { HandshakeState, Address, NodeConnectionInfo, HandshakeStateUpdate } from '../types/p2p';
 import addressUtils from '../utils/addressUtils';
 import { getExternalIp } from '../utils/utils';
 import assert from 'assert';
@@ -134,6 +134,18 @@ class Pool extends EventEmitter {
 
     this.verifyReachability();
     this.connected = true;
+  }
+
+  /**
+   * Updates the handshake data and sends a new Hello packet to currently connected
+   * peers to notify them of the change.
+   */
+  public updateHandshake = (handshakeUpdate: HandshakeStateUpdate) => {
+    this.handshakeData = { ...this.handshakeData, ...handshakeUpdate };
+    const packet = new packets.HelloPacket(this.handshakeData);
+    this.peers.forEach((peer) => {
+      peer.sendPacket(packet);
+    });
   }
 
   public disconnect = async (): Promise<void> => {

--- a/lib/types/p2p.ts
+++ b/lib/types/p2p.ts
@@ -22,6 +22,14 @@ export type HandshakeState = {
   lndltcPubKey?: string;
 };
 
+export type HandshakeStateUpdate = {
+  addresses?: Address[];
+  pairs?: string[];
+  raidenAddress?: string;
+  lndbtcPubKey?: string;
+  lndltcPubKey?: string;
+};
+
 export function isHandshakeState(obj: any): obj is HandshakeState {
   return obj && typeof obj.version === 'string' && typeof obj.nodePubKey === 'string' && Array.isArray(obj.addresses)
     && Array.isArray(obj.pairs);


### PR DESCRIPTION
Closes #513.

This commit creates an event for when a LightningClient verifies (or re-verifies) a connection to an lnd server. It includes the lnd identity pub key if it changed. When the pub key changes, the new value
is broadcast to all currently connected peers within a new Hello packet. This allows for switches of lnd servers without requiring a restart of xud, and also will inform peers of lnd pub keys when lnd comes back online should lnd be offline at the time of peer connection.

I've tested this locally and it seems to be working well. Here's what the log output looks like on the remote peer receiving the handshake update, below is the original and the updated handshake.

```
2018-9-23 15:46:03 [P2P] verbose: received hello packet from 127.0.0.1:9885: {"version":"1.0.0-prealpha.4","pairs":["LTC/BTC"],"nodePubKey":"029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345","addresses":[{"host":"75.75.58.83","port":8885},{"host":"127.0.0.1","port":8885}]}
...
2018-9-23 15:47:06 [P2P] verbose: received hello packet from 029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345: {"version":"1.0.0-prealpha.4","pairs":["LTC/BTC"],"nodePubKey":"029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345","lndbtcPubKey":"036c566039991ed0203667b9d9ac19cd67a8230de3761adbca80a6d54ab4ed7a54","addresses":[{"host":"75.75.58.83","port":8885},{"host":"127.0.0.1","port":8885}]}

