### PR TITLE
fix :Deprecation warning 

### DIFF
--- a/lib/proto/hash_resolver_grpc_pb.js
+++ b/lib/proto/hash_resolver_grpc_pb.js
@@ -29,7 +29,7 @@ function serialize_hashresolver_ResolveRequest(arg) {
   if (!(arg instanceof hash_resolver_pb.ResolveRequest)) {
     throw new Error('Expected argument of type hashresolver.ResolveRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_hashresolver_ResolveRequest(buffer_arg) {
@@ -40,7 +40,7 @@ function serialize_hashresolver_ResolveResponse(arg) {
   if (!(arg instanceof hash_resolver_pb.ResolveResponse)) {
     throw new Error('Expected argument of type hashresolver.ResolveResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_hashresolver_ResolveResponse(buffer_arg) {

--- a/lib/proto/lndrpc_grpc_pb.js
+++ b/lib/proto/lndrpc_grpc_pb.js
@@ -30,7 +30,7 @@ function serialize_lnrpc_AddInvoiceResponse(arg) {
   if (!(arg instanceof lndrpc_pb.AddInvoiceResponse)) {
     throw new Error('Expected argument of type lnrpc.AddInvoiceResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_AddInvoiceResponse(buffer_arg) {
@@ -41,7 +41,7 @@ function serialize_lnrpc_ChanInfoRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ChanInfoRequest)) {
     throw new Error('Expected argument of type lnrpc.ChanInfoRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChanInfoRequest(buffer_arg) {
@@ -52,7 +52,7 @@ function serialize_lnrpc_ChangePasswordRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ChangePasswordRequest)) {
     throw new Error('Expected argument of type lnrpc.ChangePasswordRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChangePasswordRequest(buffer_arg) {
@@ -63,7 +63,7 @@ function serialize_lnrpc_ChangePasswordResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ChangePasswordResponse)) {
     throw new Error('Expected argument of type lnrpc.ChangePasswordResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChangePasswordResponse(buffer_arg) {
@@ -74,7 +74,7 @@ function serialize_lnrpc_ChannelBalanceRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ChannelBalanceRequest)) {
     throw new Error('Expected argument of type lnrpc.ChannelBalanceRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChannelBalanceRequest(buffer_arg) {
@@ -85,7 +85,7 @@ function serialize_lnrpc_ChannelBalanceResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ChannelBalanceResponse)) {
     throw new Error('Expected argument of type lnrpc.ChannelBalanceResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChannelBalanceResponse(buffer_arg) {
@@ -96,7 +96,7 @@ function serialize_lnrpc_ChannelEdge(arg) {
   if (!(arg instanceof lndrpc_pb.ChannelEdge)) {
     throw new Error('Expected argument of type lnrpc.ChannelEdge');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChannelEdge(buffer_arg) {
@@ -107,7 +107,7 @@ function serialize_lnrpc_ChannelGraph(arg) {
   if (!(arg instanceof lndrpc_pb.ChannelGraph)) {
     throw new Error('Expected argument of type lnrpc.ChannelGraph');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChannelGraph(buffer_arg) {
@@ -118,7 +118,7 @@ function serialize_lnrpc_ChannelGraphRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ChannelGraphRequest)) {
     throw new Error('Expected argument of type lnrpc.ChannelGraphRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChannelGraphRequest(buffer_arg) {
@@ -129,7 +129,7 @@ function serialize_lnrpc_ChannelPoint(arg) {
   if (!(arg instanceof lndrpc_pb.ChannelPoint)) {
     throw new Error('Expected argument of type lnrpc.ChannelPoint');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ChannelPoint(buffer_arg) {
@@ -140,7 +140,7 @@ function serialize_lnrpc_CloseChannelRequest(arg) {
   if (!(arg instanceof lndrpc_pb.CloseChannelRequest)) {
     throw new Error('Expected argument of type lnrpc.CloseChannelRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_CloseChannelRequest(buffer_arg) {
@@ -151,7 +151,7 @@ function serialize_lnrpc_CloseStatusUpdate(arg) {
   if (!(arg instanceof lndrpc_pb.CloseStatusUpdate)) {
     throw new Error('Expected argument of type lnrpc.CloseStatusUpdate');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_CloseStatusUpdate(buffer_arg) {
@@ -162,7 +162,7 @@ function serialize_lnrpc_ClosedChannelsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ClosedChannelsRequest)) {
     throw new Error('Expected argument of type lnrpc.ClosedChannelsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ClosedChannelsRequest(buffer_arg) {
@@ -173,7 +173,7 @@ function serialize_lnrpc_ClosedChannelsResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ClosedChannelsResponse)) {
     throw new Error('Expected argument of type lnrpc.ClosedChannelsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ClosedChannelsResponse(buffer_arg) {
@@ -184,7 +184,7 @@ function serialize_lnrpc_ConnectPeerRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ConnectPeerRequest)) {
     throw new Error('Expected argument of type lnrpc.ConnectPeerRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ConnectPeerRequest(buffer_arg) {
@@ -195,7 +195,7 @@ function serialize_lnrpc_ConnectPeerResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ConnectPeerResponse)) {
     throw new Error('Expected argument of type lnrpc.ConnectPeerResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ConnectPeerResponse(buffer_arg) {
@@ -206,7 +206,7 @@ function serialize_lnrpc_DebugLevelRequest(arg) {
   if (!(arg instanceof lndrpc_pb.DebugLevelRequest)) {
     throw new Error('Expected argument of type lnrpc.DebugLevelRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_DebugLevelRequest(buffer_arg) {
@@ -217,7 +217,7 @@ function serialize_lnrpc_DebugLevelResponse(arg) {
   if (!(arg instanceof lndrpc_pb.DebugLevelResponse)) {
     throw new Error('Expected argument of type lnrpc.DebugLevelResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_DebugLevelResponse(buffer_arg) {
@@ -228,7 +228,7 @@ function serialize_lnrpc_DeleteAllPaymentsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.DeleteAllPaymentsRequest)) {
     throw new Error('Expected argument of type lnrpc.DeleteAllPaymentsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_DeleteAllPaymentsRequest(buffer_arg) {
@@ -239,7 +239,7 @@ function serialize_lnrpc_DeleteAllPaymentsResponse(arg) {
   if (!(arg instanceof lndrpc_pb.DeleteAllPaymentsResponse)) {
     throw new Error('Expected argument of type lnrpc.DeleteAllPaymentsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_DeleteAllPaymentsResponse(buffer_arg) {
@@ -250,7 +250,7 @@ function serialize_lnrpc_DisconnectPeerRequest(arg) {
   if (!(arg instanceof lndrpc_pb.DisconnectPeerRequest)) {
     throw new Error('Expected argument of type lnrpc.DisconnectPeerRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_DisconnectPeerRequest(buffer_arg) {
@@ -261,7 +261,7 @@ function serialize_lnrpc_DisconnectPeerResponse(arg) {
   if (!(arg instanceof lndrpc_pb.DisconnectPeerResponse)) {
     throw new Error('Expected argument of type lnrpc.DisconnectPeerResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_DisconnectPeerResponse(buffer_arg) {
@@ -272,7 +272,7 @@ function serialize_lnrpc_FeeReportRequest(arg) {
   if (!(arg instanceof lndrpc_pb.FeeReportRequest)) {
     throw new Error('Expected argument of type lnrpc.FeeReportRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_FeeReportRequest(buffer_arg) {
@@ -283,7 +283,7 @@ function serialize_lnrpc_FeeReportResponse(arg) {
   if (!(arg instanceof lndrpc_pb.FeeReportResponse)) {
     throw new Error('Expected argument of type lnrpc.FeeReportResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_FeeReportResponse(buffer_arg) {
@@ -294,7 +294,7 @@ function serialize_lnrpc_ForwardingHistoryRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ForwardingHistoryRequest)) {
     throw new Error('Expected argument of type lnrpc.ForwardingHistoryRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ForwardingHistoryRequest(buffer_arg) {
@@ -305,7 +305,7 @@ function serialize_lnrpc_ForwardingHistoryResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ForwardingHistoryResponse)) {
     throw new Error('Expected argument of type lnrpc.ForwardingHistoryResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ForwardingHistoryResponse(buffer_arg) {
@@ -316,7 +316,7 @@ function serialize_lnrpc_GenSeedRequest(arg) {
   if (!(arg instanceof lndrpc_pb.GenSeedRequest)) {
     throw new Error('Expected argument of type lnrpc.GenSeedRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GenSeedRequest(buffer_arg) {
@@ -327,7 +327,7 @@ function serialize_lnrpc_GenSeedResponse(arg) {
   if (!(arg instanceof lndrpc_pb.GenSeedResponse)) {
     throw new Error('Expected argument of type lnrpc.GenSeedResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GenSeedResponse(buffer_arg) {
@@ -338,7 +338,7 @@ function serialize_lnrpc_GetInfoRequest(arg) {
   if (!(arg instanceof lndrpc_pb.GetInfoRequest)) {
     throw new Error('Expected argument of type lnrpc.GetInfoRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GetInfoRequest(buffer_arg) {
@@ -349,7 +349,7 @@ function serialize_lnrpc_GetInfoResponse(arg) {
   if (!(arg instanceof lndrpc_pb.GetInfoResponse)) {
     throw new Error('Expected argument of type lnrpc.GetInfoResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GetInfoResponse(buffer_arg) {
@@ -360,7 +360,7 @@ function serialize_lnrpc_GetTransactionsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.GetTransactionsRequest)) {
     throw new Error('Expected argument of type lnrpc.GetTransactionsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GetTransactionsRequest(buffer_arg) {
@@ -371,7 +371,7 @@ function serialize_lnrpc_GraphTopologySubscription(arg) {
   if (!(arg instanceof lndrpc_pb.GraphTopologySubscription)) {
     throw new Error('Expected argument of type lnrpc.GraphTopologySubscription');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GraphTopologySubscription(buffer_arg) {
@@ -382,7 +382,7 @@ function serialize_lnrpc_GraphTopologyUpdate(arg) {
   if (!(arg instanceof lndrpc_pb.GraphTopologyUpdate)) {
     throw new Error('Expected argument of type lnrpc.GraphTopologyUpdate');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_GraphTopologyUpdate(buffer_arg) {
@@ -393,7 +393,7 @@ function serialize_lnrpc_InitWalletRequest(arg) {
   if (!(arg instanceof lndrpc_pb.InitWalletRequest)) {
     throw new Error('Expected argument of type lnrpc.InitWalletRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_InitWalletRequest(buffer_arg) {
@@ -404,7 +404,7 @@ function serialize_lnrpc_InitWalletResponse(arg) {
   if (!(arg instanceof lndrpc_pb.InitWalletResponse)) {
     throw new Error('Expected argument of type lnrpc.InitWalletResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_InitWalletResponse(buffer_arg) {
@@ -415,7 +415,7 @@ function serialize_lnrpc_Invoice(arg) {
   if (!(arg instanceof lndrpc_pb.Invoice)) {
     throw new Error('Expected argument of type lnrpc.Invoice');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_Invoice(buffer_arg) {
@@ -426,7 +426,7 @@ function serialize_lnrpc_InvoiceSubscription(arg) {
   if (!(arg instanceof lndrpc_pb.InvoiceSubscription)) {
     throw new Error('Expected argument of type lnrpc.InvoiceSubscription');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_InvoiceSubscription(buffer_arg) {
@@ -437,7 +437,7 @@ function serialize_lnrpc_ListChannelsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ListChannelsRequest)) {
     throw new Error('Expected argument of type lnrpc.ListChannelsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListChannelsRequest(buffer_arg) {
@@ -448,7 +448,7 @@ function serialize_lnrpc_ListChannelsResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ListChannelsResponse)) {
     throw new Error('Expected argument of type lnrpc.ListChannelsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListChannelsResponse(buffer_arg) {
@@ -459,7 +459,7 @@ function serialize_lnrpc_ListInvoiceRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ListInvoiceRequest)) {
     throw new Error('Expected argument of type lnrpc.ListInvoiceRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListInvoiceRequest(buffer_arg) {
@@ -470,7 +470,7 @@ function serialize_lnrpc_ListInvoiceResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ListInvoiceResponse)) {
     throw new Error('Expected argument of type lnrpc.ListInvoiceResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListInvoiceResponse(buffer_arg) {
@@ -481,7 +481,7 @@ function serialize_lnrpc_ListPaymentsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ListPaymentsRequest)) {
     throw new Error('Expected argument of type lnrpc.ListPaymentsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListPaymentsRequest(buffer_arg) {
@@ -492,7 +492,7 @@ function serialize_lnrpc_ListPaymentsResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ListPaymentsResponse)) {
     throw new Error('Expected argument of type lnrpc.ListPaymentsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListPaymentsResponse(buffer_arg) {
@@ -503,7 +503,7 @@ function serialize_lnrpc_ListPeersRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ListPeersRequest)) {
     throw new Error('Expected argument of type lnrpc.ListPeersRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListPeersRequest(buffer_arg) {
@@ -514,7 +514,7 @@ function serialize_lnrpc_ListPeersResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ListPeersResponse)) {
     throw new Error('Expected argument of type lnrpc.ListPeersResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ListPeersResponse(buffer_arg) {
@@ -525,7 +525,7 @@ function serialize_lnrpc_NetworkInfo(arg) {
   if (!(arg instanceof lndrpc_pb.NetworkInfo)) {
     throw new Error('Expected argument of type lnrpc.NetworkInfo');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NetworkInfo(buffer_arg) {
@@ -536,7 +536,7 @@ function serialize_lnrpc_NetworkInfoRequest(arg) {
   if (!(arg instanceof lndrpc_pb.NetworkInfoRequest)) {
     throw new Error('Expected argument of type lnrpc.NetworkInfoRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NetworkInfoRequest(buffer_arg) {
@@ -547,7 +547,7 @@ function serialize_lnrpc_NewAddressRequest(arg) {
   if (!(arg instanceof lndrpc_pb.NewAddressRequest)) {
     throw new Error('Expected argument of type lnrpc.NewAddressRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NewAddressRequest(buffer_arg) {
@@ -558,7 +558,7 @@ function serialize_lnrpc_NewAddressResponse(arg) {
   if (!(arg instanceof lndrpc_pb.NewAddressResponse)) {
     throw new Error('Expected argument of type lnrpc.NewAddressResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NewAddressResponse(buffer_arg) {
@@ -569,7 +569,7 @@ function serialize_lnrpc_NewWitnessAddressRequest(arg) {
   if (!(arg instanceof lndrpc_pb.NewWitnessAddressRequest)) {
     throw new Error('Expected argument of type lnrpc.NewWitnessAddressRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NewWitnessAddressRequest(buffer_arg) {
@@ -580,7 +580,7 @@ function serialize_lnrpc_NodeInfo(arg) {
   if (!(arg instanceof lndrpc_pb.NodeInfo)) {
     throw new Error('Expected argument of type lnrpc.NodeInfo');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NodeInfo(buffer_arg) {
@@ -591,7 +591,7 @@ function serialize_lnrpc_NodeInfoRequest(arg) {
   if (!(arg instanceof lndrpc_pb.NodeInfoRequest)) {
     throw new Error('Expected argument of type lnrpc.NodeInfoRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_NodeInfoRequest(buffer_arg) {
@@ -602,7 +602,7 @@ function serialize_lnrpc_OpenChannelRequest(arg) {
   if (!(arg instanceof lndrpc_pb.OpenChannelRequest)) {
     throw new Error('Expected argument of type lnrpc.OpenChannelRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_OpenChannelRequest(buffer_arg) {
@@ -613,7 +613,7 @@ function serialize_lnrpc_OpenStatusUpdate(arg) {
   if (!(arg instanceof lndrpc_pb.OpenStatusUpdate)) {
     throw new Error('Expected argument of type lnrpc.OpenStatusUpdate');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_OpenStatusUpdate(buffer_arg) {
@@ -624,7 +624,7 @@ function serialize_lnrpc_PayReq(arg) {
   if (!(arg instanceof lndrpc_pb.PayReq)) {
     throw new Error('Expected argument of type lnrpc.PayReq');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PayReq(buffer_arg) {
@@ -635,7 +635,7 @@ function serialize_lnrpc_PayReqString(arg) {
   if (!(arg instanceof lndrpc_pb.PayReqString)) {
     throw new Error('Expected argument of type lnrpc.PayReqString');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PayReqString(buffer_arg) {
@@ -646,7 +646,7 @@ function serialize_lnrpc_PaymentHash(arg) {
   if (!(arg instanceof lndrpc_pb.PaymentHash)) {
     throw new Error('Expected argument of type lnrpc.PaymentHash');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PaymentHash(buffer_arg) {
@@ -657,7 +657,7 @@ function serialize_lnrpc_PendingChannelsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.PendingChannelsRequest)) {
     throw new Error('Expected argument of type lnrpc.PendingChannelsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PendingChannelsRequest(buffer_arg) {
@@ -668,7 +668,7 @@ function serialize_lnrpc_PendingChannelsResponse(arg) {
   if (!(arg instanceof lndrpc_pb.PendingChannelsResponse)) {
     throw new Error('Expected argument of type lnrpc.PendingChannelsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PendingChannelsResponse(buffer_arg) {
@@ -679,7 +679,7 @@ function serialize_lnrpc_PolicyUpdateRequest(arg) {
   if (!(arg instanceof lndrpc_pb.PolicyUpdateRequest)) {
     throw new Error('Expected argument of type lnrpc.PolicyUpdateRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PolicyUpdateRequest(buffer_arg) {
@@ -690,7 +690,7 @@ function serialize_lnrpc_PolicyUpdateResponse(arg) {
   if (!(arg instanceof lndrpc_pb.PolicyUpdateResponse)) {
     throw new Error('Expected argument of type lnrpc.PolicyUpdateResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_PolicyUpdateResponse(buffer_arg) {
@@ -701,7 +701,7 @@ function serialize_lnrpc_QueryRoutesRequest(arg) {
   if (!(arg instanceof lndrpc_pb.QueryRoutesRequest)) {
     throw new Error('Expected argument of type lnrpc.QueryRoutesRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_QueryRoutesRequest(buffer_arg) {
@@ -712,7 +712,7 @@ function serialize_lnrpc_QueryRoutesResponse(arg) {
   if (!(arg instanceof lndrpc_pb.QueryRoutesResponse)) {
     throw new Error('Expected argument of type lnrpc.QueryRoutesResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_QueryRoutesResponse(buffer_arg) {
@@ -723,7 +723,7 @@ function serialize_lnrpc_ResolveRequest(arg) {
   if (!(arg instanceof lndrpc_pb.ResolveRequest)) {
     throw new Error('Expected argument of type lnrpc.ResolveRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ResolveRequest(buffer_arg) {
@@ -734,7 +734,7 @@ function serialize_lnrpc_ResolveResponse(arg) {
   if (!(arg instanceof lndrpc_pb.ResolveResponse)) {
     throw new Error('Expected argument of type lnrpc.ResolveResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_ResolveResponse(buffer_arg) {
@@ -745,7 +745,7 @@ function serialize_lnrpc_SendCoinsRequest(arg) {
   if (!(arg instanceof lndrpc_pb.SendCoinsRequest)) {
     throw new Error('Expected argument of type lnrpc.SendCoinsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendCoinsRequest(buffer_arg) {
@@ -756,7 +756,7 @@ function serialize_lnrpc_SendCoinsResponse(arg) {
   if (!(arg instanceof lndrpc_pb.SendCoinsResponse)) {
     throw new Error('Expected argument of type lnrpc.SendCoinsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendCoinsResponse(buffer_arg) {
@@ -767,7 +767,7 @@ function serialize_lnrpc_SendManyRequest(arg) {
   if (!(arg instanceof lndrpc_pb.SendManyRequest)) {
     throw new Error('Expected argument of type lnrpc.SendManyRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendManyRequest(buffer_arg) {
@@ -778,7 +778,7 @@ function serialize_lnrpc_SendManyResponse(arg) {
   if (!(arg instanceof lndrpc_pb.SendManyResponse)) {
     throw new Error('Expected argument of type lnrpc.SendManyResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendManyResponse(buffer_arg) {
@@ -789,7 +789,7 @@ function serialize_lnrpc_SendRequest(arg) {
   if (!(arg instanceof lndrpc_pb.SendRequest)) {
     throw new Error('Expected argument of type lnrpc.SendRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendRequest(buffer_arg) {
@@ -800,7 +800,7 @@ function serialize_lnrpc_SendResponse(arg) {
   if (!(arg instanceof lndrpc_pb.SendResponse)) {
     throw new Error('Expected argument of type lnrpc.SendResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendResponse(buffer_arg) {
@@ -811,7 +811,7 @@ function serialize_lnrpc_SendToRouteRequest(arg) {
   if (!(arg instanceof lndrpc_pb.SendToRouteRequest)) {
     throw new Error('Expected argument of type lnrpc.SendToRouteRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SendToRouteRequest(buffer_arg) {
@@ -822,7 +822,7 @@ function serialize_lnrpc_SignMessageRequest(arg) {
   if (!(arg instanceof lndrpc_pb.SignMessageRequest)) {
     throw new Error('Expected argument of type lnrpc.SignMessageRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SignMessageRequest(buffer_arg) {
@@ -833,7 +833,7 @@ function serialize_lnrpc_SignMessageResponse(arg) {
   if (!(arg instanceof lndrpc_pb.SignMessageResponse)) {
     throw new Error('Expected argument of type lnrpc.SignMessageResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_SignMessageResponse(buffer_arg) {
@@ -844,7 +844,7 @@ function serialize_lnrpc_StopRequest(arg) {
   if (!(arg instanceof lndrpc_pb.StopRequest)) {
     throw new Error('Expected argument of type lnrpc.StopRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_StopRequest(buffer_arg) {
@@ -855,7 +855,7 @@ function serialize_lnrpc_StopResponse(arg) {
   if (!(arg instanceof lndrpc_pb.StopResponse)) {
     throw new Error('Expected argument of type lnrpc.StopResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_StopResponse(buffer_arg) {
@@ -866,7 +866,7 @@ function serialize_lnrpc_Transaction(arg) {
   if (!(arg instanceof lndrpc_pb.Transaction)) {
     throw new Error('Expected argument of type lnrpc.Transaction');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_Transaction(buffer_arg) {
@@ -877,7 +877,7 @@ function serialize_lnrpc_TransactionDetails(arg) {
   if (!(arg instanceof lndrpc_pb.TransactionDetails)) {
     throw new Error('Expected argument of type lnrpc.TransactionDetails');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_TransactionDetails(buffer_arg) {
@@ -888,7 +888,7 @@ function serialize_lnrpc_UnlockWalletRequest(arg) {
   if (!(arg instanceof lndrpc_pb.UnlockWalletRequest)) {
     throw new Error('Expected argument of type lnrpc.UnlockWalletRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_UnlockWalletRequest(buffer_arg) {
@@ -899,7 +899,7 @@ function serialize_lnrpc_UnlockWalletResponse(arg) {
   if (!(arg instanceof lndrpc_pb.UnlockWalletResponse)) {
     throw new Error('Expected argument of type lnrpc.UnlockWalletResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_UnlockWalletResponse(buffer_arg) {
@@ -910,7 +910,7 @@ function serialize_lnrpc_VerifyMessageRequest(arg) {
   if (!(arg instanceof lndrpc_pb.VerifyMessageRequest)) {
     throw new Error('Expected argument of type lnrpc.VerifyMessageRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_VerifyMessageRequest(buffer_arg) {
@@ -921,7 +921,7 @@ function serialize_lnrpc_VerifyMessageResponse(arg) {
   if (!(arg instanceof lndrpc_pb.VerifyMessageResponse)) {
     throw new Error('Expected argument of type lnrpc.VerifyMessageResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_VerifyMessageResponse(buffer_arg) {
@@ -932,7 +932,7 @@ function serialize_lnrpc_WalletBalanceRequest(arg) {
   if (!(arg instanceof lndrpc_pb.WalletBalanceRequest)) {
     throw new Error('Expected argument of type lnrpc.WalletBalanceRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_WalletBalanceRequest(buffer_arg) {
@@ -943,7 +943,7 @@ function serialize_lnrpc_WalletBalanceResponse(arg) {
   if (!(arg instanceof lndrpc_pb.WalletBalanceResponse)) {
     throw new Error('Expected argument of type lnrpc.WalletBalanceResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_lnrpc_WalletBalanceResponse(buffer_arg) {

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -30,7 +30,7 @@ function serialize_xudrpc_AddCurrencyRequest(arg) {
   if (!(arg instanceof xudrpc_pb.AddCurrencyRequest)) {
     throw new Error('Expected argument of type xudrpc.AddCurrencyRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_AddCurrencyRequest(buffer_arg) {
@@ -41,7 +41,7 @@ function serialize_xudrpc_AddCurrencyResponse(arg) {
   if (!(arg instanceof xudrpc_pb.AddCurrencyResponse)) {
     throw new Error('Expected argument of type xudrpc.AddCurrencyResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_AddCurrencyResponse(buffer_arg) {
@@ -52,7 +52,7 @@ function serialize_xudrpc_AddPairRequest(arg) {
   if (!(arg instanceof xudrpc_pb.AddPairRequest)) {
     throw new Error('Expected argument of type xudrpc.AddPairRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_AddPairRequest(buffer_arg) {
@@ -63,7 +63,7 @@ function serialize_xudrpc_AddPairResponse(arg) {
   if (!(arg instanceof xudrpc_pb.AddPairResponse)) {
     throw new Error('Expected argument of type xudrpc.AddPairResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_AddPairResponse(buffer_arg) {
@@ -74,7 +74,7 @@ function serialize_xudrpc_CancelOrderRequest(arg) {
   if (!(arg instanceof xudrpc_pb.CancelOrderRequest)) {
     throw new Error('Expected argument of type xudrpc.CancelOrderRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_CancelOrderRequest(buffer_arg) {
@@ -85,7 +85,7 @@ function serialize_xudrpc_CancelOrderResponse(arg) {
   if (!(arg instanceof xudrpc_pb.CancelOrderResponse)) {
     throw new Error('Expected argument of type xudrpc.CancelOrderResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_CancelOrderResponse(buffer_arg) {
@@ -96,7 +96,7 @@ function serialize_xudrpc_ChannelBalanceRequest(arg) {
   if (!(arg instanceof xudrpc_pb.ChannelBalanceRequest)) {
     throw new Error('Expected argument of type xudrpc.ChannelBalanceRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ChannelBalanceRequest(buffer_arg) {
@@ -107,7 +107,7 @@ function serialize_xudrpc_ChannelBalanceResponse(arg) {
   if (!(arg instanceof xudrpc_pb.ChannelBalanceResponse)) {
     throw new Error('Expected argument of type xudrpc.ChannelBalanceResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ChannelBalanceResponse(buffer_arg) {
@@ -118,7 +118,7 @@ function serialize_xudrpc_ConnectRequest(arg) {
   if (!(arg instanceof xudrpc_pb.ConnectRequest)) {
     throw new Error('Expected argument of type xudrpc.ConnectRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ConnectRequest(buffer_arg) {
@@ -129,7 +129,7 @@ function serialize_xudrpc_ConnectResponse(arg) {
   if (!(arg instanceof xudrpc_pb.ConnectResponse)) {
     throw new Error('Expected argument of type xudrpc.ConnectResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ConnectResponse(buffer_arg) {
@@ -140,7 +140,7 @@ function serialize_xudrpc_DisconnectRequest(arg) {
   if (!(arg instanceof xudrpc_pb.DisconnectRequest)) {
     throw new Error('Expected argument of type xudrpc.DisconnectRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_DisconnectRequest(buffer_arg) {
@@ -151,7 +151,7 @@ function serialize_xudrpc_DisconnectResponse(arg) {
   if (!(arg instanceof xudrpc_pb.DisconnectResponse)) {
     throw new Error('Expected argument of type xudrpc.DisconnectResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_DisconnectResponse(buffer_arg) {
@@ -162,7 +162,7 @@ function serialize_xudrpc_GetInfoRequest(arg) {
   if (!(arg instanceof xudrpc_pb.GetInfoRequest)) {
     throw new Error('Expected argument of type xudrpc.GetInfoRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_GetInfoRequest(buffer_arg) {
@@ -173,7 +173,7 @@ function serialize_xudrpc_GetInfoResponse(arg) {
   if (!(arg instanceof xudrpc_pb.GetInfoResponse)) {
     throw new Error('Expected argument of type xudrpc.GetInfoResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_GetInfoResponse(buffer_arg) {
@@ -184,7 +184,7 @@ function serialize_xudrpc_GetOrdersRequest(arg) {
   if (!(arg instanceof xudrpc_pb.GetOrdersRequest)) {
     throw new Error('Expected argument of type xudrpc.GetOrdersRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_GetOrdersRequest(buffer_arg) {
@@ -195,7 +195,7 @@ function serialize_xudrpc_GetOrdersResponse(arg) {
   if (!(arg instanceof xudrpc_pb.GetOrdersResponse)) {
     throw new Error('Expected argument of type xudrpc.GetOrdersResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_GetOrdersResponse(buffer_arg) {
@@ -206,7 +206,7 @@ function serialize_xudrpc_ListCurrenciesRequest(arg) {
   if (!(arg instanceof xudrpc_pb.ListCurrenciesRequest)) {
     throw new Error('Expected argument of type xudrpc.ListCurrenciesRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ListCurrenciesRequest(buffer_arg) {
@@ -217,7 +217,7 @@ function serialize_xudrpc_ListCurrenciesResponse(arg) {
   if (!(arg instanceof xudrpc_pb.ListCurrenciesResponse)) {
     throw new Error('Expected argument of type xudrpc.ListCurrenciesResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ListCurrenciesResponse(buffer_arg) {
@@ -228,7 +228,7 @@ function serialize_xudrpc_ListPairsRequest(arg) {
   if (!(arg instanceof xudrpc_pb.ListPairsRequest)) {
     throw new Error('Expected argument of type xudrpc.ListPairsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ListPairsRequest(buffer_arg) {
@@ -239,7 +239,7 @@ function serialize_xudrpc_ListPairsResponse(arg) {
   if (!(arg instanceof xudrpc_pb.ListPairsResponse)) {
     throw new Error('Expected argument of type xudrpc.ListPairsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ListPairsResponse(buffer_arg) {
@@ -250,7 +250,7 @@ function serialize_xudrpc_ListPeersRequest(arg) {
   if (!(arg instanceof xudrpc_pb.ListPeersRequest)) {
     throw new Error('Expected argument of type xudrpc.ListPeersRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ListPeersRequest(buffer_arg) {
@@ -261,7 +261,7 @@ function serialize_xudrpc_ListPeersResponse(arg) {
   if (!(arg instanceof xudrpc_pb.ListPeersResponse)) {
     throw new Error('Expected argument of type xudrpc.ListPeersResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ListPeersResponse(buffer_arg) {
@@ -272,7 +272,7 @@ function serialize_xudrpc_PlaceOrderRequest(arg) {
   if (!(arg instanceof xudrpc_pb.PlaceOrderRequest)) {
     throw new Error('Expected argument of type xudrpc.PlaceOrderRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_PlaceOrderRequest(buffer_arg) {
@@ -283,7 +283,7 @@ function serialize_xudrpc_PlaceOrderResponse(arg) {
   if (!(arg instanceof xudrpc_pb.PlaceOrderResponse)) {
     throw new Error('Expected argument of type xudrpc.PlaceOrderResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_PlaceOrderResponse(buffer_arg) {
@@ -294,7 +294,7 @@ function serialize_xudrpc_RemoveCurrencyRequest(arg) {
   if (!(arg instanceof xudrpc_pb.RemoveCurrencyRequest)) {
     throw new Error('Expected argument of type xudrpc.RemoveCurrencyRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_RemoveCurrencyRequest(buffer_arg) {
@@ -305,7 +305,7 @@ function serialize_xudrpc_RemoveCurrencyResponse(arg) {
   if (!(arg instanceof xudrpc_pb.RemoveCurrencyResponse)) {
     throw new Error('Expected argument of type xudrpc.RemoveCurrencyResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_RemoveCurrencyResponse(buffer_arg) {
@@ -316,7 +316,7 @@ function serialize_xudrpc_RemovePairRequest(arg) {
   if (!(arg instanceof xudrpc_pb.RemovePairRequest)) {
     throw new Error('Expected argument of type xudrpc.RemovePairRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_RemovePairRequest(buffer_arg) {
@@ -327,7 +327,7 @@ function serialize_xudrpc_RemovePairResponse(arg) {
   if (!(arg instanceof xudrpc_pb.RemovePairResponse)) {
     throw new Error('Expected argument of type xudrpc.RemovePairResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_RemovePairResponse(buffer_arg) {
@@ -338,7 +338,7 @@ function serialize_xudrpc_ShutdownRequest(arg) {
   if (!(arg instanceof xudrpc_pb.ShutdownRequest)) {
     throw new Error('Expected argument of type xudrpc.ShutdownRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ShutdownRequest(buffer_arg) {
@@ -349,7 +349,7 @@ function serialize_xudrpc_ShutdownResponse(arg) {
   if (!(arg instanceof xudrpc_pb.ShutdownResponse)) {
     throw new Error('Expected argument of type xudrpc.ShutdownResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_ShutdownResponse(buffer_arg) {
@@ -360,7 +360,7 @@ function serialize_xudrpc_SubscribePeerOrdersRequest(arg) {
   if (!(arg instanceof xudrpc_pb.SubscribePeerOrdersRequest)) {
     throw new Error('Expected argument of type xudrpc.SubscribePeerOrdersRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_SubscribePeerOrdersRequest(buffer_arg) {
@@ -371,7 +371,7 @@ function serialize_xudrpc_SubscribePeerOrdersResponse(arg) {
   if (!(arg instanceof xudrpc_pb.SubscribePeerOrdersResponse)) {
     throw new Error('Expected argument of type xudrpc.SubscribePeerOrdersResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_SubscribePeerOrdersResponse(buffer_arg) {
@@ -382,7 +382,7 @@ function serialize_xudrpc_SubscribeSwapsRequest(arg) {
   if (!(arg instanceof xudrpc_pb.SubscribeSwapsRequest)) {
     throw new Error('Expected argument of type xudrpc.SubscribeSwapsRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_SubscribeSwapsRequest(buffer_arg) {
@@ -393,7 +393,7 @@ function serialize_xudrpc_SubscribeSwapsResponse(arg) {
   if (!(arg instanceof xudrpc_pb.SubscribeSwapsResponse)) {
     throw new Error('Expected argument of type xudrpc.SubscribeSwapsResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_xudrpc_SubscribeSwapsResponse(buffer_arg) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lintNoFix": "tslint --project tsconfig.json && tslint --config tslint-alt.json 'bin/*' 'test/**/*.ts' 'tasks/**/*.ts'",
     "nodemon:watch": "nodemon --watch dist -e js dist/Xud.js",
     "prepublishOnly": "npm run compile",
-    "proto": "cross-os proto && cross-os swagger && cross-os protodocs",
+    "proto": "cross-os proto && cross-os swagger && cross-os protodocs && cross-os protoFixDeprecation",
     "start": "node dist/Xud.js",
     "stop": "cross-os stop",
     "test": "npm run test:unit && npm run test:int && npm run test:p2p",
@@ -39,6 +39,11 @@
       "linux": "rm -rf ./dist",
       "darwin": "rm -rf ./dist",
       "win32": "rd /q /s dist || cd ."
+    },
+    "protoFixDeprecation": {
+      "linux": "sed -i -- 's/new Buffer(/Buffer.from(/g' lib/proto/*.js",
+      "darwin": "sed -i '' 's/new Buffer(/Buffer.from(/g' lib/proto/*.js",
+      "win32": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command ./winFixDeprecation.ps1"
     },
     "proto": {
       "linux": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",

--- a/winFixDeprecation.ps1
+++ b/winFixDeprecation.ps1
@@ -1,0 +1,6 @@
+$InputFiles = Get-Item "lib/proto/*.js"
+$OldString  = 'new Buffer'
+$NewString  = 'Buffer.from'
+$InputFiles | ForEach {
+    (Get-Content -Path $_.FullName).Replace($OldString,$NewString) | Set-Content -Path $_.FullName
+}


### PR DESCRIPTION
This is a simple fix we used at [`walli-server`](https://github.com/dopetard/walli-server) it simply changes `new Buffer` to `Buffer.from`.