### PR TITLE
Use new lnd 0.5 macaroon paths

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -7,12 +7,14 @@ import { PoolConfig } from './p2p/Pool';
 import { LndClientConfig } from './lndclient/LndClient';
 import { RaidenClientConfig } from './raidenclient/RaidenClient';
 import { Level } from './Logger';
+import { Network } from './types/enums';
 
 class Config {
   public p2p: PoolConfig;
   public xudir: string;
   public loglevel: string;
   public logpath: string;
+  public network: Network;
   public rpc: { disable: boolean, host: string, port: number };
   public lndbtc: LndClientConfig;
   public lndltc: LndClientConfig;
@@ -53,6 +55,7 @@ class Config {
     this.dbpath = this.getDefaultDbPath();
     this.loglevel = this.getDefaultLogLevel();
     this.logpath = this.getDefaultLogPath();
+    this.network = Network.TestNet;
 
     this.p2p = {
       listen: true,

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -31,21 +31,21 @@ class Config {
     let lndDefaultDatadir;
     switch (platform) {
       case 'win32': { // windows
-        const homeDir = process.env.LOCALAPPDATA;
-        this.xudir = `${homeDir}/Xud/`;
-        lndDefaultDatadir = `${homeDir}/Lnd/`;
+        const homeDir = process.env.LOCALAPPDATA!;
+        this.xudir = path.join(homeDir, 'Xud');
+        lndDefaultDatadir = path.join(homeDir, 'Lnd');
         break;
       }
       case 'darwin': { // mac
-        const homeDir = process.env.HOME;
-        this.xudir = `${homeDir}/.xud/`;
-        lndDefaultDatadir = `${homeDir}/Library/Application Support/Lnd/`;
+        const homeDir = process.env.HOME!;
+        this.xudir = path.join(homeDir, '.xud');
+        lndDefaultDatadir = path.join(homeDir, 'Library', 'Application Support', 'Lnd');
         break;
       }
       default: { // linux
-        const homeDir = process.env.HOME;
-        this.xudir = `${homeDir}/.xud/`;
-        lndDefaultDatadir = `${homeDir}/.lnd/`;
+        const homeDir = process.env.HOME!;
+        this.xudir = path.join(homeDir, '.xud');
+        lndDefaultDatadir = path.join(homeDir, '.lnd');
         break;
       }
     }
@@ -74,7 +74,7 @@ class Config {
     this.lndbtc = {
       disable: false,
       certpath: path.join(lndDefaultDatadir, 'tls.cert'),
-      macaroonpath: path.join(lndDefaultDatadir, 'admin.macaroon'),
+      macaroonpath: path.join(lndDefaultDatadir, 'data', 'chain', 'bitcoin', this.network, 'admin.macaroon'),
       host: 'localhost',
       port: 10009,
       cltvdelta: 144,
@@ -82,7 +82,7 @@ class Config {
     this.lndltc = {
       disable: false,
       certpath: path.join(lndDefaultDatadir, 'tls.cert'),
-      macaroonpath: path.join(lndDefaultDatadir, 'admin.macaroon'),
+      macaroonpath: path.join(lndDefaultDatadir, 'data', 'chain', 'litecoin', this.network, 'admin.macaroon'),
       host: 'localhost',
       port: 10010,
       cltvdelta: 576,

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -14,6 +14,13 @@ export enum OrderSide {
   Sell,
 }
 
+export enum Network {
+  MainNet = 'mainnet',
+  TestNet = 'testnet',
+  SimNet = 'simnet',
+  RegTest = 'regtest',
+}
+
 export enum SwapDealRole {
   Taker = 0,
   Maker = 1,

--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -1,18 +1,20 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import Xud from '../../lib/Xud';
+import { getUnusedPort } from '../utils';
 
-describe('WebProxy', () => {
+describe('WebProxy', async () => {
   let xud: Xud;
   let config: any;
   chai.use(chaiHttp);
+  const port = await getUnusedPort();
 
   before(async () => {
     config = {
       dbpath: ':memory:',
       webproxy: {
+        port,
         disable: false,
-        port: 8080,
       },
       logpath: '',
       loglevel: 'warn',

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -2,23 +2,9 @@ import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import { getUri } from '../../lib/utils/utils';
-import net from 'net';
+import { getUnusedPort } from '../utils';
 
 chai.use(chaiAsPromised);
-
-const getUnusedPort = async () => {
-  return new Promise<number>((resolve, reject) => {
-    const server = net.createServer();
-    server.unref();
-    server.on('error', reject);
-    server.listen(0, () => {
-      const { port } = server.address();
-      server.close(() => {
-        resolve(port);
-      });
-    });
-  });
-};
 
 const createConfig = (instanceid: number, p2pPort: number) => ({
   instanceid,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,18 @@
+import net from 'net';
+
+/**
+ * Discovers and returns a dynamically assigned, unused port available for testing.
+ */
+export const getUnusedPort = async () => {
+  return new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, () => {
+      const { port } = server.address();
+      server.close(() => {
+        resolve(port);
+      });
+    });
+  });
+};


### PR DESCRIPTION
This PR adds a config option that specifies the network for lnd clients, defaulting to `testnet`, and uses it for setting the default macaroon paths to use the new paths in lnd 0.5.

I'd originally had a `network` value for both lndbtc and lndltc clients, but changed it to be global. Will we envision ever having a use case of running lnd clients simultaneously on separate networks? e.g. simnet on one and testnet on the other?