### PR TITLE
feat(lndclient): check if chain is out of sync

### DIFF
--- a/lib/BaseClient.ts
+++ b/lib/BaseClient.ts
@@ -5,6 +5,7 @@ enum ClientStatus {
   Disabled,
   Disconnected,
   ConnectionVerified,
+  OutOfSync,
 }
 
 /**
@@ -17,9 +18,9 @@ abstract class BaseClient extends EventEmitter {
     super();
   }
 
-  protected setStatus(val: ClientStatus): void {
-    this.logger.info(`${this.constructor.name} status: ${ClientStatus[val]}`);
-    this.status = val;
+  protected setStatus(status: ClientStatus): void {
+    this.logger.info(`${this.constructor.name} status: ${ClientStatus[status]}`);
+    this.status = status;
   }
   public isConnected(): boolean {
     return this.status === ClientStatus.ConnectionVerified;

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -184,17 +184,13 @@ class LndClient extends BaseClient {
     if (this.isDisabled()) {
       throw(errors.LND_IS_DISABLED);
     }
-    if (this.isConnected()) {
-      this.logger.warn(`not verifying connection to lnd, lnd is already connected`);
-      return;
-    }
     if (this.isDisconnected()) {
       this.logger.info(`trying to verify connection to lnd with uri: ${this.uri}`);
       this.lightning = new LightningClient(this.uri, this.credentials);
 
       try {
         const getInfoResponse = await this.getInfo();
-        if (getInfoResponse) {
+        if (getInfoResponse.getSyncedToChain()) {
           // mark connection as active
           this.setStatus(ClientStatus.ConnectionVerified);
           this.subscribeInvoices();
@@ -210,6 +206,10 @@ class LndClient extends BaseClient {
             this.identityPubKey = newPubKey;
           }
           this.emit('connectionVerified', newPubKey);
+        } else {
+          this.setStatus(ClientStatus.OutOfSync);
+          this.logger.error(`lnd at ${this.uri} is out of sync with chain, retrying in ${LndClient.RECONNECT_TIMER} ms`);
+          this.reconnectionTimer = setTimeout(this.verifyConnection, LndClient.RECONNECT_TIMER);
         }
       } catch (err) {
         this.setStatus(ClientStatus.Disconnected);


### PR DESCRIPTION
When testing with an old node that's been offline for a while, I've noticed that xud starts up just fine even while lnd is still catching up and is not yet fully functional. This PR checks to make sure lnd is synced to the backend chain when verifying a connection to it. If out of sync, we set a timer to reverify the same as if we could not call `getInfo` and hit a `Disconnected` status. This also removes the check against verifying the connection after a connection has been verified, as we might want to make checks going forward that lnd is still responsive and in sync.

I think we may want to consider setting a timer to periodically recheck that the chain is in sync and all is well. I've found that lnd continues to accept and send payments if it loses connectivity to the backing bitcoin node, but we may want to disallow that. I believe attempting to open/close channels at minimum will simply not work. I can open a separate issue for that.