### PR TITLE
refactor: make static constants readonly

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -44,7 +44,7 @@ type Loggers = {
 };
 
 class Logger {
-  public static disabledLogger = new Logger({ disabled: true });
+  public static readonly DISABLED_LOGGER = new Logger({ disabled: true });
 
   private level: string;
   private context: Context;

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -55,7 +55,7 @@ class LndClient extends BaseClient {
   private identityPubKey?: string;
 
   /** Time in milliseconds between attempts to recheck connectivity to lnd if it is lost. */
-  private static RECONNECT_TIMER = 5000;
+  private static readonly RECONNECT_TIMER = 5000;
 
   /**
    * Create an lnd client.

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -60,7 +60,7 @@ class OrderBook extends EventEmitter {
   private repository: OrderBookRepository;
 
   /** Max time for addOwnOrder iterations (due to swaps failures retries). */
-  private static MAX_ADD_OWN_ORDER_ITERATIONS_TIME = 10000; // 10 sec
+  private static readonly MAX_ADD_OWN_ORDER_ITERATIONS_TIME = 10000; // 10 sec
 
   /** Gets an iterable of supported pair ids. */
   public get pairIds() {

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -26,7 +26,7 @@ interface NodeList {
 class NodeList extends EventEmitter {
   private nodes = new Map<string, NodeInstance>();
 
-  private static readonly banThreshold = -50;
+  private static readonly BAN_THRESHOLD = -50;
 
   public get count() {
     return this.nodes.size;
@@ -135,7 +135,7 @@ class NodeList extends EventEmitter {
 
       this.updateReputationScore(node, event);
 
-      if (node.reputationScore < NodeList.banThreshold) {
+      if (node.reputationScore < NodeList.BAN_THRESHOLD) {
         promises.push(this.setBanStatus(node, true));
         this.emit('node.ban', nodePubKey);
       } else if (node.banned) {

--- a/lib/p2p/Parser.ts
+++ b/lib/p2p/Parser.ts
@@ -71,7 +71,7 @@ interface Parser {
 class Parser extends EventEmitter {
   private buffer = '';
 
-  private static MAX_BUFFER_SIZE = (4 * 1024 * 1024); // in bytes
+  private static readonly MAX_BUFFER_SIZE = (4 * 1024 * 1024); // in bytes
 
   constructor(private delimiter: string, private maxBufferSize: number = Parser.MAX_BUFFER_SIZE) {
     super();

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -60,19 +60,19 @@ class Peer extends EventEmitter {
   /** A counter for packets sent to be used for assigning unique packet ids. */
   private packetCount = 0;
   /** Interval to check required responses from peer. */
-  private static STALL_INTERVAL = 5000;
+  private static readonly STALL_INTERVAL = 5000;
   /** Interval for pinging peers. */
-  private static PING_INTERVAL = 30000;
+  private static readonly PING_INTERVAL = 30000;
   /** Response timeout for response packets. */
-  private static RESPONSE_TIMEOUT = 10000;
+  private static readonly RESPONSE_TIMEOUT = 10000;
   /** Socket connection timeout for outbound peers. */
-  private static CONNECTION_TIMEOUT = 10000;
+  private static readonly CONNECTION_TIMEOUT = 10000;
   /** Connection retries min delay. */
-  private static CONNECTION_RETRIES_MIN_DELAY = 5000;
+  private static readonly CONNECTION_RETRIES_MIN_DELAY = 5000;
   /** Connection retries max delay. */
-  private static CONNECTION_RETRIES_MAX_DELAY = 3600000;
+  private static readonly CONNECTION_RETRIES_MAX_DELAY = 3600000;
   /** Connection retries max period. */
-  private static CONNECTION_RETRIES_MAX_PERIOD = 604800000;
+  private static readonly CONNECTION_RETRIES_MAX_PERIOD = 604800000;
 
   /** The hex-encoded node public key for this peer, or undefined if it is still not known. */
   public get nodePubKey(): string | undefined {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -197,7 +197,7 @@ class Pool extends EventEmitter {
       const externalAddress = addressUtils.toString(address);
       this.logger.debug(`Verifying reachability of advertised address: ${externalAddress}`);
       try {
-        const peer = new Peer(Logger.disabledLogger, address);
+        const peer = new Peer(Logger.DISABLED_LOGGER, address);
         await peer.open(this.handshakeData, this.handshakeData.nodePubKey);
         assert(false, errors.ATTEMPTED_CONNECTION_TO_SELF.message);
       } catch (err) {

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -41,7 +41,7 @@ abstract class Packet<T = any> implements PacketInterface {
   public body?: T;
   public header: PacketHeader;
   /** Wire protocol delimiter. */
-  public static PROTOCOL_DELIMITER = 'ↂ₿ↂ';
+  public static readonly PROTOCOL_DELIMITER = 'ↂ₿ↂ';
 
   /**
    * Create a packet from a deserialized packet message.


### PR DESCRIPTION
This makes all static constant fields `readonly` so that they can't be reassigned a new value and also uses a consistent UPPER_SNAKE_CASE naming convention.