### PR TITLE
feat: add network command line argument

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -23,6 +23,12 @@ const { argv } = require('yargs')
       describe: 'Path to the log file',
       type: 'string',
     },
+    network: {
+      describe: 'The network the lnd clients are using',
+      type: 'string',
+      choices: ['mainnet', 'testnet', 'simnet', 'regtest'],
+      alias: 'n',
+    },
     xudir: {
       describe: 'Data directory for xud',
       type: 'string',


### PR DESCRIPTION
This PR adds a command line argument for the recently added `network` config option, which specifies the network for all lnd clients.