### PR TITLE
Disable initdb for web proxy tests & prevent new connections after closing pool

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -56,7 +56,7 @@ class Pool extends EventEmitter {
   /** The local handshake data to be sent to newly connected peers. */
   public handshakeData!: HandshakeState;
   /** A set of pub keys of nodes for which we have pending outgoing connections. */
-  private pendingOutgoingConnections = new Set<string>();
+  private pendingOutgoingConnections = new Map<string, Peer>();
   /** A collection of known nodes on the XU network. */
   private nodes: NodeList;
   /** A collection of opened, active peers. */
@@ -143,6 +143,7 @@ class Pool extends EventEmitter {
       await this.unlisten();
     }
 
+    this.closePendingConnections();
     this.closePeers();
 
     this.connected = false;
@@ -200,7 +201,6 @@ class Pool extends EventEmitter {
 
       // Validate this node.
       if (isNotUs && hasAddresses && isNotIgnored && hasNoPendingConnections) {
-        this.pendingOutgoingConnections.add(node.nodePubKey);
         connectionPromises.push(this.tryConnectNode(node, retryConnecting));
       }
     });
@@ -265,6 +265,7 @@ class Pool extends EventEmitter {
     }
 
     const peer = new Peer(this.logger, address);
+    this.pendingOutgoingConnections.set(nodePubKey, peer);
     await this.openPeer(peer, nodePubKey, retryConnecting);
     return peer;
   }
@@ -429,6 +430,11 @@ class Pool extends EventEmitter {
   }
 
   private handleOpen = async (peer: Peer): Promise<void> => {
+    if (!this.connected) {
+      // if we have disconnected the pool, don't allow any new connections to open
+      peer.close();
+      return;
+    }
     if (peer.nodePubKey === this.handshakeData.nodePubKey) {
       return;
     }
@@ -534,8 +540,14 @@ class Pool extends EventEmitter {
     });
   }
 
-  private closePeers = (): void => {
+  private closePeers = () => {
     this.peers.forEach(peer => peer.close());
+  }
+
+  private closePendingConnections = () => {
+    for (const peer of this.pendingOutgoingConnections.values()) {
+      peer.close();
+    }
   }
 
   /**

--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -10,6 +10,7 @@ describe('WebProxy', () => {
   before(async () => {
     config = {
       dbpath: ':memory:',
+      initdb: false,
       webproxy: {
         disable: false,
         port: 8080,


### PR DESCRIPTION
Fixes #516.

This PR addresses two issues identified in the issue above:

1. It disables the `initdb` option when creating an `xud` instance for the web proxy tests. Initializing the database is not necessary for these tests.

2. It ensures that no connections that are in a pending state when the p2p pool is disconnected are allowed to complete. It closes all pending connections and any connections that open after
disconnection of the pool. Previously, a connection that's attempted right before disconnecting could have interfered with shutting down `xud`.
