### PR TITLE
test: use in-memory db for web proxy tests

### DIFF
--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -9,6 +9,7 @@ describe('WebProxy', () => {
 
   before(async () => {
     config = {
+      dbpath: ':memory:',
       webproxy: {
         disable: false,
         port: 8080,


### PR DESCRIPTION
This makes the web proxy tests use an in-memory database instead of loading an existing database from disk.