### PR TITLE
Fixes #539, tricky bug for removing ownOrders when there's an unreachable node

### DIFF
--- a/lib/orderbook/MatchingEngine.ts
+++ b/lib/orderbook/MatchingEngine.ts
@@ -144,6 +144,9 @@ class MatchingEngine {
    * Remove all orders given a peer pubKey.
    */
   public removePeerOrders = (peerPubKey: string): StampedPeerOrder[] => {
+    // if incoming peerPubKey is undefined or empty, don't even try to find it in order queues
+    if (!peerPubKey) return [];
+
     const callback = (order: StampedOrder) => (order as StampedPeerOrder).peerPubKey === peerPubKey;
 
     // remove from queues

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -406,15 +406,17 @@ class OrderBook extends EventEmitter {
   private removePeerOrders = async (peer: Peer): Promise<void> => {
     // TODO: remove only from pairs which are supported by the peer
     this.matchingEngines.forEach((matchingEngine) => {
-      const orders = matchingEngine.removePeerOrders(peer.nodePubKey!);
+      if (peer.nodePubKey) {
+        const orders = matchingEngine.removePeerOrders(peer.nodePubKey);
 
-      orders.forEach((order) => {
-        this.emit('peerOrder.invalidation', {
-          orderId: order.id,
-          pairId: order.pairId,
-          quantity: order.quantity,
+        orders.forEach((order) => {
+          this.emit('peerOrder.invalidation', {
+            orderId: order.id,
+            pairId: order.pairId,
+            quantity: order.quantity,
+          });
         });
-      });
+      }
     });
   }
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -405,18 +405,19 @@ class OrderBook extends EventEmitter {
 
   private removePeerOrders = async (peer: Peer): Promise<void> => {
     // TODO: remove only from pairs which are supported by the peer
-    this.matchingEngines.forEach((matchingEngine) => {
-      if (peer.nodePubKey) {
-        const orders = matchingEngine.removePeerOrders(peer.nodePubKey);
+    if (!peer.nodePubKey) {
+      return;
+    }
 
-        orders.forEach((order) => {
-          this.emit('peerOrder.invalidation', {
-            orderId: order.id,
-            pairId: order.pairId,
-            quantity: order.quantity,
-          });
+    this.matchingEngines.forEach((matchingEngine) => {
+      const orders = matchingEngine.removePeerOrders(peer.nodePubKey!);
+      orders.forEach((order) => {
+        this.emit('peerOrder.invalidation', {
+          orderId: order.id,
+          pairId: order.pairId,
+          quantity: order.quantity,
         });
-      }
+      });
     });
   }
 


### PR DESCRIPTION
Fixes #539 

Hello,

first of all this was a bit tricky to reproduce but I managed in the end, in my opinion current simple commit fixes the issue, maybe not calling `this.removePeerOrders` on `peer.close` in `bindPool` method would be better, I couldn't decide, current fix seemed easier to me.

Would you please check ?
