### PR TITLE
fix(p2p): consistent checks before connecting

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -116,12 +116,14 @@ class GrpcService {
       case orderErrorCodes.DUPLICATE_ORDER:
       case p2pErrorCodes.NODE_ALREADY_CONNECTED:
       case p2pErrorCodes.NODE_ALREADY_BANNED:
+      case p2pErrorCodes.ALREADY_CONNECTING:
       case orderErrorCodes.CURRENCY_ALREADY_EXISTS:
       case orderErrorCodes.PAIR_ALREADY_EXISTS:
         code = status.ALREADY_EXISTS;
         break;
       case p2pErrorCodes.NOT_CONNECTED:
       case p2pErrorCodes.NODE_NOT_BANNED:
+      case p2pErrorCodes.NODE_IS_BANNED:
       case lndErrorCodes.LND_IS_DISABLED:
       case lndErrorCodes.LND_IS_DISCONNECTED:
       case orderErrorCodes.CURRENCY_DOES_NOT_EXIST:

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -222,28 +222,17 @@ class Pool extends EventEmitter {
   private connectNodes = (nodes: NodeConnectionIterator, ignoreKnown = false, retryConnecting = false) => {
     const connectionPromises: Promise<void>[] = [];
     nodes.forEach((node) => {
-      let isNotIgnored = false;
-      let hasNoPendingConnections = true;
-
       // check that this node is not ourselves
       const isNotUs = node.nodePubKey !== this.handshakeData.nodePubKey;
 
-      // that it has listening addresses,
+      // check that it has listening addresses,
       const hasAddresses = node.addresses.length > 0;
 
-      // ignore nodes that are banned or, if ignoreKnown is true, that we already know
-      const isKnownNode = this.nodes.has(node.nodePubKey);
-      if (isKnownNode) {
-        isNotIgnored = !ignoreKnown && !this.nodes.isBanned(node.nodePubKey);
-      }
+      // ignore nodes that we already know if ignoreKnown is true
+      const isNotIgnored = this.nodes.has(node.nodePubKey) && !ignoreKnown;
 
-      // Check we're not already trying to connect to this node.
-      if (this.pendingOutgoingConnections.has(node.nodePubKey)) {
-        hasNoPendingConnections = false;
-      }
-
-      // Validate this node.
-      if (isNotUs && hasAddresses && isNotIgnored && hasNoPendingConnections) {
+      // determine whether we should attempt to connect
+      if (isNotUs && hasAddresses && isNotIgnored) {
         connectionPromises.push(this.tryConnectNode(node, retryConnecting));
       }
     });
@@ -285,9 +274,11 @@ class Pool extends EventEmitter {
 
       try {
         await this.addOutbound(address, nodePubKey, false);
-        return; // once we've successfully established an outbound connection, stop attempting new connections
+        return true; // once we've successfully established an outbound connection, stop attempting new connections
       } catch (err) {}
     }
+
+    return false;
   }
 
   /**
@@ -302,9 +293,12 @@ class Pool extends EventEmitter {
       const err = errors.ATTEMPTED_CONNECTION_TO_SELF;
       this.logger.warn(err.message);
       throw err;
+    } else if (this.nodes.isBanned(nodePubKey)) {
+      throw errors.NODE_IS_BANNED(nodePubKey);
     } else if (this.peers.has(nodePubKey)) {
-      const err = errors.NODE_ALREADY_CONNECTED(nodePubKey, address);
-      throw err;
+      throw errors.NODE_ALREADY_CONNECTED(nodePubKey, address);
+    } else if (this.pendingOutgoingConnections.has(nodePubKey)) {
+      throw errors.ALREADY_CONNECTING(nodePubKey);
     }
 
     const peer = new Peer(this.logger, address);
@@ -363,7 +357,6 @@ class Pool extends EventEmitter {
   public banNode = async (nodePubKey: string): Promise<void> => {
     if (this.nodes.isBanned(nodePubKey)) {
       throw errors.NODE_ALREADY_BANNED(nodePubKey);
-
     } else {
       const banned = await this.nodes.addReputationEvent(nodePubKey, ReputationEvent.ManualBan);
 

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -14,11 +14,13 @@ const errorCodes = {
   NODE_UNKNOWN: codesPrefix.concat('.8'),
   NODE_ALREADY_BANNED: codesPrefix.concat('.9'),
   NODE_NOT_BANNED: codesPrefix.concat('.10'),
+  NODE_IS_BANNED: codesPrefix.concat('.11'),
+  ALREADY_CONNECTING: codesPrefix.concat('.12'),
 };
 
 const errors = {
   NODE_ALREADY_CONNECTED: (nodePubKey: string, address: Address) => ({
-    message: `Node ${nodePubKey} at ${addressUtils.toString(address)} already connected`,
+    message: `node ${nodePubKey} at ${addressUtils.toString(address)} already connected`,
     code: errorCodes.NODE_ALREADY_CONNECTED,
   }),
   NOT_CONNECTED: (nodePubKey: string) => ({
@@ -50,12 +52,20 @@ const errors = {
     code: errorCodes.NODE_UNKNOWN,
   }),
   NODE_ALREADY_BANNED: (nodePubKey: string) => ({
-    message: `node ${nodePubKey} has allredy been banned`,
+    message: `node ${nodePubKey} has already been banned`,
     code: errorCodes.NODE_ALREADY_BANNED,
   }),
   NODE_NOT_BANNED: (nodePubKey: string) => ({
     message: `node ${nodePubKey} has not been banned`,
     code: errorCodes.NODE_NOT_BANNED,
+  }),
+  NODE_IS_BANNED: (nodePubKey: string) => ({
+    message: `could not connect to node ${nodePubKey} because it is banned`,
+    code: errorCodes.NODE_IS_BANNED,
+  }),
+  ALREADY_CONNECTING: (nodePubKey: string) => ({
+    message: `there is already an existing connection attempt to node ${nodePubKey}`,
+    code: errorCodes.ALREADY_CONNECTING,
   }),
 };
 


### PR DESCRIPTION
This commit fixes the logic that prevents us from connecting to banned nodes or creating duplicate connections to any node. Some of that logic was only applied for connecting to a set of nodes, but not on attempts to connect to a single node like through the rpc `connect call. All general checks have been moved to the `addOutbound` method which is a key method that all outgoing peer connection attempts go through.