### PR TITLE
feat(lndclient): add nomacaroons option

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -45,6 +45,11 @@ const { argv } = require('yargs')
       describe: 'Path of the admin macaroon for lndBtc',
       type: 'string',
     },
+    'lndbtc.nomacaroons': {
+      describe: 'Whether to disable macaroons for lndBtc',
+      type: 'boolean',
+      default: undefined,
+    },
     'lndbtc.port': {
       describe: 'Port of the lndBtc gRPC interface',
       type: 'number',
@@ -69,6 +74,11 @@ const { argv } = require('yargs')
     'lndltc.macaroonpath': {
       describe: 'Path of the admin macaroon for lndLtc',
       type: 'string',
+    },
+    'lndltc.nomacaroons': {
+      describe: 'Whether to disable macaroons for lndLtc',
+      type: 'boolean',
+      default: undefined,
     },
     'lndltc.port': {
       describe: 'Port of the lndLtc gRPC interface',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -78,6 +78,7 @@ class Config {
       host: 'localhost',
       port: 10009,
       cltvdelta: 144,
+      nomacaroons: false,
     };
     this.lndltc = {
       disable: false,
@@ -86,6 +87,7 @@ class Config {
       host: 'localhost',
       port: 10010,
       cltvdelta: 576,
+      nomacaroons: false,
     };
     this.raiden = {
       disable: false,


### PR DESCRIPTION
This PR adds a `nomacaroons` option for lnd clients to disable use of macaroons, which can be a helpful shortcut for testing purposes.