### PR TITLE
fix(orderbook): set localId on own order removals

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -275,6 +275,7 @@ class OrderBook extends EventEmitter {
       const portion: OrderPortion = { orderId: maker.id, pairId: maker.pairId, quantity: maker.quantity };
       if (orders.isOwnOrder(maker)) {
         // internal match
+        portion.localId = maker.localId;
         result.internalMatches.push(maker);
         this.emit('ownOrder.filled', portion);
         onUpdate && onUpdate({ case: PlaceOrderEventCase.InternalMatch, payload: maker });


### PR DESCRIPTION
This fixes a bug where an order's local id was not being set on the `ownOrder.filled` event.

Thanks to @michael1011 for noticing the behavior.