### PR TITLE
test: use dynamic port for web proxy tests

### DIFF
--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -1,18 +1,20 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import Xud from '../../lib/Xud';
+import { getUnusedPort } from '../utils';
 
-describe('WebProxy', () => {
+describe('WebProxy', async () => {
   let xud: Xud;
   let config: any;
   chai.use(chaiHttp);
+  const port = await getUnusedPort();
 
   before(async () => {
     config = {
       dbpath: ':memory:',
       webproxy: {
+        port,
         disable: false,
-        port: 8080,
       },
       logpath: '',
       loglevel: 'warn',

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -2,23 +2,9 @@ import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import { getUri } from '../../lib/utils/utils';
-import net from 'net';
+import { getUnusedPort } from '../utils';
 
 chai.use(chaiAsPromised);
-
-const getUnusedPort = async () => {
-  return new Promise<number>((resolve, reject) => {
-    const server = net.createServer();
-    server.unref();
-    server.on('error', reject);
-    server.listen(0, () => {
-      const { port } = server.address();
-      server.close(() => {
-        resolve(port);
-      });
-    });
-  });
-};
 
 const createConfig = (instanceid: number, p2pPort: number) => ({
   instanceid,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,18 @@
+import net from 'net';
+
+/**
+ * Discovers and returns a dynamically assigned, unused port available for testing.
+ */
+export const getUnusedPort = async () => {
+  return new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, () => {
+      const { port } = server.address();
+      server.close(() => {
+        resolve(port);
+      });
+    });
+  });
+};


### PR DESCRIPTION
This changes the web proxy tests to use a dynamic, unused port instead of the default 8080 port, which could cause the tests to fail if 8080 is being used.