### PR TITLE
perf: improve parallel await on init

### DIFF
--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -57,8 +57,9 @@ class DB {
 
     if (newDb && initDb) {
       // populate new databases with default data
+      const firstStagePromises: Bluebird<any>[] = [];
       // TODO: make seed peers configurable
-      await Node.bulkCreate(<db.NodeAttributes[]>[
+      firstStagePromises.push(Node.bulkCreate(<db.NodeAttributes[]>[
         {
           nodePubKey: '02b66438730d1fcdf4a4ae5d3d73e847a272f160fee2938e132b52cab0a0d9cfc6',
           addresses: [{ host: 'xud1.test.exchangeunion.com', port: 8885 }],
@@ -71,14 +72,16 @@ class DB {
           nodePubKey: '03fd337659e99e628d0487e4f87acf93e353db06f754dccc402f2de1b857a319d0',
           addresses: [{ host: 'xud3.test.exchangeunion.com', port: 8885 }],
         },
-      ]);
+      ]));
 
-      await Currency.bulkCreate(<db.CurrencyAttributes[]>[
+      firstStagePromises.push(Currency.bulkCreate(<db.CurrencyAttributes[]>[
         { id: 'BTC', swapClient: SwapClients.Lnd, decimalPlaces: 8 },
         { id: 'LTC', swapClient: SwapClients.Lnd, decimalPlaces: 8 },
         { id: 'ZRX', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
         { id: 'GNT', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
-      ]);
+      ]));
+
+      await Promise.all(firstStagePromises);
 
       await Pair.bulkCreate(<db.PairAttributes[]>[
         { baseCurrency: 'LTC', quoteCurrency: 'BTC' },

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -75,7 +75,7 @@ class OrderBook extends EventEmitter {
 
   /** Loads the supported pairs and currencies from the database. */
   public init = async () => {
-    const promises = [await this.repository.getPairs(), await this.repository.getCurrencies()];
+    const promises: PromiseLike<any>[] = [this.repository.getPairs(), this.repository.getCurrencies()];
     const results = await Promise.all(promises);
     const pairs = results[0] as db.PairInstance[];
     const currencies = results[1] as db.CurrencyInstance[];


### PR DESCRIPTION
This fixes several instances in the code during the initialization process for `xud` where we're unnecessarily awaiting for promises to resolve serially, instead awaiting for them in parallel to shave a bit of time off the startup process.