### PR TITLE
feat(rpc): add option to disable tls

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -27,6 +27,11 @@ require('yargs')
       describe: 'Path to the TLS certificate of xud',
       type: 'string',
     },
+    disabletls: {
+      alias: 'd',
+      describe: 'Whether to disable TLS for gRPC calls',
+      type: 'boolean',
+    },
   })
   .commandDir('../dist/cli/commands/', { recurse: true })
   .demandCommand(1, '')

--- a/bin/xud
+++ b/bin/xud
@@ -110,6 +110,11 @@ const { argv } = require('yargs')
       type: 'number',
       alias: 'r',
     },
+    'rpc.usetls': {
+      describe: 'Whether to use TLS for gRPC calls',
+      type: 'boolean',
+      default: undefined,
+    },
     'webproxy.disable': {
       describe: 'Disable web proxy server',
       type: 'boolean',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -15,7 +15,12 @@ class Config {
   public loglevel: string;
   public logpath: string;
   public network: Network;
-  public rpc: { disable: boolean, host: string, port: number };
+  public rpc: {
+    disable: boolean,
+    host: string,
+    port: number,
+    disabletls: boolean,
+  };
   public lndbtc: LndClientConfig;
   public lndltc: LndClientConfig;
   public raiden: RaidenClientConfig;
@@ -66,6 +71,7 @@ class Config {
       disable: false,
       host: 'localhost',
       port: 8886,
+      disabletls: false,
     };
     this.webproxy = {
       disable: true,

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -127,6 +127,7 @@ class Xud extends EventEmitter {
           this.config.rpc.host,
           path.join(this.config.xudir, 'tls.cert'),
           path.join(this.config.xudir, 'tls.key'),
+          this.config.rpc.disabletls,
         );
 
         if (!listening) {
@@ -144,6 +145,7 @@ class Xud extends EventEmitter {
               this.config.rpc.port,
               this.config.rpc.host,
               path.join(this.config.xudir, 'tls.cert'),
+              this.config.rpc.disabletls,
             );
           } catch (err) {
             this.logger.error('Could not start gRPC web proxy server', err);

--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -23,9 +23,14 @@ export const loadXudClient = (argv: Arguments) => {
     }
   };
 
-  const certPath = argv.tlscertpath ? argv.tlscertpath : path.join(getXudDir(), 'tls.cert');
-  const cert = fs.readFileSync(certPath);
-  const credentials = grpc.credentials.createSsl(cert);
+  let credentials: grpc.ChannelCredentials;
+  if (argv.disabletls) {
+    credentials = grpc.credentials.createInsecure();
+  } else {
+    const certPath = argv.tlscertpath ? argv.tlscertpath : path.join(getXudDir(), 'tls.cert');
+    const cert = fs.readFileSync(certPath);
+    credentials = grpc.credentials.createSsl(cert);
+  }
 
   return new XudClient(`${argv.rpchost}:${argv.rpcport}`, credentials);
 };

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -47,7 +47,7 @@ class GrpcServer {
    * Start the server and begin listening on the provided port
    * @returns true if the server started listening successfully, false otherwise
    */
-  public listen = async (port: number, host: string, tlsCertPath: string, tlsKeyPath: string): Promise<boolean> => {
+  public listen = async (port: number, host: string, tlsCertPath: string, tlsKeyPath: string, disableTls = false): Promise<boolean> => {
     assert(Number.isInteger(port) && port > 1023 && port < 65536, 'port must be an integer between 1024 and 65535');
 
     let certificate: Buffer;
@@ -65,7 +65,7 @@ class GrpcServer {
     }
 
     // tslint:disable-next-line:no-null-keyword
-    const credentials = grpc.ServerCredentials.createSsl(null,
+    const credentials = disableTls ? grpc.ServerCredentials.createInsecure() : grpc.ServerCredentials.createSsl(null,
       [{
         cert_chain: certificate,
         private_key: privateKey,

--- a/lib/grpc/webproxy/GrpcWebProxyServer.ts
+++ b/lib/grpc/webproxy/GrpcWebProxyServer.ts
@@ -25,13 +25,14 @@ class GrpcWebProxyServer {
   /**
    * Start the server and begins listening on the specified proxy port.
    */
-  public listen = (proxyPort: number, grpcPort: number, grpcHost: string, tlsCertPath: string): Promise<void> => {
+  public listen = (proxyPort: number, grpcPort: number, grpcHost: string, tlsCertPath: string, disableTls = false): Promise<void> => {
     // Load the proxy on / URL
     const protoPath = path.join(__dirname, '..', '..', '..', 'proto');
+    const credentials = disableTls ? grpc.credentials.createInsecure() : grpc.credentials.createSsl(fs.readFileSync(tlsCertPath));
     const gateway = grpcGateway(
       ['xudrpc.proto'],
       `${grpcHost}:${grpcPort}`,
-      grpc.credentials.createSsl(fs.readFileSync(tlsCertPath)),
+      credentials,
       protoPath,
     );
     this.app.use('/api/', gateway);


### PR DESCRIPTION
This commit adds an option to disable TLS on gRPC calls, which may be useful for testing and debugging purposes.

This is necessary as a short term fix for swap resolver communication with lnd until the resolver branch can be modified to properly use the xud tls.cert file.

This works well in my tests, below is how xucli commands look with TLS disabled on the server:

```
xucli getinfo
E1004 13:21:38.417000000 10260 ssl_transport_security.cc:1228] Handshake failed with fatal error SSL_ERROR_SSL: error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER.
E1004 13:21:38.418000000 10260 ssl_transport_security.cc:1228] Handshake failed with fatal error SSL_ERROR_SSL: error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER.
Error: 14 UNAVAILABLE: Connect Failed

xucli getinfo -d
{
  "version": "1.0.0-prealpha.4",
  "nodePubKey": "029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345",
  "urisList": [
    "029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345@75.75.58.83:8885",
    "029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345@127.0.0.1:8885"
  ],
  "numPeers": 3,
  "numPairs": 2,
  "orders": {
    "peer": 0,
    "own": 0
  },
  "lndbtc": {
    "error": "lnd is not connected",
    "chainsList": [],
    "blockheight": 0,
    "urisList": [],
    "version": "",
    "alias": ""
  },
  "lndltc": {
    "error": "",
    "channels": {
      "active": 1,
      "inactive": 0,
      "pending": 0
    },
    "chainsList": [
      "litecoin"
    ],
    "blockheight": 788671,
    "urisList": [],
    "version": "0.5.0-beta commit=",
    "alias": "Exchange A LTC on 10001/10011"
  }
}
```
