### PR TITLE
chore: add VS Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,6 @@ dist/
 # Yarn Integrity file
 .yarn-integrity
 
-# Visual Studio Code config
-.vscode/
-
 #  Webstorm config
 .idea/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug",
+      "cwd": "${workspaceRoot}",
+      "args": [
+        "bin/xud"
+      ],
+      "runtimeArgs": [
+        "-r",  "ts-node/register"
+      ],
+      "sourceMaps": true,
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All",
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "--no-timeouts",
+        "--colors",
+        "-r",  "ts-node/register",
+        "${workspaceRoot}/test/*/*.spec.ts"
+      ],
+      "sourceMaps": true,
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "--no-timeouts",
+        "--colors",
+        "-r",  "ts-node/register",
+        "${file}"
+      ],
+      "sourceMaps": true,
+      "console": "integratedTerminal"
+    },
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.tabSize": 2,
+  
+  "typescript.preferences.quoteStyle": "single",
+  "javascript.preferences.quoteStyle": "single"
+}


### PR DESCRIPTION
This commit adds Visual Studio Code debug configurations for the tests and XUD itself and a few settings that should make creating new TypeScript files easier. It also removes those configuration files from the `.gitignore`.