### PR TITLE
fix: don't send order invalidation to taker

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -64,7 +64,7 @@ class OrderBook extends EventEmitter {
       this.swaps.on('swap.paid', (deal) => {
         if (deal.myRole === SwapDealRole.Maker) {
           // assume full order execution of an own order
-          this.removeOwnOrder(deal.orderId, deal.pairId);
+          this.removeOwnOrder(deal.orderId, deal.pairId, deal.takerPubKey);
 
           // TODO: handle partial order execution, updating existing order
         }
@@ -253,9 +253,10 @@ class OrderBook extends EventEmitter {
 
   /**
    * Attempts to remove a local order from the order book.
+   * @param takerPubKey the node pub key of the taker who filled this order, if applicable
    * @returns true if an order was removed, otherwise false
    */
-  private removeOwnOrder = (orderId: string, pairId: string): boolean => {
+  private removeOwnOrder = (orderId: string, pairId: string, takerPubKey?: string): boolean => {
     const matchingEngine = this.matchingEngines.get(pairId);
     if (!matchingEngine) {
       this.logger.warn(`invalid pairId: ${pairId}`);
@@ -275,7 +276,7 @@ class OrderBook extends EventEmitter {
       this.pool.broadcastOrderInvalidation({
         orderId,
         pairId,
-      });
+      }, takerPubKey);
     }
 
     return true;

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -314,9 +314,17 @@ class Pool extends EventEmitter {
     // TODO: send only to peers which accepts the pairId
   }
 
-  public broadcastOrderInvalidation = (order: OrderIdentifier) => {
+  /**
+   * Broadcasts an [[OrderInvalidationPacket]] to all currently connected peers.
+   * @param nodeToExclude the node pub key of a node to exclude from the packet broadcast
+   */
+  public broadcastOrderInvalidation = (order: OrderIdentifier, nodeToExclude?: string) => {
     const orderInvalidationPacket = new packets.OrderInvalidationPacket(order);
-    this.peers.forEach(peer => peer.sendPacket(orderInvalidationPacket));
+    this.peers.forEach((peer) => {
+      if (!nodeToExclude || peer.nodePubKey !== nodeToExclude) {
+        peer.sendPacket(orderInvalidationPacket);
+      }
+    });
 
     // TODO: send only to peers which accepts the pairId
   }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -22,6 +22,8 @@ type SwapDeal = {
   state: SwapDealState;
   /** The reason for being in current state */
   stateReason: string;
+  /** The xud node pub key of the counterparty to this swap deal. */
+  peerPubKey: string;
   /** Global order id in the XU network. */
   orderId: string;
   /** The quantity of the order to execute as proposed by the taker. Negative when the taker is selling. */
@@ -235,6 +237,7 @@ class Swaps extends EventEmitter {
 
     const deal: SwapDeal = {
       ...swapRequestBody,
+      peerPubKey: peer.nodePubKey!,
       phase: SwapDealPhase.SwapCreated,
       state: SwapDealState.Active,
       stateReason: '',
@@ -282,6 +285,7 @@ class Swaps extends EventEmitter {
     // accept the deal
     const deal: SwapDeal = {
       ...requestBody,
+      peerPubKey: peer.nodePubKey!,
       quantity: requestBody.proposedQuantity,
       phase: SwapDealPhase.SwapCreated,
       state: SwapDealState.Active,


### PR DESCRIPTION
This commit fixes a bug where a a maker sends an invalidation packet to the taker after an order is executed. The taker will have already adjusted the orderbook locally upon successful execution, resulting in
a duplicate attempt. This fix makes it so makers don't send invalidation
packets to takers.

Fixes #506. Fixes #478.