### PR TITLE
fix(config): properly set default macaroon paths

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -82,7 +82,8 @@ class Config {
     this.lndltc = {
       disable: false,
       certpath: path.join(lndDefaultDatadir, 'tls.cert'),
-      macaroonpath: path.join(lndDefaultDatadir, 'data', 'chain', 'litecoin', this.network, 'admin.macaroon'),
+      macaroonpath: path.join(lndDefaultDatadir, 'data', 'chain', 'litecoin',
+        this.network === Network.TestNet ? 'testnet4' : this.network, 'admin.macaroon'),
       host: 'localhost',
       port: 10010,
       cltvdelta: 576,
@@ -95,8 +96,13 @@ class Config {
   }
 
   public load(args?: { [argName: string]: any }): Config {
-    if (args && args.xudir) {
-      this.updateDefaultPaths(args.xudir);
+    if (args) {
+      if (args.xudir) {
+        this.updateDefaultPaths(args.xudir);
+      }
+      if (args.network) {
+        this.updateMacaroonPaths(args.network);
+      }
     }
     const configPath = path.join(this.xudir, 'xud.conf');
     if (!fs.existsSync(this.xudir)) {
@@ -108,6 +114,16 @@ class Config {
 
         if (props.xudir && (!args || !args.xudir)) {
           this.updateDefaultPaths(props.xudir);
+        }
+
+        if (props.network !== undefined && (!args || !args.network)) {
+          // first check that network is a valid value
+          if (typeof props.network !== 'string' || !Object.values(Network).includes(props.network)) {
+            // delete the invalid network value
+            delete props.network;
+          } else {
+            this.updateMacaroonPaths(props.network);
+          }
         }
 
         // merge parsed json properties from config file to the default config
@@ -149,6 +165,13 @@ class Config {
     this.xudir = xudir;
     this.logpath = this.getDefaultLogPath();
     this.dbpath = this.getDefaultDbPath();
+  }
+
+  private updateMacaroonPaths = (network: string) => {
+    this.network = network as Network;
+    this.lndbtc.macaroonpath = path.join(this.lndbtc.macaroonpath, '..', '..', this.network, 'admin.macaroon');
+    this.lndltc.macaroonpath = path.join(this.lndltc.macaroonpath, '..', '..',
+      this.network === Network.TestNet ? 'testnet4' : this.network, 'admin.macaroon');
   }
 
   private getDefaultDbPath = () => {

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -13,6 +13,7 @@ import NodeKey from './nodekey/NodeKey';
 import Service from './service/Service';
 import { EventEmitter } from 'events';
 import Swaps from './swaps/Swaps';
+import { Network } from './types/enums';
 
 const version: string = require('../package.json').version;
 
@@ -61,6 +62,8 @@ class Xud extends EventEmitter {
     const loggers = Logger.createLoggers(this.config.loglevel, this.config.logpath, this.config.instanceid);
     this.logger = loggers.global;
     this.logger.info('config loaded');
+    console.log(JSON.stringify(Object.keys(Network)));
+    console.log(JSON.stringify(Object.values(Network)));
 
     try {
       // TODO: wait for decryption of existing key or encryption of new key, config option to disable encryption


### PR DESCRIPTION
This PR fixes the derivation of the default lnd macaroon paths based on the active network. Previously, changing the `network` config value from `testnet` would not change the default macaroon paths, they would need to be manually specified. This also correctly sets the testnet directory for the litecoin network as `testnet4` instead of `testnet`.