### PR TITLE
fix(cli): fix addCurrency swapClient arg

### DIFF
--- a/lib/cli/commands/addcurrency.ts
+++ b/lib/cli/commands/addcurrency.ts
@@ -15,7 +15,7 @@ export const builder = {
   swap_client: {
     description: 'The payment channel network client for swaps',
     type: 'string',
-    choices: ['LND', 'RAIDEN'],
+    choices: ['Lnd', 'Raiden'],
   },
   decimal_places: {
     description: 'The places to the right of the decimal point of the smallest subunit (e.g. satoshi)',


### PR DESCRIPTION
Fixes #527.

This PR fixes a bug where the available swap client choices in the cli for the `addcurrency` call did not match the internal `SwapClient` enum values.