### PR TITLE
feat: leave partially swapped orders in order book

### DIFF
--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -184,18 +184,8 @@ class MatchingEngine {
     return removedOrders;
   }
 
-  /**
-   * Removes an own order by its global order id.
-   * @returns the removed order, or undefined if no order with the provided id could be found
-   */
-  public removeOwnOrder = (orderId: string): StampedOwnOrder | undefined => {
-    const order = this.ownOrders.buy.get(orderId) || this.ownOrders.sell.get(orderId);
-    if (!order) {
-      return;
-    }
-
+  public removeOwnOrder = (order: StampedOwnOrder) => {
     this.removeOrder(order, this.ownOrders);
-    return order;
   }
 
   private removePeerOrder = (order: StampedPeerOrder) => {

--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -4,6 +4,7 @@ import { matchingEngine, orders } from '../types';
 import { OrderingDirection } from '../types/enums';
 import Logger from '../Logger';
 import { isOwnOrder, StampedOrder, StampedOwnOrder, StampedPeerOrder } from '../types/orders';
+import errors from './errors';
 
 type SplitOrder = {
   matched: StampedOrder;
@@ -140,30 +141,6 @@ class MatchingEngine {
   }
 
   /**
-   * Removes a quantity from a peer order. If the entire quantity is met, the order will be removed entirely.
-   * @param quantityToRemove the quantity to remove, if undefined or if greater than or equal to the available
-   * quantity then the entire order is removed
-   * @returns the removed order or order portion, otherwise undefined if the order wasn't found
-   */
-  public removePeerOrderQuantity = (orderId: string, quantityToRemove?: number): StampedPeerOrder | undefined => {
-    const order = this.peerOrders.buy.get(orderId) || this.peerOrders.sell.get(orderId);
-    if (!order) {
-      return;
-    }
-
-    if (quantityToRemove && quantityToRemove < order.quantity) {
-      // if quantityToRemove is below the order quantity, reduce the order quantity
-      // and return a copy of the order with the quantity that was removed
-      order.quantity = order.quantity - quantityToRemove;
-      return { ...order, quantity: quantityToRemove };
-    } else {
-      // otherwise, remove the order entirely, and return it
-      this.removePeerOrder(order);
-      return order;
-    }
-  }
-
-  /**
    * Remove all orders given a peer pubKey.
    */
   public removePeerOrders = (peerPubKey: string): StampedPeerOrder[] => {
@@ -184,20 +161,48 @@ class MatchingEngine {
     return removedOrders;
   }
 
-  public removeOwnOrder = (order: StampedOwnOrder) => {
-    this.removeOrder(order, this.ownOrders);
+  /**
+   * Removes all or part of a peer order.
+   * @param quantityToRemove the quantity to remove, if undefined or if greater than or equal to the available
+   * quantity then the entire order is removed
+   * @returns the removed order or order portion, otherwise undefined if the order wasn't found
+   */
+  public removePeerOrder = (orderId: string, quantityToRemove?: number): { order: StampedOwnOrder, fullyRemoved: boolean} => {
+    return this.removeOrder(orderId, this.peerOrders, quantityToRemove);
   }
 
-  private removePeerOrder = (order: StampedPeerOrder) => {
-    this.removeOrder(order, this.peerOrders);
+  /**
+   * Removes all or part of an own order.
+   * @param quantityToRemove the quantity to remove, if undefined or if greater than or equal to the available
+   * quantity then the entire order is removed
+   * @returns true if the entire order was removed, or false if only part of the order was removed
+   */
+  public removeOwnOrder = (orderId: string, quantityToRemove?: number): { order: StampedOwnOrder, fullyRemoved: boolean} => {
+    return this.removeOrder(orderId, this.ownOrders, quantityToRemove);
   }
 
-  private removeOrder = (order: StampedOrder, lists: OrderSidesLists<StampedOrder>) => {
-    const list = order.isBuy ? lists.buy : lists.sell;
-    const queue = order.isBuy ? this.queues.buy : this.queues.sell;
+  private removeOrder = <T extends StampedOrder>(orderId: string, lists: OrderSidesLists<StampedOrder>, quantityToRemove?: number):
+    { order: T, fullyRemoved: boolean } => {
+    const order = lists.buy.get(orderId) || lists.sell.get(orderId);
+    if (!order) {
+      throw errors.ORDER_NOT_FOUND(orderId);
+    }
 
-    list.delete(order.id);
-    queue.remove(order);
+    if (quantityToRemove && quantityToRemove < order.quantity) {
+      // if quantityToRemove is below the order quantity, reduce the order quantity
+      order.quantity = order.quantity - quantityToRemove;
+      this.logger.debug(`order quantity reduced by ${quantityToRemove}: ${orderId}`);
+      return { order: { ...order, quantity: quantityToRemove } as T, fullyRemoved: false } ;
+    } else {
+      // otherwise, remove the order entirely
+      const list = order.isBuy ? lists.buy : lists.sell;
+      const queue = order.isBuy ? this.queues.buy : this.queues.sell;
+
+      list.delete(order.id);
+      queue.remove(order);
+      this.logger.debug(`order removed: ${orderId}`);
+      return { order: order as T, fullyRemoved: true };
+    }
   }
 
   private getOrderList = (order: StampedOrder): OrderList<StampedOrder> => {

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -4,11 +4,12 @@ const codesPrefix = errorCodesPrefix.ORDERBOOK;
 const errorCodes = {
   PAIR_DOES_NOT_EXIST: codesPrefix.concat('.1'),
   DUPLICATE_ORDER: codesPrefix.concat('.2'),
-  ORDER_NOT_FOUND: codesPrefix.concat('.3'),
+  OWN_ORDER_NOT_FOUND: codesPrefix.concat('.3'),
   CURRENCY_DOES_NOT_EXIST: codesPrefix.concat('.4'),
   CURRENCY_CANNOT_BE_REMOVED: codesPrefix.concat('.5'),
   CURRENCY_ALREADY_EXISTS: codesPrefix.concat('.6'),
   PAIR_ALREADY_EXISTS: codesPrefix.concat('.7'),
+  ORDER_NOT_FOUND: codesPrefix.concat('.8'),
 };
 
 const errors = {
@@ -17,12 +18,12 @@ const errors = {
     code: errorCodes.PAIR_DOES_NOT_EXIST,
   }),
   DUPLICATE_ORDER: (localId: string) => ({
-    message: `order with localId ${localId} already exists`,
+    message: `order with local id ${localId} already exists`,
     code: errorCodes.DUPLICATE_ORDER,
   }),
-  ORDER_NOT_FOUND: (localId: string) => ({
-    message: `order with local id ${localId} could not be found`,
-    code: errorCodes.ORDER_NOT_FOUND,
+  OWN_ORDER_NOT_FOUND: (localId: string) => ({
+    message: `own order with local id ${localId} could not be found`,
+    code: errorCodes.OWN_ORDER_NOT_FOUND,
   }),
   CURRENCY_DOES_NOT_EXIST: (currency: string) => ({
     message: `currency ${currency} does not exist`,
@@ -39,6 +40,10 @@ const errors = {
   PAIR_ALREADY_EXISTS: (pair_id: string) => ({
     message: `trading pair ${pair_id} already exists`,
     code: errorCodes.PAIR_ALREADY_EXISTS,
+  }),
+  ORDER_NOT_FOUND: (orderId: string) => ({
+    message: `order with id ${orderId} could not be found`,
+    code: errorCodes.ORDER_NOT_FOUND,
   }),
 };
 

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -211,10 +211,7 @@ describe('MatchingEngine.removeOwnOrder', () => {
     expect(matchingResult.matches).to.be.empty;
     expect(matchingResult.remainingOrder).to.not.be.undefined;
 
-    expect(engine.removeOwnOrder(uuidv1())).to.be.undefined;
-
-    const removedOrder = engine.removeOwnOrder(matchingResult.remainingOrder!.id);
-    expect(JSON.stringify(removedOrder)).to.equals(JSON.stringify(matchingResult.remainingOrder));
+    engine.removeOwnOrder(matchingResult.remainingOrder!);
     isEmpty(engine);
   });
 });
@@ -268,7 +265,7 @@ describe('MatchingEngine queues and lists integrity', () => {
     expect(engine.ownOrders.sell.size).to.equal(1);
     expect(engine.queues.sell.size).to.be.equal(1);
 
-    engine.removeOwnOrder(ownOrder.id);
+    engine.removeOwnOrder(ownOrder);
     isEmpty(engine);
   });
 

--- a/test/unit/MatchingEngine.spec.ts
+++ b/test/unit/MatchingEngine.spec.ts
@@ -211,7 +211,7 @@ describe('MatchingEngine.removeOwnOrder', () => {
     expect(matchingResult.matches).to.be.empty;
     expect(matchingResult.remainingOrder).to.not.be.undefined;
 
-    engine.removeOwnOrder(matchingResult.remainingOrder!);
+    engine.removeOwnOrder(matchingResult.remainingOrder!.id);
     isEmpty(engine);
   });
 });
@@ -248,10 +248,10 @@ describe('MatchingEngine.removePeerOrders', () => {
     const order = createPeerOrder(5, quantity, false);
     engine.addPeerOrder(order);
 
-    let removedOrder = engine.removePeerOrderQuantity(order.id, quantityToRemove) as orders.StampedPeerOrder;
+    let removedOrder = engine.removePeerOrder(order.id, quantityToRemove).order;
     expect(removedOrder.quantity).to.be.equal(quantityToRemove);
 
-    removedOrder = engine.removePeerOrderQuantity(order.id) as orders.StampedPeerOrder;
+    removedOrder = engine.removePeerOrder(order.id).order;
     expect(removedOrder.quantity).to.be.equal(quantity - quantityToRemove);
   });
 });
@@ -265,7 +265,7 @@ describe('MatchingEngine queues and lists integrity', () => {
     expect(engine.ownOrders.sell.size).to.equal(1);
     expect(engine.queues.sell.size).to.be.equal(1);
 
-    engine.removeOwnOrder(ownOrder);
+    engine.removeOwnOrder(ownOrder.id);
     isEmpty(engine);
   });
 
@@ -275,7 +275,7 @@ describe('MatchingEngine queues and lists integrity', () => {
     expect(engine.peerOrders.sell.size).to.equal(1);
     expect(engine.queues.sell.size).to.be.equal(1);
 
-    engine['removePeerOrder'](peerOrder);
+    engine['removePeerOrder'](peerOrder.id);
     expect(engine.peerOrders.sell).to.be.empty;
     expect(engine.queues.sell.isEmpty()).to.be.true;
   });
@@ -285,8 +285,8 @@ describe('MatchingEngine queues and lists integrity', () => {
     engine.addPeerOrder(peerOrder);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
-    const removedOrder = engine.removePeerOrderQuantity(peerOrder.id, 3);
-    expect(removedOrder!.quantity).to.equal(3);
+    const removeResult = engine.removePeerOrder(peerOrder.id, 3);
+    expect(removeResult.order.quantity).to.equal(3);
     expect(engine.peerOrders.sell.size).to.equal(1);
 
     const listRemainingOrder = engine.peerOrders.sell.get(peerOrder.id);


### PR DESCRIPTION
This PR makes it so we only remove part of our own maker orders when only part of them get swapped. Previously, the full order was removed from the order book even if only part of it was swapped. Now,
a partial swap results in a quantity reduction but leaves the order in the order book.