### PR TITLE
refactor(db): remove seed ZRX/GNT trading pair

### DIFF
--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -77,15 +77,15 @@ class DB {
       promises.push(Currency.bulkCreate(<db.CurrencyAttributes[]>[
         { id: 'BTC', swapClient: SwapClients.Lnd, decimalPlaces: 8 },
         { id: 'LTC', swapClient: SwapClients.Lnd, decimalPlaces: 8 },
-        { id: 'ZRX', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
-        { id: 'GNT', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
+        // { id: 'ZRX', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
+        // { id: 'GNT', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
       ]));
 
       await Promise.all(promises);
 
       await Pair.bulkCreate(<db.PairAttributes[]>[
         { baseCurrency: 'LTC', quoteCurrency: 'BTC' },
-        { baseCurrency: 'ZRX', quoteCurrency: 'GNT' },
+        // { baseCurrency: 'ZRX', quoteCurrency: 'GNT' },
       ]);
     }
   }


### PR DESCRIPTION
This PR comments out the ZRX/GNT trading pair from being initialized for new databases, since they currently have no swap support.