### PR TITLE
refactor: use positive quantity for buys & sells

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,7 @@
     - [SwapPayload](#xudrpc.SwapPayload)
   
     - [AddCurrencyRequest.SwapClient](#xudrpc.AddCurrencyRequest.SwapClient)
+    - [OrderSide](#xudrpc.OrderSide)
   
   
     - [Xud](#xudrpc.Xud)
@@ -469,6 +470,7 @@
 | created_at | [int64](#int64) |  | The epoch time when this order was created |
 | invoice | [string](#string) |  | Lightning invoice |
 | canceled | [bool](#bool) |  | Indicates whether an order was canceled |
+| side | [OrderSide](#xudrpc.OrderSide) |  | Whether the order is a Buy or Sell |
 
 
 
@@ -555,6 +557,7 @@
 | quantity | [double](#double) |  | The quantity of the order, precise to 6 decimal places. |
 | pair_id | [string](#string) |  | The trading pair that the order is for |
 | order_id | [string](#string) |  | The local id to assign to the order |
+| side | [OrderSide](#xudrpc.OrderSide) |  | Whether the order is a Buy or Sell |
 
 
 
@@ -746,6 +749,18 @@
 | ---- | ------ | ----------- |
 | LND | 0 |  |
 | RAIDEN | 1 |  |
+
+
+
+<a name="xudrpc.OrderSide"></a>
+
+### OrderSide
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| BUY | 0 |  |
+| SELL | 1 |  |
 
 
  

--- a/lib/cli/utils.ts
+++ b/lib/cli/utils.ts
@@ -1,6 +1,6 @@
 import { callback, loadXudClient } from './command';
 import { Arguments, Argv } from 'yargs';
-import { PlaceOrderRequest } from '../proto/xudrpc_pb';
+import { PlaceOrderRequest, OrderSide } from '../proto/xudrpc_pb';
 
 export const orderBuilder = (argv: Argv, command: string) => argv
   .option('quantity', {
@@ -28,7 +28,8 @@ export const orderHandler = (argv: Arguments, isSell = false) => {
   const numericPrice = Number(argv.price);
   const priceStr = argv.price.toLowerCase();
 
-  request.setQuantity(isSell ? argv.quantity * -1 : argv.quantity);
+  request.setQuantity(argv.quantity);
+  request.setSide(isSell ? OrderSide.SELL : OrderSide.BUY);
   request.setPairId(argv.pair_id.toUpperCase());
 
   if (!isNaN(numericPrice)) {

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -10,7 +10,6 @@ import { errorCodes as serviceErrorCodes } from '../service/errors';
 import { errorCodes as p2pErrorCodes } from '../p2p/errors';
 import { errorCodes as lndErrorCodes } from '../lndclient/errors';
 import { LndInfo } from '../lndclient/LndClient';
-import { OrderSidesArrays } from '../orderbook/MatchingEngine';
 
 /**
  * Convert a [[StampedOrder]] to an xudrpc Order message.
@@ -25,6 +24,7 @@ const getOrder = (order: StampedOrder) => {
   grpcOrder.setPeerPubKey((order as StampedPeerOrder).peerPubKey);
   grpcOrder.setPrice(order.price);
   grpcOrder.setQuantity(order.quantity);
+  grpcOrder.setSide(order.isBuy ? xudrpc.OrderSide.BUY : xudrpc.OrderSide.SELL);
   return grpcOrder;
 };
 

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -80,7 +80,7 @@ class MatchingEngine {
    */
   public static getMatchingQuantity = (buyOrder: StampedOrder, sellOrder: StampedOrder): number => {
     if (buyOrder.price >= sellOrder.price) {
-      return Math.min(buyOrder.quantity, sellOrder.quantity * -1);
+      return Math.min(buyOrder.quantity, sellOrder.quantity);
     } else {
       return 0;
     }
@@ -91,13 +91,11 @@ class MatchingEngine {
    */
   public static splitOrderByQuantity = (order: StampedOrder, matchingQuantity: number): SplitOrder => {
     const { quantity } = order;
-    const absQuantity = Math.abs(quantity);
-    assert(absQuantity > matchingQuantity, 'order abs quantity must be greater than matchingQuantity');
+    assert(quantity > matchingQuantity, 'order quantity must be greater than matchingQuantity');
 
-    const direction = quantity / absQuantity;
     return {
-      matched: { ...order, quantity: matchingQuantity * direction },
-      remaining: { ...order, quantity: quantity - (matchingQuantity * direction) },
+      matched: { ...order, quantity: matchingQuantity },
+      remaining: { ...order, quantity: quantity - matchingQuantity },
     };
   }
 
@@ -128,9 +126,8 @@ class MatchingEngine {
   }
 
   private addOrder = (order: StampedOrder, lists: OrderSidesLists<StampedOrder>): boolean => {
-    const isBuyOrder = order.quantity > 0;
-    const list = isBuyOrder ? lists.buy : lists.sell;
-    const queue = isBuyOrder ? this.queues.buy : this.queues.sell;
+    const list = order.isBuy ? lists.buy : lists.sell;
+    const queue = order.isBuy ? this.queues.buy : this.queues.sell;
 
     if (list.has(order.id)) {
       return false;
@@ -151,7 +148,7 @@ class MatchingEngine {
       return;
     }
 
-    if (quantityToDecrease && quantityToDecrease < Math.abs(order.quantity)) {
+    if (quantityToDecrease && quantityToDecrease < order.quantity) {
       // if quantityToDecrease is below the order quantity, mutate the order quantity, and return a simulation of the removed order portion
       order.quantity = order.quantity - quantityToDecrease;
       return { ...order, quantity: quantityToDecrease };
@@ -176,7 +173,7 @@ class MatchingEngine {
 
     // remove from lists. for further optimization, we can maintain a separate list for each peer pubKey
     removedOrders.forEach((order: StampedPeerOrder) => {
-      const list = order.quantity > 0 ? this.peerOrders.buy : this.peerOrders.sell;
+      const list = order.isBuy ? this.peerOrders.buy : this.peerOrders.sell;
       list.delete(order.id);
     });
 
@@ -198,9 +195,8 @@ class MatchingEngine {
   }
 
   private removeOrder = (order: StampedOrder, lists: OrderSidesLists<StampedOrder>) => {
-    const isBuyOrder = order.quantity > 0;
-    const list = isBuyOrder ? lists.buy : lists.sell;
-    const queue = isBuyOrder ? this.queues.buy : this.queues.sell;
+    const list = order.isBuy ? lists.buy : lists.sell;
+    const queue = order.isBuy ? this.queues.buy : this.queues.sell;
 
     list.delete(order.id);
     queue.remove(order);
@@ -208,9 +204,9 @@ class MatchingEngine {
 
   private getOrderList = (order: StampedOrder): OrderList<StampedOrder> => {
     if (isOwnOrder(order)) {
-      return order.quantity > 0 ? this.ownOrders.buy : this.ownOrders.sell;
+      return order.isBuy ? this.ownOrders.buy : this.ownOrders.sell;
     } else {
-      return order.quantity > 0 ? this.peerOrders.buy : this.peerOrders.sell;
+      return order.isBuy ? this.peerOrders.buy : this.peerOrders.sell;
     }
   }
 
@@ -234,13 +230,12 @@ class MatchingEngine {
    * @returns a [[MatchingResult]] with the matches as well as the remaining, unmatched portion of the order
    */
   private match = (takerOrder: StampedOwnOrder): matchingEngine.MatchingResult => {
-    const isBuyOrder = takerOrder.quantity > 0;
     const matches: matchingEngine.OrderMatch[] = [];
     /** The unmatched remaining taker order, if there is still leftover quantity after matching is complete it will enter the queue. */
     let remainingOrder: StampedOwnOrder | undefined = { ...takerOrder };
 
-    const queue = isBuyOrder ? this.queues.sell : this.queues.buy;
-    const getMatchingQuantity = (remainingOrder: StampedOwnOrder, oppositeOrder: StampedOrder) => isBuyOrder
+    const queue = takerOrder.isBuy ? this.queues.sell : this.queues.buy;
+    const getMatchingQuantity = (remainingOrder: StampedOwnOrder, oppositeOrder: StampedOrder) => takerOrder.isBuy
       ? MatchingEngine.getMatchingQuantity(remainingOrder, oppositeOrder)
       : MatchingEngine.getMatchingQuantity(oppositeOrder, remainingOrder);
 
@@ -257,16 +252,14 @@ class MatchingEngine {
         const list = this.getOrderList(makerOrder);
         list.delete(makerOrder.id);
 
-        const makerOrderAbsQuantity = Math.abs(makerOrder.quantity);
-        const remainingOrderAbsQuantity = Math.abs(remainingOrder.quantity);
         if (
-          makerOrderAbsQuantity === matchingQuantity &&
-          remainingOrderAbsQuantity === matchingQuantity
+          makerOrder.quantity === matchingQuantity &&
+          remainingOrder.quantity === matchingQuantity
         ) { // order quantities are fully matching
           matches.push({ maker: makerOrder, taker: remainingOrder });
 
           remainingOrder = undefined;
-        } else if (remainingOrderAbsQuantity === matchingQuantity) {  // taker order quantity is not sufficient. maker order will split
+        } else if (remainingOrder.quantity === matchingQuantity) {  // taker order quantity is not sufficient. maker order will split
           const splitOrder = MatchingEngine.splitOrderByQuantity(makerOrder, matchingQuantity);
           matches.push({ maker: splitOrder.matched, taker: remainingOrder });
 
@@ -275,7 +268,7 @@ class MatchingEngine {
           list.set(splitOrder.remaining.id, splitOrder.remaining);
 
           remainingOrder = undefined;
-        } else if (makerOrderAbsQuantity === matchingQuantity) { // maker order quantity is not sufficient. taker order will split
+        } else if (makerOrder.quantity === matchingQuantity) { // maker order quantity is not sufficient. taker order will split
           const splitOrder = MatchingEngine.splitOrderByQuantity(remainingOrder, matchingQuantity);
           matches.push({ maker: makerOrder, taker: splitOrder.matched });
           remainingOrder = splitOrder.remaining as StampedOwnOrder;

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -171,7 +171,7 @@ class OrderBook extends EventEmitter {
   }
 
   public addMarketOrder = (order: orders.OwnMarketOrder): matchingEngine.MatchingResult => {
-    const price = order.quantity > 0 ? Number.MAX_VALUE : 0;
+    const price = order.isBuy ? Number.MAX_VALUE : 0;
     const result = this.addOwnOrder({ ...order, price }, true);
     delete result.remainingOrder;
     return result;

--- a/lib/proto/hash_resolver_grpc_pb.js
+++ b/lib/proto/hash_resolver_grpc_pb.js
@@ -1,5 +1,26 @@
 // GENERATED CODE -- DO NOT EDIT!
 
+// Original file comments:
+// Copyright 2018 The Exchange Union Developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 'use strict';
 var grpc = require('grpc');
 var hash_resolver_pb = require('./hash_resolver_pb.js');

--- a/lib/proto/lndrpc_grpc_pb.js
+++ b/lib/proto/lndrpc_grpc_pb.js
@@ -1,5 +1,26 @@
 // GENERATED CODE -- DO NOT EDIT!
 
+// Original file comments:
+// Copyright (C) 2015-2018 The Lightning Network Developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 'use strict';
 var grpc = require('grpc');
 var lndrpc_pb = require('./lndrpc_pb.js');

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -708,6 +708,10 @@
           "type": "boolean",
           "format": "boolean",
           "title": "Indicates whether an order was canceled"
+        },
+        "side": {
+          "$ref": "#/definitions/xudrpcOrderSide",
+          "title": "Whether the order is a Buy or Sell"
         }
       }
     },
@@ -721,6 +725,14 @@
           "$ref": "#/definitions/xudrpcOrder"
         }
       }
+    },
+    "xudrpcOrderSide": {
+      "type": "string",
+      "enum": [
+        "BUY",
+        "SELL"
+      ],
+      "default": "BUY"
     },
     "xudrpcOrders": {
       "type": "object",
@@ -808,6 +820,10 @@
         "order_id": {
           "type": "string",
           "title": "The local id to assign to the order"
+        },
+        "side": {
+          "$ref": "#/definitions/xudrpcOrderSide",
+          "title": "Whether the order is a Buy or Sell"
         }
       }
     },

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -1,5 +1,26 @@
 // GENERATED CODE -- DO NOT EDIT!
 
+// Original file comments:
+// Copyright 2018 The Exchange Union Developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 'use strict';
 var grpc = require('grpc');
 var xudrpc_pb = require('./xudrpc_pb.js');

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -648,6 +648,9 @@ export class Order extends jspb.Message {
     getCanceled(): boolean;
     setCanceled(value: boolean): void;
 
+    getSide(): OrderSide;
+    setSide(value: OrderSide): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): Order.AsObject;
@@ -670,6 +673,7 @@ export namespace Order {
         createdAt: number,
         invoice: string,
         canceled: boolean,
+        side: OrderSide,
     }
 }
 
@@ -814,6 +818,9 @@ export class PlaceOrderRequest extends jspb.Message {
     getOrderId(): string;
     setOrderId(value: string): void;
 
+    getSide(): OrderSide;
+    setSide(value: OrderSide): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
@@ -831,6 +838,7 @@ export namespace PlaceOrderRequest {
         quantity: number,
         pairId: string,
         orderId: string,
+        side: OrderSide,
     }
 }
 
@@ -1125,4 +1133,9 @@ export namespace SubscribeSwapsResponse {
     export type AsObject = {
         order: string,
     }
+}
+
+export enum OrderSide {
+    BUY = 0,
+    SELL = 1,
 }

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -40,6 +40,7 @@ goog.exportSymbol('proto.xudrpc.LndChannels', null, global);
 goog.exportSymbol('proto.xudrpc.LndInfo', null, global);
 goog.exportSymbol('proto.xudrpc.Order', null, global);
 goog.exportSymbol('proto.xudrpc.OrderMatch', null, global);
+goog.exportSymbol('proto.xudrpc.OrderSide', null, global);
 goog.exportSymbol('proto.xudrpc.Orders', null, global);
 goog.exportSymbol('proto.xudrpc.OrdersCount', null, global);
 goog.exportSymbol('proto.xudrpc.Peer', null, global);
@@ -4245,7 +4246,8 @@ proto.xudrpc.Order.toObject = function(includeInstance, msg) {
     localId: jspb.Message.getFieldWithDefault(msg, 6, ""),
     createdAt: jspb.Message.getFieldWithDefault(msg, 7, 0),
     invoice: jspb.Message.getFieldWithDefault(msg, 8, ""),
-    canceled: jspb.Message.getFieldWithDefault(msg, 9, false)
+    canceled: jspb.Message.getFieldWithDefault(msg, 9, false),
+    side: jspb.Message.getFieldWithDefault(msg, 10, 0)
   };
 
   if (includeInstance) {
@@ -4317,6 +4319,10 @@ proto.xudrpc.Order.deserializeBinaryFromReader = function(msg, reader) {
     case 9:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setCanceled(value);
+      break;
+    case 10:
+      var value = /** @type {!proto.xudrpc.OrderSide} */ (reader.readEnum());
+      msg.setSide(value);
       break;
     default:
       reader.skipField();
@@ -4407,6 +4413,13 @@ proto.xudrpc.Order.serializeBinaryToWriter = function(message, writer) {
   if (f) {
     writer.writeBool(
       9,
+      f
+    );
+  }
+  f = message.getSide();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      10,
       f
     );
   }
@@ -4547,6 +4560,21 @@ proto.xudrpc.Order.prototype.getCanceled = function() {
 /** @param {boolean} value */
 proto.xudrpc.Order.prototype.setCanceled = function(value) {
   jspb.Message.setField(this, 9, value);
+};
+
+
+/**
+ * optional OrderSide side = 10;
+ * @return {!proto.xudrpc.OrderSide}
+ */
+proto.xudrpc.Order.prototype.getSide = function() {
+  return /** @type {!proto.xudrpc.OrderSide} */ (jspb.Message.getFieldWithDefault(this, 10, 0));
+};
+
+
+/** @param {!proto.xudrpc.OrderSide} value */
+proto.xudrpc.Order.prototype.setSide = function(value) {
+  jspb.Message.setField(this, 10, value);
 };
 
 
@@ -5486,7 +5514,8 @@ proto.xudrpc.PlaceOrderRequest.toObject = function(includeInstance, msg) {
     price: +jspb.Message.getFieldWithDefault(msg, 1, 0.0),
     quantity: +jspb.Message.getFieldWithDefault(msg, 2, 0.0),
     pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    orderId: jspb.Message.getFieldWithDefault(msg, 4, "")
+    orderId: jspb.Message.getFieldWithDefault(msg, 4, ""),
+    side: jspb.Message.getFieldWithDefault(msg, 5, 0)
   };
 
   if (includeInstance) {
@@ -5538,6 +5567,10 @@ proto.xudrpc.PlaceOrderRequest.deserializeBinaryFromReader = function(msg, reade
     case 4:
       var value = /** @type {string} */ (reader.readString());
       msg.setOrderId(value);
+      break;
+    case 5:
+      var value = /** @type {!proto.xudrpc.OrderSide} */ (reader.readEnum());
+      msg.setSide(value);
       break;
     default:
       reader.skipField();
@@ -5593,6 +5626,13 @@ proto.xudrpc.PlaceOrderRequest.serializeBinaryToWriter = function(message, write
   if (f.length > 0) {
     writer.writeString(
       4,
+      f
+    );
+  }
+  f = message.getSide();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      5,
       f
     );
   }
@@ -5656,6 +5696,21 @@ proto.xudrpc.PlaceOrderRequest.prototype.getOrderId = function() {
 /** @param {string} value */
 proto.xudrpc.PlaceOrderRequest.prototype.setOrderId = function(value) {
   jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional OrderSide side = 5;
+ * @return {!proto.xudrpc.OrderSide}
+ */
+proto.xudrpc.PlaceOrderRequest.prototype.getSide = function() {
+  return /** @type {!proto.xudrpc.OrderSide} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/** @param {!proto.xudrpc.OrderSide} value */
+proto.xudrpc.PlaceOrderRequest.prototype.setSide = function(value) {
+  jspb.Message.setField(this, 5, value);
 };
 
 
@@ -7651,5 +7706,13 @@ proto.xudrpc.SubscribeSwapsResponse.prototype.setOrder = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
+
+/**
+ * @enum {number}
+ */
+proto.xudrpc.OrderSide = {
+  BUY: 0,
+  SELL: 1
+};
 
 goog.object.extend(exports, proto.xudrpc);

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -5,10 +5,10 @@ import LndClient, { LndInfo } from '../lndclient/LndClient';
 import RaidenClient, { RaidenInfo } from '../raidenclient/RaidenClient';
 import { EventEmitter } from 'events';
 import errors from './errors';
-import { SwapDealRole, SwapClients } from '../types/enums';
+import { SwapClients, OrderSide } from '../types/enums';
 import { parseUri, getUri, UriParts } from '../utils/utils';
 import * as lndrpc from '../proto/lndrpc_pb';
-import { Pair, StampedOrder } from '../types/orders';
+import { Pair } from '../types/orders';
 import Swaps from '../swaps/Swaps';
 import { OrderSidesArrays } from '../orderbook/MatchingEngine';
 
@@ -285,8 +285,8 @@ class Service extends EventEmitter {
    * Add an order to the order book.
    * If price is zero or unspecified a market order will get added.
    */
-  public placeOrder = async (args: { pairId: string, price: number, quantity: number, orderId: string }) => {
-    const { pairId, price, quantity, orderId } = args;
+  public placeOrder = async (args: { pairId: string, price: number, quantity: number, orderId: string, side: number }) => {
+    const { pairId, price, quantity, orderId, side } = args;
     argChecks.PRICE_NON_NEGATIVE(args);
     argChecks.NON_ZERO_QUANTITY(args);
     argChecks.HAS_PAIR_ID(args);
@@ -295,6 +295,7 @@ class Service extends EventEmitter {
       pairId,
       price,
       quantity,
+      isBuy: side === OrderSide.Buy,
       localId: orderId,
     };
 

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -82,11 +82,11 @@ class Swaps extends EventEmitter {
    * @param quantity the quantity of the taker's order
    * @param price the price specified by the maker order being filled
    */
-  private static calculateSwapAmounts = (quantity: number, price: number) => {
+  private static calculateSwapAmounts = (quantity: number, price: number, isBuyOrder: boolean) => {
     let takerAmount: number;
     let makerAmount: number;
     // TODO: use configurable amount of subunits/satoshis per token for each currency
-    if (quantity > 0) {
+    if (isBuyOrder) {
       // taker is buying the base currency
       takerAmount = Math.round(quantity * 100000000);
       makerAmount = Math.round(quantity * price * 100000000);
@@ -199,7 +199,7 @@ class Swaps extends EventEmitter {
 
     let takerCurrency: string;
     let makerCurrency: string;
-    if (taker.quantity > 0) {
+    if (taker.isBuy) {
       // we are buying the base currency
       takerCurrency = baseCurrency;
       makerCurrency = quoteCurrency;
@@ -218,7 +218,7 @@ class Swaps extends EventEmitter {
         takerCltvDelta = this.lndLtcClient.cltvDelta;
         break;
     }
-    const { takerAmount, makerAmount } = Swaps.calculateSwapAmounts(taker.quantity, maker.price);
+    const { takerAmount, makerAmount } = Swaps.calculateSwapAmounts(taker.quantity, maker.price, taker.isBuy);
     const preimage = randomBytes(32);
 
     const swapRequestBody: packets.SwapRequestPacketBody = {

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -9,6 +9,11 @@ export enum OrderingDirection {
   Asc = 'ASC',
 }
 
+export enum OrderSide {
+  Buy,
+  Sell,
+}
+
 export enum SwapDealRole {
   Taker = 0,
   Maker = 1,

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -5,6 +5,8 @@ type MarketOrder = {
   quantity: number;
   /** A trading pair symbol with the base currency first followed by a '/' separator and the quote currency */
   pairId: string;
+  /** Whether the order is a buy (if `true`) or a sell (if `false`). */
+  isBuy: boolean;
 };
 
 /** A limit order with a specified price. */

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -156,6 +156,11 @@ service Xud {
   }
 }
 
+enum OrderSide {
+  BUY = 0;
+  SELL = 1;
+}
+
 message AddCurrencyRequest {
   // The ticker symbol for this currency such as BTC, LTC, ETH, etc...
   string currency = 1 [json_name = "currency"];
@@ -291,6 +296,8 @@ message Order {
   string invoice = 8 [json_name = "invoice"];
   // Indicates whether an order was canceled 
   bool canceled = 9 [json_name = "canceled"];
+  // Whether the order is a Buy or Sell
+  OrderSide side = 10 [json_name = "side"];
 }
 
 message Orders {
@@ -334,6 +341,8 @@ message PlaceOrderRequest {
   string pair_id = 3 [json_name = "pair_id"];
   // The local id to assign to the order
   string order_id = 4 [json_name = "order_id"];
+  // Whether the order is a Buy or Sell
+  OrderSide side = 5 [json_name = "side"];
 }
 message PlaceOrderResponse {
   // A list of orders matching the newly placed order

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import Service from '../../lib/service/Service';
-import { SwapClients } from '../../lib/types/enums';
+import { SwapClients, OrderSide } from '../../lib/types/enums';
 
 chai.use(chaiAsPromised);
 
@@ -16,6 +16,7 @@ describe('API Service', () => {
     orderId: '1',
     price: 100,
     quantity: 1,
+    side: OrderSide.Buy,
   };
 
   before(async () => {
@@ -86,6 +87,7 @@ describe('API Service', () => {
     expect(order.price).to.equal(placeOrderArgs.price);
     expect(order.quantity).to.equal(placeOrderArgs.quantity);
     expect(order.pairId).to.equal(placeOrderArgs.pairId);
+    expect(order.isBuy).to.equal(placeOrderArgs.side === OrderSide.Buy);
   });
 
   it('should cancel an order', async () => {

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -9,9 +9,10 @@ import { ms } from '../../lib/utils/utils';
 const PAIR_ID = 'LTC/BTC';
 const loggers = Logger.createLoggers(Level.Warn);
 
-const createOwnOrder = (price: number, quantity: number, createdAt = ms()): orders.StampedOwnOrder => ({
+const createOwnOrder = (price: number, quantity: number, isBuy: boolean, createdAt = ms()): orders.StampedOwnOrder => ({
   price,
   quantity,
+  isBuy,
   createdAt,
   id: uuidv1(),
   localId: uuidv1(),
@@ -21,11 +22,13 @@ const createOwnOrder = (price: number, quantity: number, createdAt = ms()): orde
 const createPeerOrder = (
   price: number,
   quantity: number,
+  isBuy: boolean,
   createdAt = ms(),
   peerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345',
 ): orders.StampedPeerOrder => ({
   quantity,
   price,
+  isBuy,
   createdAt,
   peerPubKey,
   id: uuidv1(),
@@ -48,32 +51,32 @@ const init = () => {
 describe('MatchingEngine.getMatchingQuantity', () => {
   it('should not match buy order with a lower price then a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOwnOrder(5, 10),
-      createOwnOrder(5.5, -10),
+      createOwnOrder(5, 10, true),
+      createOwnOrder(5.5, 10, false),
     );
     expect(res).to.equal(0);
   });
 
   it('should match buy order with a higher then a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOwnOrder(5.5, 10),
-      createOwnOrder(5, -10),
+      createOwnOrder(5.5, 10, true),
+      createOwnOrder(5, 10, false),
     );
     expect(res).to.equal(10);
   });
 
   it('should match buy order with an equal price to a sell order', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOwnOrder(5, 10),
-      createOwnOrder(5, -10),
+      createOwnOrder(5, 10, true),
+      createOwnOrder(5, 10, false),
     );
     expect(res).to.equal(10);
   });
 
   it('should match with lowest quantity of both orders', () => {
     const res = MatchingEngine.getMatchingQuantity(
-      createOwnOrder(5, 5),
-      createOwnOrder(5, -10),
+      createOwnOrder(5, 5, true),
+      createOwnOrder(5, 10, false),
     );
     expect(res).to.equal(5);
   });
@@ -83,8 +86,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize lower price on ASC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.Asc);
     const res = comparator(
-      createOwnOrder(5, 10),
-      createOwnOrder(5.5, -10),
+      createOwnOrder(5, 10, true),
+      createOwnOrder(5.5, 10, false),
     );
     expect(res).to.be.true;
   });
@@ -92,8 +95,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should not prioritize higher price on ASC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.Asc);
     const res = comparator(
-      createOwnOrder(5.5, 10),
-      createOwnOrder(5, -10),
+      createOwnOrder(5.5, 10, true),
+      createOwnOrder(5, 10, false),
     );
     expect(res).to.be.false;
   });
@@ -101,8 +104,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize higher price on DESC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.Desc);
     const res = comparator(
-      createOwnOrder(5.5, 10),
-      createOwnOrder(5, -10),
+      createOwnOrder(5.5, 10, true),
+      createOwnOrder(5, 10, false),
     );
     expect(res).to.be.true;
   });
@@ -110,8 +113,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should not prioritize lower price on DESC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.Desc);
     const res = comparator(
-      createOwnOrder(5, 10),
-      createOwnOrder(5.5, -10),
+      createOwnOrder(5, 10, true),
+      createOwnOrder(5.5, 10, false),
     );
     expect(res).to.be.false;
   });
@@ -119,8 +122,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize earlier createdAt when prices are equal on ASC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.Asc);
     const res = comparator(
-      createOwnOrder(5, 10, ms() - 1),
-      createOwnOrder(5, -10, ms()),
+      createOwnOrder(5, 10, true, ms() - 1),
+      createOwnOrder(5, 10, false, ms()),
     );
     expect(res).to.be.true;
   });
@@ -128,8 +131,8 @@ describe('MatchingEngine.getOrdersPriorityQueueComparator', () => {
   it('should prioritize earlier createdAt when prices are equal on DESC ordering direction', () => {
     const comparator = MatchingEngine.getOrdersPriorityQueueComparator(OrderingDirection.Desc);
     const res = comparator(
-      createOwnOrder(5, 10, ms() - 1),
-      createOwnOrder(5, -10, ms()),
+      createOwnOrder(5, 10, true, ms() - 1),
+      createOwnOrder(5, 10, false, ms()),
     );
     expect(res).to.be.true;
   });
@@ -140,7 +143,7 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
     const orderQuantity = 10;
     const matchingQuantity = 6;
     const { matched, remaining } = MatchingEngine.splitOrderByQuantity(
-      createOwnOrder(5, orderQuantity),
+      createOwnOrder(5, orderQuantity, true),
       matchingQuantity,
     );
     expect(matched.quantity).to.equal(matchingQuantity);
@@ -148,21 +151,21 @@ describe('MatchingEngine.splitOrderByQuantity', () => {
   });
 
   it('should split sell orders properly', () => {
-    const orderQuantity = -10;
+    const orderQuantity = 10;
     const matchingQuantity = 4;
     const { matched, remaining } = MatchingEngine.splitOrderByQuantity(
-      createOwnOrder(5, orderQuantity),
+      createOwnOrder(5, orderQuantity, false),
       matchingQuantity,
     );
-    expect(matched.quantity).to.equal(matchingQuantity * -1);
-    expect(remaining.quantity).to.equal(orderQuantity + matchingQuantity);
+    expect(matched.quantity).to.equal(matchingQuantity);
+    expect(remaining.quantity).to.equal(orderQuantity - matchingQuantity);
   });
 
   it('should not work when matchingQuantity higher than quantity of order', () => {
     expect(() => MatchingEngine.splitOrderByQuantity(
-      createOwnOrder(5, 5),
+      createOwnOrder(5, 5, true),
       10,
-    )).to.throw('order abs quantity must be greater than matchingQuantity');
+    )).to.throw('order quantity must be greater than matchingQuantity');
   });
 });
 
@@ -170,33 +173,33 @@ describe('MatchingEngine.match', () => {
   beforeEach(init);
 
   it('should fully match with two maker orders', () => {
-    engine.addPeerOrder(createPeerOrder(5, -5));
-    engine.addPeerOrder(createPeerOrder(5, -5));
-    const { remainingOrder } = engine['match'](createOwnOrder(5, 10));
+    engine.addPeerOrder(createPeerOrder(5, 5, false));
+    engine.addPeerOrder(createPeerOrder(5, 5, false));
+    const { remainingOrder } = engine['match'](createOwnOrder(5, 10, true));
     expect(remainingOrder).to.be.undefined;
   });
 
   it('should split taker order when makers are insufficient', () => {
-    engine.addPeerOrder(createPeerOrder(5, -4));
-    engine.addPeerOrder(createPeerOrder(5, -5));
+    engine.addPeerOrder(createPeerOrder(5, 4, false));
+    engine.addPeerOrder(createPeerOrder(5, 5, false));
     const matchAgainst = [engine.queues.sell];
-    const { remainingOrder } = engine['match'](createOwnOrder(5, 10));
+    const { remainingOrder } = engine['match'](createOwnOrder(5, 10, true));
     expect(remainingOrder).to.not.be.undefined;
     expect(remainingOrder!.quantity).to.equal(1);
   });
 
   it('should split one maker order when taker is insufficient', () => {
-    engine.addPeerOrder(createPeerOrder(5, -5));
-    engine.addPeerOrder(createPeerOrder(5, -6));
+    engine.addPeerOrder(createPeerOrder(5, 5, false));
+    engine.addPeerOrder(createPeerOrder(5, 6, false));
     const matchAgainst = [engine.queues.sell];
-    const { matches, remainingOrder } = engine['match'](createOwnOrder(5, 10));
+    const { matches, remainingOrder } = engine['match'](createOwnOrder(5, 10, true));
     expect(remainingOrder).to.be.undefined;
     matches.forEach((match) => {
-      expect(match.maker.quantity).to.equal(-5);
+      expect(match.maker.quantity).to.equal(5);
     });
     const peekResult = engine.queues.sell.peek();
     expect(peekResult).to.not.be.undefined;
-    expect(peekResult!.quantity).to.equal(-1);
+    expect(peekResult!.quantity).to.equal(1);
   });
 });
 
@@ -204,7 +207,7 @@ describe('MatchingEngine.removeOwnOrder', () => {
   beforeEach(init);
 
   it('should add a new ownOrder and then remove it', async () => {
-    const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(5, -5), false);
+    const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(5, 5, false), false);
     expect(matchingResult.matches).to.be.empty;
     expect(matchingResult.remainingOrder).to.not.be.undefined;
 
@@ -221,12 +224,13 @@ describe('MatchingEngine.removePeerOrders', () => {
 
   it('should add new peerOrders and then remove some of them', () => {
     const firstPeerPubKey = '026a848ebd1792001ff10c6e212f6077aec5669af3de890e1ae196b4e9730d75b9';
-    const secondPeertPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345';
+    const secondPeerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345';
 
-    const firstHostOrders = [createPeerOrder(100, -5, ms(), firstPeerPubKey), createPeerOrder(100, -5, ms(), firstPeerPubKey)];
+    const firstHostOrders = [createPeerOrder(100, 5, false, ms(), firstPeerPubKey),
+      createPeerOrder(100, 5, false, ms(), firstPeerPubKey)];
     engine.addPeerOrder(firstHostOrders[0]);
     engine.addPeerOrder(firstHostOrders[1]);
-    engine.addPeerOrder(createPeerOrder(100, -5, ms(), secondPeertPubKey));
+    engine.addPeerOrder(createPeerOrder(100, 5, false, ms(), secondPeerPubKey));
     expect(engine.peerOrders.sell.size).to.equal(3);
 
     const removedOrders = engine.removePeerOrders(firstPeerPubKey);
@@ -235,16 +239,16 @@ describe('MatchingEngine.removePeerOrders', () => {
     expect(engine.queues.sell.size).to.equal(1);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
-    const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(100, 15), false);
+    const matchingResult = engine.matchOrAddOwnOrder(createOwnOrder(100, 15, true), false);
     expect(matchingResult.remainingOrder).to.not.be.undefined;
     expect(matchingResult.remainingOrder!.quantity).to.equal(10);
   });
 
   it('should add a new peerOrder and then remove it partially', () => {
-    const quantity = -5;
-    const quantityToDecrease = -3;
+    const quantity = 5;
+    const quantityToDecrease = 3;
 
-    const order = createPeerOrder(5, quantity);
+    const order = createPeerOrder(5, quantity, false);
     engine.addPeerOrder(order);
 
     let removedOrder = engine.removePeerOrderQuantity(order.id, quantityToDecrease) as orders.StampedPeerOrder;
@@ -259,7 +263,7 @@ describe('MatchingEngine queues and lists integrity', () => {
   beforeEach(init);
 
   it('queue and list should both remove an own order', () => {
-    const ownOrder = createOwnOrder(100, -10);
+    const ownOrder = createOwnOrder(100, 10, false);
     engine.matchOrAddOwnOrder(ownOrder, false);
     expect(engine.ownOrders.sell.size).to.equal(1);
     expect(engine.queues.sell.size).to.be.equal(1);
@@ -269,7 +273,7 @@ describe('MatchingEngine queues and lists integrity', () => {
   });
 
   it('queue and list should both remove a peer order', () => {
-    const peerOrder = createPeerOrder(100, -10);
+    const peerOrder = createPeerOrder(100, 10, false);
     engine['addPeerOrder'](peerOrder);
     expect(engine.peerOrders.sell.size).to.equal(1);
     expect(engine.queues.sell.size).to.be.equal(1);
@@ -280,41 +284,41 @@ describe('MatchingEngine queues and lists integrity', () => {
   });
 
   it('queue and list should have the same order instance after a partial peer order removal', () => {
-    const peerOrder = createPeerOrder(100, -10, ms());
+    const peerOrder = createPeerOrder(100, 10, false, ms());
     engine.addPeerOrder(peerOrder);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
-    const removedOrder = engine.removePeerOrderQuantity(peerOrder.id, -3);
-    expect(removedOrder!.quantity).to.equal(-3);
+    const removedOrder = engine.removePeerOrderQuantity(peerOrder.id, 3);
+    expect(removedOrder!.quantity).to.equal(3);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
     const listRemainingOrder = engine.peerOrders.sell.get(peerOrder.id);
     const queueRemainingOrder = engine.queues.sell.peek();
-    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(-7);
+    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(7);
     expect(listRemainingOrder).to.equal(queueRemainingOrder);
   });
 
   it('queue and list should have the same order instance after a partial match / maker order split', () => {
-    const peerOrder = createPeerOrder(100, -10, ms());
+    const peerOrder = createPeerOrder(100, 10, false, ms());
     engine.addPeerOrder(peerOrder);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
-    const ownOrder = createOwnOrder(100, 3);
+    const ownOrder = createOwnOrder(100, 3, true);
     const matchingResult = engine.matchOrAddOwnOrder(ownOrder, false);
     expect(matchingResult.remainingOrder).to.be.undefined;
 
     const listRemainingOrder = engine.peerOrders.sell.get(peerOrder.id);
     const queueRemainingOrder = engine.queues.sell.peek();
-    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(-7);
+    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(7);
     expect(listRemainingOrder).to.equal(queueRemainingOrder);
   });
 
   it('queue and list should both have the maker order removed after a full match', () => {
-    const peerOrder = createPeerOrder(100, -10, ms());
+    const peerOrder = createPeerOrder(100, 10, false, ms());
     engine.addPeerOrder(peerOrder);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
-    const ownOrder = createOwnOrder(100, 10);
+    const ownOrder = createOwnOrder(100, 10, true);
     const matchingResult = engine.matchOrAddOwnOrder(ownOrder, false);
     expect(matchingResult.remainingOrder).to.be.undefined;
 


### PR DESCRIPTION
This PR refactors how we represent buy and sell orders. Previously, sell orders were represented with a negative quantity. However, I believe this to be potentially confusing especially in regards to the API and quantity updates to existing orders, and this was echoed in our discussions. Instead, orders now have a `side` property to indicate whether they are buys or sells, and all standing orders and order matches are represented with positive quantities.

This passes all tests as well as some limited local testing of mine, namely manually placing buy and sell orders via the cli and ensuring they match as expected.