### PR TITLE
style(config): use lower case for all config vars

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -4,22 +4,22 @@ const Xud = require('../dist/Xud').default;
 
 const { argv } = require('yargs')
   .options({
-    dbPath: {
+    dbpath: {
       describe: 'The file path for the database',
       type: 'string',
       alias: 'd',
     },
-    initDb: {
+    initdb: {
       describe: 'Whether to initialize the db with data',
       type: 'boolean',
       default: undefined,
     },
-    logLevel: {
+    loglevel: {
       describe: 'Verbosity of the logger',
       type: 'string',
       alias: 'l',
     },
-    logPath: {
+    logpath: {
       describe: 'Path to the log file',
       type: 'string',
     },

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -11,18 +11,18 @@ import { Level } from './Logger';
 class Config {
   public p2p: PoolConfig;
   public xudir: string;
-  public logLevel: string;
-  public logPath: string;
+  public loglevel: string;
+  public logpath: string;
   public rpc: { disable: boolean, host: string, port: number };
   public lndbtc: LndClientConfig;
   public lndltc: LndClientConfig;
   public raiden: RaidenClientConfig;
   public webproxy: { port: number, disable: boolean };
-  public instanceId = 0;
+  public instanceid = 0;
   /** Whether to intialize a new database with default values. */
-  public initDb: boolean;
+  public initdb: boolean;
   /** The file path for the database, or ':memory:' if the database should be kept in memory. */
-  public dbPath: string;
+  public dbpath: string;
 
   constructor() {
     const platform = os.platform();
@@ -49,10 +49,10 @@ class Config {
     }
 
     // default configuration
-    this.initDb = true;
-    this.dbPath = this.getDefaultDbPath();
-    this.logLevel = this.getDefaultLogLevel();
-    this.logPath = this.getDefaultLogPath();
+    this.initdb = true;
+    this.dbpath = this.getDefaultDbPath();
+    this.loglevel = this.getDefaultLogLevel();
+    this.logpath = this.getDefaultLogPath();
 
     this.p2p = {
       listen: true,
@@ -119,11 +119,11 @@ class Config {
       deepMerge(this, args);
     }
 
-    if (!Object.values(Level).includes(this.logLevel)) {
-      this.logLevel = this.getDefaultLogLevel();
+    if (!Object.values(Level).includes(this.loglevel)) {
+      this.loglevel = this.getDefaultLogLevel();
     }
 
-    this.createLogDir(this.logPath);
+    this.createLogDir(this.logpath);
 
     return this;
   }
@@ -144,8 +144,8 @@ class Config {
     // if we have a custom xu directory, update the default values for all fields that are
     // derived from the xu directory.
     this.xudir = xudir;
-    this.logPath = this.getDefaultLogPath();
-    this.dbPath = this.getDefaultDbPath();
+    this.logpath = this.getDefaultLogPath();
+    this.dbpath = this.getDefaultDbPath();
   }
 
   private getDefaultDbPath = () => {

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -58,17 +58,17 @@ class Xud extends EventEmitter {
    */
   public start = async (args?: { [argName: string]: any }) => {
     this.config.load(args);
-    const loggers = Logger.createLoggers(this.config.logLevel, this.config.logPath, this.config.instanceId);
+    const loggers = Logger.createLoggers(this.config.loglevel, this.config.logpath, this.config.instanceid);
     this.logger = loggers.global;
     this.logger.info('config loaded');
 
     try {
       // TODO: wait for decryption of existing key or encryption of new key, config option to disable encryption
-      this.nodeKey = NodeKey.load(this.config.xudir, this.config.instanceId);
+      this.nodeKey = NodeKey.load(this.config.xudir, this.config.instanceid);
       this.logger.info(`Local nodePubKey is ${this.nodeKey.nodePubKey}`);
 
-      this.db = new DB(loggers.db, this.config.dbPath);
-      await this.db.init(this.config.initDb);
+      this.db = new DB(loggers.db, this.config.dbpath);
+      await this.db.init(this.config.initdb);
 
       const initPromises: Promise<void>[] = [];
 

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -20,10 +20,10 @@ describe('API Service', () => {
 
   before(async () => {
     const config = {
-      initDb: false,
-      dbPath: ':memory:',
-      logLevel: 'warn',
-      logPath: '',
+      initdb: false,
+      dbpath: ':memory:',
+      loglevel: 'warn',
+      logpath: '',
       p2p: {
         listen: false,
       },

--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -13,8 +13,8 @@ describe('WebProxy', () => {
         disable: false,
         port: 8080,
       },
-      logPath: '',
-      logLevel: 'warn',
+      logpath: '',
+      loglevel: 'warn',
       p2p: {
         listen: false,
       },

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -20,12 +20,12 @@ const getUnusedPort = async () => {
   });
 };
 
-const createConfig = (instanceId: number, p2pPort: number) => ({
-  instanceId,
-  initDb: false,
-  dbPath: ':memory:',
-  logLevel: 'warn',
-  logPath: '',
+const createConfig = (instanceid: number, p2pPort: number) => ({
+  instanceid,
+  initdb: false,
+  dbpath: ':memory:',
+  loglevel: 'warn',
+  logpath: '',
   p2p: {
     listen: true,
     port: p2pPort,


### PR DESCRIPTION
This commit uses all lower case for all config variables to be both internally consistent and consistent with the config naming style found in both btcd/bitcoind and lnd.