### PR TITLE
docs: improve proto comments.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -81,8 +81,8 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | currency | [string](#string) |  | The ticker symbol for this currency such as BTC, LTC, ETH, etc... |
-| swap_client | [AddCurrencyRequest.SwapClient](#xudrpc.AddCurrencyRequest.SwapClient) |  | The payment channel network client to use for executing swaps |
-| token_address | [string](#string) |  | The contract address for layered tokens such as ERC20 |
+| swap_client | [AddCurrencyRequest.SwapClient](#xudrpc.AddCurrencyRequest.SwapClient) |  | The payment channel network client to use for executing swaps. |
+| token_address | [string](#string) |  | The contract address for layered tokens such as ERC20. |
 | decimal_places | [uint32](#uint32) |  | The number of places to the right of the decimal point of the smallest subunit of the currency. For example, BTC, LTC, and others where the smallest subunits (satoshis) are 0.00000001 full units (bitcoins) have 8 decimal places. ETH has 18. This can be thought of as the base 10 exponent of the smallest subunit expressed as a positive integer. A default value of 8 is used if unspecified. |
 
 
@@ -108,8 +108,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| base_currency | [string](#string) |  | The base currency that is bought and sold for this trading pair |
-| quote_currency | [string](#string) |  | The currency used to quote a price for the base currency |
+| base_currency | [string](#string) |  | The base currency that is bought and sold for this trading pair. |
+| quote_currency | [string](#string) |  | The currency used to quote a price for the base currency. |
 
 
 
@@ -134,7 +134,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| node_pub_key | [string](#string) |  |  |
+| node_pub_key | [string](#string) |  | The node pub key of the node to ban. |
 
 
 
@@ -159,8 +159,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| balance | [int64](#int64) |  | Sum of channels balances denominated in satoshis or equivalent |
-| pending_open_balance | [int64](#int64) |  | Sum of channels pending balances denominated in satoshis or equivalent |
+| balance | [int64](#int64) |  | Sum of channels balances denominated in satoshis or equivalent. |
+| pending_open_balance | [int64](#int64) |  | Sum of channels pending balances denominated in satoshis or equivalent. |
 
 
 
@@ -175,7 +175,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| currency | [string](#string) |  | The ticker symbol of the currency to query for, if unspecified then balances for all supported currencies are queried |
+| currency | [string](#string) |  | The ticker symbol of the currency to query for, if unspecified then balances for all supported currencies are queried. |
 
 
 
@@ -190,7 +190,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| balances | [ChannelBalanceResponse.BalancesEntry](#xudrpc.ChannelBalanceResponse.BalancesEntry) | repeated | A map between currency ticker symbols and their channel balances |
+| balances | [ChannelBalanceResponse.BalancesEntry](#xudrpc.ChannelBalanceResponse.BalancesEntry) | repeated | A map between currency ticker symbols and their channel balances. |
 
 
 
@@ -221,7 +221,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| node_uri | [string](#string) |  |  |
+| node_uri | [string](#string) |  | The uri of the node to connect to in &#34;[nodePubKey]@[host]:[port]&#34; format. |
 
 
 
@@ -256,12 +256,12 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| version | [string](#string) |  |  |
-| node_pub_key | [string](#string) |  |  |
-| uris | [string](#string) | repeated |  |
-| num_peers | [int32](#int32) |  |  |
-| num_pairs | [int32](#int32) |  |  |
-| orders | [OrdersCount](#xudrpc.OrdersCount) |  |  |
+| version | [string](#string) |  | The version of this instance of xud. |
+| node_pub_key | [string](#string) |  | The node pub key of this node. |
+| uris | [string](#string) | repeated | A list of uris that can be used to connect to this node. These are shared with peers. |
+| num_peers | [int32](#int32) |  | The number of currently connected peers. |
+| num_pairs | [int32](#int32) |  | The number of supported trading pairs. |
+| orders | [OrdersCount](#xudrpc.OrdersCount) |  | The number of active, standing orders in the order book. |
 | lndbtc | [LndInfo](#xudrpc.LndInfo) |  |  |
 | lndltc | [LndInfo](#xudrpc.LndInfo) |  |  |
 | raiden | [RaidenInfo](#xudrpc.RaidenInfo) |  |  |
@@ -279,8 +279,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| pair_id | [string](#string) |  | The trading pair for which to retrieve orders |
-| include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not |
+| pair_id | [string](#string) |  | The trading pair for which to retrieve orders. |
+| include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not. |
 
 
 
@@ -295,7 +295,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| orders | [GetOrdersResponse.OrdersEntry](#xudrpc.GetOrdersResponse.OrdersEntry) | repeated | A map between pair ids and their buy and sell orders |
+| orders | [GetOrdersResponse.OrdersEntry](#xudrpc.GetOrdersResponse.OrdersEntry) | repeated | A map between pair ids and their buy and sell orders. |
 
 
 
@@ -336,7 +336,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| currencies | [string](#string) | repeated | The ticker symbols of supported currencies |
+| currencies | [string](#string) | repeated | A list of ticker symbols of the supported currencies. |
 
 
 
@@ -361,7 +361,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| pairs | [string](#string) | repeated | The supported trading pair tickers in formats like &#34;LTC/BTC&#34; |
+| pairs | [string](#string) | repeated | The list of supported trading pair tickers in formats like &#34;LTC/BTC&#34;. |
 
 
 
@@ -386,7 +386,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| peers | [Peer](#xudrpc.Peer) | repeated |  |
+| peers | [Peer](#xudrpc.Peer) | repeated | The list of connected peers. |
 
 
 
@@ -401,9 +401,9 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| active | [int32](#int32) |  |  |
-| inactive | [int32](#int32) |  |  |
-| pending | [int32](#int32) |  |  |
+| active | [int32](#int32) |  | The number of active/online channels for this lnd instance that can be used for swaps. |
+| inactive | [int32](#int32) |  | The number of inactive/offline channels for this lnd instance. |
+| pending | [int32](#int32) |  | The number of channels that are pending on-chain confirmation before they can be used. |
 
 
 
@@ -481,8 +481,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| buy_orders | [Order](#xudrpc.Order) | repeated | A list of buy orders sorted by descending price |
-| sell_orders | [Order](#xudrpc.Order) | repeated | A list of sell orders sorted by ascending price |
+| buy_orders | [Order](#xudrpc.Order) | repeated | A list of buy orders sorted by descending price. |
+| sell_orders | [Order](#xudrpc.Order) | repeated | A list of sell orders sorted by ascending price. |
 
 
 
@@ -497,8 +497,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| peer | [int32](#int32) |  |  |
-| own | [int32](#int32) |  |  |
+| peer | [int32](#int32) |  | The number of orders belonging to remote xud nodes. |
+| own | [int32](#int32) |  | The number of orders belonging to our local xud node. |
 
 
 
@@ -513,14 +513,14 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [string](#string) |  | The socket address with host and port for this peer |
-| node_pub_key | [string](#string) |  | The node pub key to uniquely identify this peer |
-| lnd_btc_pub_key | [string](#string) |  | The lnd BTC pub key associated with this peer |
-| lnd_ltc_pub_key | [string](#string) |  | The lnd LTC pub key associated with this peer |
-| inbound | [bool](#bool) |  | Indicates whether this peer was connected inbound |
-| pairs | [string](#string) | repeated | A list of trading pair tickers supported by this peer |
-| xud_version | [string](#string) |  | The version of xud being used by the peer |
-| seconds_connected | [int32](#int32) |  | The time in seconds that we have been connected to this peer |
+| address | [string](#string) |  | The socket address with host and port for this peer. |
+| node_pub_key | [string](#string) |  | The node pub key to uniquely identify this peer. |
+| lnd_btc_pub_key | [string](#string) |  | The lnd BTC pub key associated with this peer. |
+| lnd_ltc_pub_key | [string](#string) |  | The lnd LTC pub key associated with this peer. |
+| inbound | [bool](#bool) |  | Indicates whether this peer was connected inbound. |
+| pairs | [string](#string) | repeated | A list of trading pair tickers supported by this peer. |
+| xud_version | [string](#string) |  | The version of xud being used by the peer. |
+| seconds_connected | [int32](#int32) |  | The time in seconds that we have been connected to this peer. |
 
 
 
@@ -535,9 +535,9 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| internal_match | [Order](#xudrpc.Order) |  | An own orders (or portions thereof) that matched the newly placed order |
-| swap_result | [SwapResult](#xudrpc.SwapResult) |  | A swap results of peer orders that matched the newly placed order |
-| remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book |
+| internal_match | [Order](#xudrpc.Order) |  | An own orders (or portions thereof) that matched the newly placed order. |
+| swap_result | [SwapResult](#xudrpc.SwapResult) |  | A swap results of peer orders that matched the newly placed order. |
+| remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
 
 
 
@@ -554,9 +554,9 @@
 | ----- | ---- | ----- | ----------- |
 | price | [double](#double) |  | The price of the order. |
 | quantity | [double](#double) |  | The quantity of the order. |
-| pair_id | [string](#string) |  | The trading pair that the order is for |
-| order_id | [string](#string) |  | The local id to assign to the order |
-| side | [OrderSide](#xudrpc.OrderSide) |  | Whether the order is a Buy or Sell |
+| pair_id | [string](#string) |  | The trading pair that the order is for. |
+| order_id | [string](#string) |  | The local id to assign to the order. |
+| side | [OrderSide](#xudrpc.OrderSide) |  | Whether the order is a Buy or Sell. |
 
 
 
@@ -571,9 +571,9 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| internal_matches | [Order](#xudrpc.Order) | repeated | A list of own orders (or portions thereof) that matched the newly placed order |
-| swap_results | [SwapResult](#xudrpc.SwapResult) | repeated | A list of swap results of peer orders that matched the newly placed order |
-| remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book |
+| internal_matches | [Order](#xudrpc.Order) | repeated | A list of own orders (or portions thereof) that matched the newly placed order. |
+| swap_results | [SwapResult](#xudrpc.SwapResult) | repeated | A list of swap results of peer orders that matched the newly placed order. |
+| remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
 
 
 
@@ -631,7 +631,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| order_id | [string](#string) |  | The local id of the order to remove |
+| order_id | [string](#string) |  | The local id of the order to remove. |
 
 
 
@@ -656,7 +656,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| pair_id | [string](#string) |  | The trading pair ticker to remove, such as &#34;LTC/BTC&#34; |
+| pair_id | [string](#string) |  | The trading pair ticker to remove in a format such as &#34;LTC/BTC&#34;. |
 
 
 
@@ -739,7 +739,7 @@
 | amount_received | [int64](#int64) |  | The amount of subunits (satoshis) received. |
 | amount_sent | [int64](#int64) |  | The amount of subunits (satoshis) sent. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer that executed this order. |
-| role | [SwapResult.Role](#xudrpc.SwapResult.Role) |  | Our role in the swap, either MAKER or TAKER |
+| role | [SwapResult.Role](#xudrpc.SwapResult.Role) |  | Our role in the swap, either MAKER or TAKER. |
 
 
 
@@ -754,8 +754,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| node_pub_key | [string](#string) |  |  |
-| reconnect | [bool](#bool) |  |  |
+| node_pub_key | [string](#string) |  | The node pub key of the peer to unban. |
+| reconnect | [bool](#bool) |  | Whether to attempt to connect to the peer after it is unbanned. |
 
 
 
@@ -821,23 +821,23 @@
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| AddCurrency | [AddCurrencyRequest](#xudrpc.AddCurrencyRequest) | [AddCurrencyResponse](#xudrpc.AddCurrencyResponse) | Add a currency to the list of supported currencies. |
-| AddPair | [AddPairRequest](#xudrpc.AddPairRequest) | [AddPairResponse](#xudrpc.AddPairResponse) | Add a trading pair to the list of supported trading pairs. |
-| RemoveOrder | [RemoveOrderRequest](#xudrpc.RemoveOrderRequest) | [RemoveOrderResponse](#xudrpc.RemoveOrderResponse) | Removes an order from the order book by its local id. |
-| ChannelBalance | [ChannelBalanceRequest](#xudrpc.ChannelBalanceRequest) | [ChannelBalanceResponse](#xudrpc.ChannelBalanceResponse) | Get the total balance available across all channels for a given currency. |
-| Connect | [ConnectRequest](#xudrpc.ConnectRequest) | [ConnectResponse](#xudrpc.ConnectResponse) | Connect to an XU node. |
-| Ban | [BanRequest](#xudrpc.BanRequest) | [BanResponse](#xudrpc.BanResponse) | Ban a XU node manually and disconnect from it. |
-| Unban | [UnbanRequest](#xudrpc.UnbanRequest) | [UnbanResponse](#xudrpc.UnbanResponse) | Remove ban from XU node manually and connect to it. |
-| GetInfo | [GetInfoRequest](#xudrpc.GetInfoRequest) | [GetInfoResponse](#xudrpc.GetInfoResponse) | Get general information about this Exchange Union node. |
+| AddCurrency | [AddCurrencyRequest](#xudrpc.AddCurrencyRequest) | [AddCurrencyResponse](#xudrpc.AddCurrencyResponse) | Adds a currency to the list of supported currencies. Once added, the currency may be used for new trading pairs. |
+| AddPair | [AddPairRequest](#xudrpc.AddPairRequest) | [AddPairResponse](#xudrpc.AddPairResponse) | Adds a trading pair to the list of supported trading pairs. The newly supported pair is advertised to peers so they may begin sending orders for it. |
+| RemoveOrder | [RemoveOrderRequest](#xudrpc.RemoveOrderRequest) | [RemoveOrderResponse](#xudrpc.RemoveOrderResponse) | Removes an order from the order book by its local id. This should be called when an order is canceled or filled outside of xud. Removed orders become immediately unavailable for swaps, and peers are notified that the order is no longer valid. |
+| ChannelBalance | [ChannelBalanceRequest](#xudrpc.ChannelBalanceRequest) | [ChannelBalanceResponse](#xudrpc.ChannelBalanceResponse) | Gets the total balance available across all payment channels for one or all currencies. |
+| Connect | [ConnectRequest](#xudrpc.ConnectRequest) | [ConnectResponse](#xudrpc.ConnectResponse) | Attempts to connect to a node. Once connected, the node is added to the list of peers and becomes available for swaps and trading. A handshake exchanges information about the peer&#39;s supported trading and swap clients. Orders will be shared with the peer upon connection and upon new order placements. |
+| Ban | [BanRequest](#xudrpc.BanRequest) | [BanResponse](#xudrpc.BanResponse) | Bans a node and immediately disconnects from it. This can be used to prevent any connections to a specific node. |
+| Unban | [UnbanRequest](#xudrpc.UnbanRequest) | [UnbanResponse](#xudrpc.UnbanResponse) | Removes a ban from a node manually and, optionally, attempts to connect to it. |
+| GetInfo | [GetInfoRequest](#xudrpc.GetInfoRequest) | [GetInfoResponse](#xudrpc.GetInfoResponse) | Gets general information about this node. |
 | GetOrders | [GetOrdersRequest](#xudrpc.GetOrdersRequest) | [GetOrdersResponse](#xudrpc.GetOrdersResponse) | Gets orders from the order book. This call returns the state of the order book at a given point in time, although it is not guaranteed to still be vaild by the time a response is received and processed by a client. It accepts an optional trading pair id parameter. If specified, only orders for that particular trading pair are returned. Otherwise, all orders are returned. Orders are separated into buys and sells for each trading pair, but unsorted. |
-| ListCurrencies | [ListCurrenciesRequest](#xudrpc.ListCurrenciesRequest) | [ListCurrenciesResponse](#xudrpc.ListCurrenciesResponse) | Get the list of the order book&#39;s supported currencies. |
-| ListPairs | [ListPairsRequest](#xudrpc.ListPairsRequest) | [ListPairsResponse](#xudrpc.ListPairsResponse) | Get the list of the order book&#39;s suported trading pairs. |
-| ListPeers | [ListPeersRequest](#xudrpc.ListPeersRequest) | [ListPeersResponse](#xudrpc.ListPeersResponse) | Get a list of connected peers. |
-| PlaceOrder | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderEvent](#xudrpc.PlaceOrderEvent) stream | Add an order to the order book. If price is zero or unspecified a market order will get added. |
+| ListCurrencies | [ListCurrenciesRequest](#xudrpc.ListCurrenciesRequest) | [ListCurrenciesResponse](#xudrpc.ListCurrenciesResponse) | Gets a list of this node&#39;s supported currencies. |
+| ListPairs | [ListPairsRequest](#xudrpc.ListPairsRequest) | [ListPairsResponse](#xudrpc.ListPairsResponse) | Gets a list of this nodes suported trading pairs. |
+| ListPeers | [ListPeersRequest](#xudrpc.ListPeersRequest) | [ListPeersResponse](#xudrpc.ListPeersResponse) | Gets a list of connected peers. |
+| PlaceOrder | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderEvent](#xudrpc.PlaceOrderEvent) stream | Adds an order to the order book. If price is zero or unspecified a market order will get added. |
 | PlaceOrderSync | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderResponse](#xudrpc.PlaceOrderResponse) | The synchronous non-streaming version of PlaceOrder. |
-| RemoveCurrency | [RemoveCurrencyRequest](#xudrpc.RemoveCurrencyRequest) | [RemoveCurrencyResponse](#xudrpc.RemoveCurrencyResponse) | Remove a currency. |
-| RemovePair | [RemovePairRequest](#xudrpc.RemovePairRequest) | [RemovePairResponse](#xudrpc.RemovePairResponse) | Remove a trading pair. |
-| Shutdown | [ShutdownRequest](#xudrpc.ShutdownRequest) | [ShutdownResponse](#xudrpc.ShutdownResponse) | Begin shutting down xud. |
+| RemoveCurrency | [RemoveCurrencyRequest](#xudrpc.RemoveCurrencyRequest) | [RemoveCurrencyResponse](#xudrpc.RemoveCurrencyResponse) | Removes a currency from the list of supported currencies. Only currencies that are not in use for any currently supported trading pairs may be removed. Once removed, the currency can no longer be used for any supported trading pairs. |
+| RemovePair | [RemovePairRequest](#xudrpc.RemovePairRequest) | [RemovePairResponse](#xudrpc.RemovePairResponse) | Removes a trading pair from the list of currently supported trading pair. This call will effectively cancel any standing orders for that trading pair. Peers are informed when a pair is no longer supported so that they will know to stop sending orders for it. |
+| Shutdown | [ShutdownRequest](#xudrpc.ShutdownRequest) | [ShutdownResponse](#xudrpc.ShutdownResponse) | Begin gracefully shutting down xud. |
 | SubscribeAddedOrders | [SubscribeAddedOrdersRequest](#xudrpc.SubscribeAddedOrdersRequest) | [Order](#xudrpc.Order) stream | Subscribes to orders being added to the order book. This call, together with SubscribeRemovedOrders, allows the client to maintain an up-to-date view of the order book. For example, an exchange that wants to show its users a real time list of the orders available to them would subscribe to this streaming call to be alerted of new orders as they become available for trading. |
 | SubscribeRemovedOrders | [SubscribeRemovedOrdersRequest](#xudrpc.SubscribeRemovedOrdersRequest) | [OrderRemoval](#xudrpc.OrderRemoval) stream | Subscribes to orders being removed - either in full or in part - from the order book. This call, together with SubscribeAddedOrders, allows the client to maintain an up-to-date view of the order book. For example, an exchange that wants to show its users a real time list of the orders available to them would subscribe to this streaming call to be alerted when part or all of an existing order is no longer available for trading. |
 | SubscribeSwaps | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapResult](#xudrpc.SwapResult) stream | Subscribes to completed swaps that are initiated by a remote peer. This call allows the client to get real-time notifications when its orders are filled by a remote taker. It can be used for tracking order executions, updating balances, and informing a trader when one of their orders is settled through Exchange Union network. |

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -17,11 +17,11 @@
   "paths": {
     "/v1/addcurrency": {
       "post": {
-        "summary": "Add a currency to the list of supported currencies.",
+        "summary": "Adds a currency to the list of supported currencies. Once added, the currency may be used for\nnew trading pairs.",
         "operationId": "AddCurrency",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcAddCurrencyResponse"
             }
@@ -44,11 +44,11 @@
     },
     "/v1/addpair": {
       "post": {
-        "summary": "Add a trading pair to the list of supported trading pairs.",
+        "summary": "Adds a trading pair to the list of supported trading pairs. The newly supported pair is\nadvertised to peers so they may begin sending orders for it.",
         "operationId": "AddPair",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcAddPairResponse"
             }
@@ -71,11 +71,11 @@
     },
     "/v1/ban": {
       "post": {
-        "summary": "Ban a XU node manually and disconnect from it.",
+        "summary": "Bans a node and immediately disconnects from it. This can be used to prevent any connections\nto a specific node.",
         "operationId": "Ban",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcBanResponse"
             }
@@ -98,11 +98,11 @@
     },
     "/v1/channelbalance": {
       "get": {
-        "summary": "Get the total balance available across all channels for a given currency.",
+        "summary": "Gets the total balance available across all payment channels for one or all currencies.",
         "operationId": "ChannelBalance",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcChannelBalanceResponse"
             }
@@ -111,7 +111,7 @@
         "parameters": [
           {
             "name": "currency",
-            "description": "The ticker symbol of the currency to query for, if unspecified then balances for all\nsupported currencies are queried.",
+            "description": "The ticker symbol of the currency to query for, if unspecified then balances for all supported\ncurrencies are queried.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -124,11 +124,11 @@
     },
     "/v1/connect": {
       "post": {
-        "summary": "Connect to an XU node.",
+        "summary": "Attempts to connect to a node. Once connected, the node is added to the list of peers and\nbecomes available for swaps and trading. A handshake exchanges information about the peer's\nsupported trading and swap clients. Orders will be shared with the peer upon connection and\nupon new order placements.",
         "operationId": "Connect",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcConnectResponse"
             }
@@ -151,11 +151,11 @@
     },
     "/v1/currencies": {
       "get": {
-        "summary": "Get the list of the order book's supported currencies.",
+        "summary": "Gets a list of this node's supported currencies.",
         "operationId": "ListCurrencies",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListCurrenciesResponse"
             }
@@ -168,11 +168,11 @@
     },
     "/v1/info": {
       "get": {
-        "summary": "Get general information about this Exchange Union node.",
+        "summary": "Gets general information about this node.",
         "operationId": "GetInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetInfoResponse"
             }
@@ -189,7 +189,7 @@
         "operationId": "GetOrders",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetOrdersResponse"
             }
@@ -219,11 +219,11 @@
     },
     "/v1/pairs": {
       "get": {
-        "summary": "Get the list of the order book's suported trading pairs.",
+        "summary": "Gets a list of this nodes suported trading pairs.",
         "operationId": "ListPairs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListPairsResponse"
             }
@@ -236,11 +236,11 @@
     },
     "/v1/peers": {
       "get": {
-        "summary": "Get a list of connected peers.",
+        "summary": "Gets a list of connected peers.",
         "operationId": "ListPeers",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListPeersResponse"
             }
@@ -253,11 +253,11 @@
     },
     "/v1/placeorder": {
       "post": {
-        "summary": "Add an order to the order book.\nIf price is zero or unspecified a market order will get added.",
+        "summary": "Adds an order to the order book.\nIf price is zero or unspecified a market order will get added.",
         "operationId": "PlaceOrder",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcPlaceOrderEvent"
             }
@@ -284,7 +284,7 @@
         "operationId": "PlaceOrderSync",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcPlaceOrderResponse"
             }
@@ -307,11 +307,11 @@
     },
     "/v1/removecurrency": {
       "post": {
-        "summary": "Remove a currency.",
+        "summary": "Removes a currency from the list of supported currencies. Only currencies that are not in use\nfor any currently supported trading pairs may be removed.  Once removed, the currency can no\nlonger be used for any supported trading pairs.",
         "operationId": "RemoveCurrency",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemoveCurrencyResponse"
             }
@@ -334,11 +334,11 @@
     },
     "/v1/removeorder": {
       "post": {
-        "summary": "Removes an order from the order book by its local id.",
+        "summary": "Removes an order from the order book by its local id. This should be called when an order is\ncanceled or filled outside of xud. Removed orders become immediately unavailable for swaps, \nand peers are notified that the order is no longer valid.",
         "operationId": "RemoveOrder",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemoveOrderResponse"
             }
@@ -361,11 +361,11 @@
     },
     "/v1/removepair": {
       "post": {
-        "summary": "Remove a trading pair.",
+        "summary": "Removes a trading pair from the list of currently supported trading pair. This call will\neffectively cancel any standing orders for that trading pair. Peers are informed when a pair\nis no longer supported so that they will know to stop sending orders for it.",
         "operationId": "RemovePair",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemovePairResponse"
             }
@@ -388,11 +388,11 @@
     },
     "/v1/shutdown": {
       "post": {
-        "summary": "Begin shutting down xud.",
+        "summary": "Begin gracefully shutting down xud.",
         "operationId": "Shutdown",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcShutdownResponse"
             }
@@ -419,7 +419,7 @@
         "operationId": "SubscribeRemovedOrders",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcOrderRemoval"
             }
@@ -436,7 +436,7 @@
         "operationId": "SubscribeSwaps",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcSwapResult"
             }
@@ -449,11 +449,11 @@
     },
     "/v1/unban": {
       "post": {
-        "summary": "Remove ban from XU node manually and connect to it.",
+        "summary": "Removes a ban from a node manually and, optionally, attempts to connect to it.",
         "operationId": "Unban",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcUnbanResponse"
             }
@@ -501,16 +501,16 @@
         },
         "swap_client": {
           "$ref": "#/definitions/AddCurrencyRequestSwapClient",
-          "title": "The payment channel network client to use for executing swaps"
+          "description": "The payment channel network client to use for executing swaps."
         },
         "token_address": {
           "type": "string",
-          "title": "The contract address for layered tokens such as ERC20"
+          "description": "The contract address for layered tokens such as ERC20."
         },
         "decimal_places": {
           "type": "integer",
           "format": "int64",
-          "description": "The number of places to the right of the decimal point of the smallest subunit of the currency. For example, BTC, LTC, and others\nwhere the smallest subunits (satoshis) are 0.00000001 full units (bitcoins) have 8 decimal places. ETH has 18. This can be thought\nof as the base 10 exponent of the smallest subunit expressed as a positive integer. A default value of 8 is used if unspecified."
+          "description": "The number of places to the right of the decimal point of the smallest subunit of the currency.\nFor example, BTC, LTC, and others where the smallest subunits (satoshis) are 0.00000001 full\nunits (bitcoins) have 8 decimal places. ETH has 18. This can be thought of as the base 10\nexponent of the smallest subunit expressed as a positive integer. A default value of 8 is\nused if unspecified."
         }
       }
     },
@@ -522,11 +522,11 @@
       "properties": {
         "base_currency": {
           "type": "string",
-          "title": "The base currency that is bought and sold for this trading pair"
+          "description": "The base currency that is bought and sold for this trading pair."
         },
         "quote_currency": {
           "type": "string",
-          "title": "The currency used to quote a price for the base currency"
+          "description": "The currency used to quote a price for the base currency."
         }
       }
     },
@@ -537,7 +537,8 @@
       "type": "object",
       "properties": {
         "node_pub_key": {
-          "type": "string"
+          "type": "string",
+          "description": "The node pub key of the node to ban."
         }
       }
     },
@@ -550,12 +551,12 @@
         "balance": {
           "type": "string",
           "format": "int64",
-          "title": "Sum of channels balances denominated in satoshis or equivalent"
+          "description": "Sum of channels balances denominated in satoshis or equivalent."
         },
         "pending_open_balance": {
           "type": "string",
           "format": "int64",
-          "title": "Sum of channels pending balances denominated in satoshis or equivalent"
+          "description": "Sum of channels pending balances denominated in satoshis or equivalent."
         }
       }
     },
@@ -567,7 +568,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/xudrpcChannelBalance"
           },
-          "title": "A map between currency ticker symbols and their channel balances"
+          "description": "A map between currency ticker symbols and their channel balances."
         }
       }
     },
@@ -575,7 +576,8 @@
       "type": "object",
       "properties": {
         "node_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The uri of the node to connect to in \"[nodePubKey]@[host]:[port]\" format."
         }
       }
     },
@@ -586,27 +588,33 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": "string"
+          "type": "string",
+          "description": "The version of this instance of xud."
         },
         "node_pub_key": {
-          "type": "string"
+          "type": "string",
+          "description": "The node pub key of this node."
         },
         "uris": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of uris that can be used to connect to this node. These are shared with peers."
         },
         "num_peers": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of currently connected peers."
         },
         "num_pairs": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of supported trading pairs."
         },
         "orders": {
-          "$ref": "#/definitions/xudrpcOrdersCount"
+          "$ref": "#/definitions/xudrpcOrdersCount",
+          "description": "The number of active, standing orders in the order book."
         },
         "lndbtc": {
           "$ref": "#/definitions/xudrpcLndInfo"
@@ -627,7 +635,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/xudrpcOrders"
           },
-          "title": "A map between pair ids and their buy and sell orders"
+          "description": "A map between pair ids and their buy and sell orders."
         }
       }
     },
@@ -639,7 +647,7 @@
           "items": {
             "type": "string"
           },
-          "title": "The ticker symbols of supported currencies"
+          "description": "A list of ticker symbols of the supported currencies."
         }
       }
     },
@@ -651,7 +659,7 @@
           "items": {
             "type": "string"
           },
-          "title": "The supported trading pair tickers in formats like \"LTC/BTC\""
+          "description": "The list of supported trading pair tickers in formats like \"LTC/BTC\"."
         }
       }
     },
@@ -662,7 +670,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/xudrpcPeer"
-          }
+          },
+          "description": "The list of connected peers."
         }
       }
     },
@@ -671,15 +680,18 @@
       "properties": {
         "active": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of active/online channels for this lnd instance that can be used for swaps."
         },
         "inactive": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of inactive/offline channels for this lnd instance."
         },
         "pending": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of channels that are pending on-chain confirmation before they can be used."
         }
       }
     },
@@ -804,14 +816,14 @@
           "items": {
             "$ref": "#/definitions/xudrpcOrder"
           },
-          "title": "A list of buy orders sorted by descending price"
+          "description": "A list of buy orders sorted by descending price."
         },
         "sell_orders": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/xudrpcOrder"
           },
-          "title": "A list of sell orders sorted by ascending price"
+          "description": "A list of sell orders sorted by ascending price."
         }
       }
     },
@@ -820,11 +832,13 @@
       "properties": {
         "peer": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of orders belonging to remote xud nodes."
         },
         "own": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "The number of orders belonging to our local xud node."
         }
       }
     },
@@ -833,40 +847,40 @@
       "properties": {
         "address": {
           "type": "string",
-          "title": "The socket address with host and port for this peer"
+          "description": "The socket address with host and port for this peer."
         },
         "node_pub_key": {
           "type": "string",
-          "title": "The node pub key to uniquely identify this peer"
+          "description": "The node pub key to uniquely identify this peer."
         },
         "lnd_btc_pub_key": {
           "type": "string",
-          "title": "The lnd BTC pub key associated with this peer"
+          "description": "The lnd BTC pub key associated with this peer."
         },
         "lnd_ltc_pub_key": {
           "type": "string",
-          "title": "The lnd LTC pub key associated with this peer"
+          "description": "The lnd LTC pub key associated with this peer."
         },
         "inbound": {
           "type": "boolean",
           "format": "boolean",
-          "title": "Indicates whether this peer was connected inbound"
+          "description": "Indicates whether this peer was connected inbound."
         },
         "pairs": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "A list of trading pair tickers supported by this peer"
+          "description": "A list of trading pair tickers supported by this peer."
         },
         "xud_version": {
           "type": "string",
-          "title": "The version of xud being used by the peer"
+          "description": "The version of xud being used by the peer."
         },
         "seconds_connected": {
           "type": "integer",
           "format": "int32",
-          "title": "The time in seconds that we have been connected to this peer"
+          "description": "The time in seconds that we have been connected to this peer."
         }
       }
     },
@@ -875,15 +889,15 @@
       "properties": {
         "internal_match": {
           "$ref": "#/definitions/xudrpcOrder",
-          "title": "An own orders (or portions thereof) that matched the newly placed order"
+          "description": "An own orders (or portions thereof) that matched the newly placed order."
         },
         "swap_result": {
           "$ref": "#/definitions/xudrpcSwapResult",
-          "title": "A swap results of peer orders that matched the newly placed order"
+          "description": "A swap results of peer orders that matched the newly placed order."
         },
         "remaining_order": {
           "$ref": "#/definitions/xudrpcOrder",
-          "title": "The remaining portion of the order, after matches, that enters the order book"
+          "description": "The remaining portion of the order, after matches, that enters the order book."
         }
       }
     },
@@ -902,15 +916,15 @@
         },
         "pair_id": {
           "type": "string",
-          "title": "The trading pair that the order is for"
+          "description": "The trading pair that the order is for."
         },
         "order_id": {
           "type": "string",
-          "title": "The local id to assign to the order"
+          "description": "The local id to assign to the order."
         },
         "side": {
           "$ref": "#/definitions/xudrpcOrderSide",
-          "title": "Whether the order is a Buy or Sell"
+          "description": "Whether the order is a Buy or Sell."
         }
       }
     },
@@ -922,18 +936,18 @@
           "items": {
             "$ref": "#/definitions/xudrpcOrder"
           },
-          "title": "A list of own orders (or portions thereof) that matched the newly placed order"
+          "description": "A list of own orders (or portions thereof) that matched the newly placed order."
         },
         "swap_results": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/xudrpcSwapResult"
           },
-          "title": "A list of swap results of peer orders that matched the newly placed order"
+          "description": "A list of swap results of peer orders that matched the newly placed order."
         },
         "remaining_order": {
           "$ref": "#/definitions/xudrpcOrder",
-          "title": "The remaining portion of the order, after matches, that enters the order book"
+          "description": "The remaining portion of the order, after matches, that enters the order book."
         }
       }
     },
@@ -972,7 +986,7 @@
       "properties": {
         "order_id": {
           "type": "string",
-          "title": "The local id of the order to remove"
+          "description": "The local id of the order to remove."
         }
       }
     },
@@ -984,7 +998,7 @@
       "properties": {
         "pair_id": {
           "type": "string",
-          "title": "The trading pair ticker to remove, such as \"LTC/BTC\""
+          "description": "The trading pair ticker to remove in a format such as \"LTC/BTC\"."
         }
       }
     },
@@ -1037,7 +1051,7 @@
         },
         "role": {
           "$ref": "#/definitions/SwapResultRole",
-          "title": "Our role in the swap, either MAKER or TAKER"
+          "description": "Our role in the swap, either MAKER or TAKER."
         }
       }
     },
@@ -1045,11 +1059,13 @@
       "type": "object",
       "properties": {
         "node_pub_key": {
-          "type": "string"
+          "type": "string",
+          "description": "The node pub key of the peer to unban."
         },
         "reconnect": {
           "type": "boolean",
-          "format": "boolean"
+          "format": "boolean",
+          "description": "Whether to attempt to connect to the peer after it is unbanned."
         }
       }
     },

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -457,7 +457,8 @@ function deserialize_xudrpc_UnbanResponse(buffer_arg) {
 
 
 var XudService = exports.XudService = {
-  // Add a currency to the list of supported currencies. 
+  // Adds a currency to the list of supported currencies. Once added, the currency may be used for
+  // new trading pairs. 
   addCurrency: {
     path: '/xudrpc.Xud/AddCurrency',
     requestStream: false,
@@ -469,7 +470,8 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_AddCurrencyResponse,
     responseDeserialize: deserialize_xudrpc_AddCurrencyResponse,
   },
-  // Add a trading pair to the list of supported trading pairs. 
+  // Adds a trading pair to the list of supported trading pairs. The newly supported pair is
+  // advertised to peers so they may begin sending orders for it. 
   addPair: {
     path: '/xudrpc.Xud/AddPair',
     requestStream: false,
@@ -481,7 +483,9 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_AddPairResponse,
     responseDeserialize: deserialize_xudrpc_AddPairResponse,
   },
-  // Removes an order from the order book by its local id. 
+  // Removes an order from the order book by its local id. This should be called when an order is
+  // canceled or filled outside of xud. Removed orders become immediately unavailable for swaps, 
+  // and peers are notified that the order is no longer valid. 
   removeOrder: {
     path: '/xudrpc.Xud/RemoveOrder',
     requestStream: false,
@@ -493,7 +497,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_RemoveOrderResponse,
     responseDeserialize: deserialize_xudrpc_RemoveOrderResponse,
   },
-  // Get the total balance available across all channels for a given currency. 
+  // Gets the total balance available across all payment channels for one or all currencies. 
   channelBalance: {
     path: '/xudrpc.Xud/ChannelBalance',
     requestStream: false,
@@ -505,7 +509,10 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_ChannelBalanceResponse,
     responseDeserialize: deserialize_xudrpc_ChannelBalanceResponse,
   },
-  // Connect to an XU node. 
+  // Attempts to connect to a node. Once connected, the node is added to the list of peers and
+  // becomes available for swaps and trading. A handshake exchanges information about the peer's
+  // supported trading and swap clients. Orders will be shared with the peer upon connection and
+  // upon new order placements.
   connect: {
     path: '/xudrpc.Xud/Connect',
     requestStream: false,
@@ -517,7 +524,8 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_ConnectResponse,
     responseDeserialize: deserialize_xudrpc_ConnectResponse,
   },
-  // Ban a XU node manually and disconnect from it. 
+  // Bans a node and immediately disconnects from it. This can be used to prevent any connections
+  // to a specific node.
   ban: {
     path: '/xudrpc.Xud/Ban',
     requestStream: false,
@@ -529,7 +537,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_BanResponse,
     responseDeserialize: deserialize_xudrpc_BanResponse,
   },
-  // Remove ban from XU node manually and connect to it. 
+  // Removes a ban from a node manually and, optionally, attempts to connect to it. 
   unban: {
     path: '/xudrpc.Xud/Unban',
     requestStream: false,
@@ -541,7 +549,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_UnbanResponse,
     responseDeserialize: deserialize_xudrpc_UnbanResponse,
   },
-  // Get general information about this Exchange Union node. 
+  // Gets general information about this node. 
   getInfo: {
     path: '/xudrpc.Xud/GetInfo',
     requestStream: false,
@@ -569,7 +577,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_GetOrdersResponse,
     responseDeserialize: deserialize_xudrpc_GetOrdersResponse,
   },
-  // Get the list of the order book's supported currencies. 
+  // Gets a list of this node's supported currencies. 
   listCurrencies: {
     path: '/xudrpc.Xud/ListCurrencies',
     requestStream: false,
@@ -581,7 +589,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_ListCurrenciesResponse,
     responseDeserialize: deserialize_xudrpc_ListCurrenciesResponse,
   },
-  // Get the list of the order book's suported trading pairs. 
+  // Gets a list of this nodes suported trading pairs. 
   listPairs: {
     path: '/xudrpc.Xud/ListPairs',
     requestStream: false,
@@ -593,7 +601,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_ListPairsResponse,
     responseDeserialize: deserialize_xudrpc_ListPairsResponse,
   },
-  // Get a list of connected peers. 
+  // Gets a list of connected peers. 
   listPeers: {
     path: '/xudrpc.Xud/ListPeers',
     requestStream: false,
@@ -605,8 +613,8 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_ListPeersResponse,
     responseDeserialize: deserialize_xudrpc_ListPeersResponse,
   },
-  // Add an order to the order book.
-  // If price is zero or unspecified a market order will get added.
+  // Adds an order to the order book.
+  // If price is zero or unspecified a market order will get added. 
   placeOrder: {
     path: '/xudrpc.Xud/PlaceOrder',
     requestStream: false,
@@ -630,7 +638,9 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_PlaceOrderResponse,
     responseDeserialize: deserialize_xudrpc_PlaceOrderResponse,
   },
-  // Remove a currency. 
+  // Removes a currency from the list of supported currencies. Only currencies that are not in use
+  // for any currently supported trading pairs may be removed.  Once removed, the currency can no
+  // longer be used for any supported trading pairs. 
   removeCurrency: {
     path: '/xudrpc.Xud/RemoveCurrency',
     requestStream: false,
@@ -642,7 +652,9 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_RemoveCurrencyResponse,
     responseDeserialize: deserialize_xudrpc_RemoveCurrencyResponse,
   },
-  // Remove a trading pair. 
+  // Removes a trading pair from the list of currently supported trading pair. This call will
+  // effectively cancel any standing orders for that trading pair. Peers are informed when a pair
+  // is no longer supported so that they will know to stop sending orders for it. 
   removePair: {
     path: '/xudrpc.Xud/RemovePair',
     requestStream: false,
@@ -654,7 +666,7 @@ var XudService = exports.XudService = {
     responseSerialize: serialize_xudrpc_RemovePairResponse,
     responseDeserialize: deserialize_xudrpc_RemovePairResponse,
   },
-  // Begin shutting down xud. 
+  // Begin gracefully shutting down xud. 
   shutdown: {
     path: '/xudrpc.Xud/Shutdown',
     requestStream: false,

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -25,7 +25,8 @@ import "annotations.proto";
 package xudrpc;
 
 service Xud {
-  /* Add a currency to the list of supported currencies. */
+  /* Adds a currency to the list of supported currencies. Once added, the currency may be used for
+   * new trading pairs. */
   rpc AddCurrency(AddCurrencyRequest) returns (AddCurrencyResponse) {
     option (google.api.http) = {
       post: "/v1/addcurrency"
@@ -33,7 +34,8 @@ service Xud {
     };
   }
 
-  /* Add a trading pair to the list of supported trading pairs. */
+  /* Adds a trading pair to the list of supported trading pairs. The newly supported pair is
+   * advertised to peers so they may begin sending orders for it. */
   rpc AddPair(AddPairRequest) returns (AddPairResponse) {
     option (google.api.http) = {
       post: "/v1/addpair"
@@ -41,7 +43,9 @@ service Xud {
     };
   }
 
-  /* Removes an order from the order book by its local id. */
+  /* Removes an order from the order book by its local id. This should be called when an order is
+   * canceled or filled outside of xud. Removed orders become immediately unavailable for swaps, 
+   * and peers are notified that the order is no longer valid. */
   rpc RemoveOrder(RemoveOrderRequest) returns (RemoveOrderResponse) {
     option (google.api.http) = {
       post: "/v1/removeorder"
@@ -49,14 +53,17 @@ service Xud {
     };
   }
 
-  /* Get the total balance available across all channels for a given currency. */
+  /* Gets the total balance available across all payment channels for one or all currencies. */
   rpc ChannelBalance(ChannelBalanceRequest) returns (ChannelBalanceResponse) {
     option (google.api.http) = {
       get: "/v1/channelbalance"
     };
   }
   
-  /* Connect to an XU node. */
+  /* Attempts to connect to a node. Once connected, the node is added to the list of peers and
+   * becomes available for swaps and trading. A handshake exchanges information about the peer's
+   * supported trading and swap clients. Orders will be shared with the peer upon connection and
+   * upon new order placements.*/
   rpc Connect(ConnectRequest) returns (ConnectResponse) {
     option (google.api.http) = {
       post: "/v1/connect"
@@ -64,7 +71,8 @@ service Xud {
     };
   }
   
-  /* Ban a XU node manually and disconnect from it. */
+  /* Bans a node and immediately disconnects from it. This can be used to prevent any connections
+   * to a specific node.*/
   rpc Ban(BanRequest) returns (BanResponse) {
     option (google.api.http) = {
       post: "/v1/ban"
@@ -72,7 +80,7 @@ service Xud {
     };
   }
 
-  /* Remove ban from XU node manually and connect to it. */
+  /* Removes a ban from a node manually and, optionally, attempts to connect to it. */
   rpc Unban(UnbanRequest) returns (UnbanResponse) {
     option (google.api.http) = {
       post: "/v1/unban"
@@ -80,7 +88,7 @@ service Xud {
     };
   }
   
-  /* Get general information about this Exchange Union node. */
+  /* Gets general information about this node. */
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {
     option (google.api.http) = {
       get: "/v1/info"
@@ -98,30 +106,29 @@ service Xud {
     };
   }
   
-  /* Get the list of the order book's supported currencies. */
+  /* Gets a list of this node's supported currencies. */
   rpc ListCurrencies(ListCurrenciesRequest) returns (ListCurrenciesResponse) {
     option (google.api.http) = {
       get: "/v1/currencies"
     };
   }
   
-  /* Get the list of the order book's suported trading pairs. */
+  /* Gets a list of this nodes suported trading pairs. */
   rpc ListPairs(ListPairsRequest) returns (ListPairsResponse) {
     option (google.api.http) = {
       get: "/v1/pairs"
     };
   }
   
-  /* Get a list of connected peers. */
+  /* Gets a list of connected peers. */
   rpc ListPeers(ListPeersRequest) returns (ListPeersResponse) {
     option (google.api.http) = {
       get: "/v1/peers"
     };
   }
 
-  /* Add an order to the order book.
-   * If price is zero or unspecified a market order will get added.
-   */
+  /* Adds an order to the order book.
+   * If price is zero or unspecified a market order will get added. */
   rpc PlaceOrder(PlaceOrderRequest) returns (stream PlaceOrderEvent) {
     option (google.api.http) = {
       post: "/v1/placeorder"
@@ -138,7 +145,9 @@ service Xud {
   }
 
 
-  /* Remove a currency. */
+  /* Removes a currency from the list of supported currencies. Only currencies that are not in use
+   * for any currently supported trading pairs may be removed. Once removed, the currency can no
+   * longer be used for any supported trading pairs. */
   rpc RemoveCurrency(RemoveCurrencyRequest) returns (RemoveCurrencyResponse) {
     option (google.api.http) = {
       post: "/v1/removecurrency"
@@ -146,7 +155,9 @@ service Xud {
     };
   }
 
-  /* Remove a trading pair. */
+  /* Removes a trading pair from the list of currently supported trading pair. This call will
+   * effectively cancel any standing orders for that trading pair. Peers are informed when a pair
+   * is no longer supported so that they will know to stop sending orders for it. */
   rpc RemovePair(RemovePairRequest) returns (RemovePairResponse) {
     option (google.api.http) = {
       post: "/v1/removepair"
@@ -154,7 +165,7 @@ service Xud {
     };
   }
   
-  /* Begin shutting down xud. */
+  /* Begin gracefully shutting down xud. */
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse) {
     option (google.api.http) = {
       post: "/v1/shutdown"
@@ -206,65 +217,75 @@ message AddCurrencyRequest {
     LND = 0;
     RAIDEN = 1;
   }
-  // The payment channel network client to use for executing swaps
+  // The payment channel network client to use for executing swaps.
   SwapClient swap_client = 2 [json_name = "swap_client"];
-  // The contract address for layered tokens such as ERC20
+  // The contract address for layered tokens such as ERC20.
   string token_address = 3 [json_name = "token_address"];
-  // The number of places to the right of the decimal point of the smallest subunit of the currency. For example, BTC, LTC, and others
-  // where the smallest subunits (satoshis) are 0.00000001 full units (bitcoins) have 8 decimal places. ETH has 18. This can be thought
-  // of as the base 10 exponent of the smallest subunit expressed as a positive integer. A default value of 8 is used if unspecified.
+  // The number of places to the right of the decimal point of the smallest subunit of the currency.
+  // For example, BTC, LTC, and others where the smallest subunits (satoshis) are 0.00000001 full
+  // units (bitcoins) have 8 decimal places. ETH has 18. This can be thought of as the base 10
+  // exponent of the smallest subunit expressed as a positive integer. A default value of 8 is
+  // used if unspecified.
   uint32 decimal_places = 4 [json_name = "decimal_places"];
 }
 message AddCurrencyResponse {}
 
 message AddPairRequest {
-  // The base currency that is bought and sold for this trading pair
+  // The base currency that is bought and sold for this trading pair.
   string base_currency = 1 [json_name = "base_currency"];
-  // The currency used to quote a price for the base currency
+  // The currency used to quote a price for the base currency.
   string quote_currency = 2 [json_name = "quote_currency"];
 }
 message AddPairResponse {}
 
 message RemoveOrderRequest {
-  // The local id of the order to remove
+  // The local id of the order to remove.
   string order_id = 1 [json_name = "order_id"];
 }
 message RemoveOrderResponse {}
 
 message ChannelBalance {
-  // Sum of channels balances denominated in satoshis or equivalent
+  // Sum of channels balances denominated in satoshis or equivalent.
   int64 balance = 1 [json_name = "balance"];
-  // Sum of channels pending balances denominated in satoshis or equivalent
+  // Sum of channels pending balances denominated in satoshis or equivalent.
   int64 pending_open_balance = 2 [json_name = "pending_open_balance"];
 }
 
 message ChannelBalanceRequest {
-  // The ticker symbol of the currency to query for, if unspecified then balances for all
-  // supported currencies are queried
+  // The ticker symbol of the currency to query for, if unspecified then balances for all supported
+  // currencies are queried.
   string currency = 1 [json_name = "currency"];
 }
 message ChannelBalanceResponse {
-  // A map between currency ticker symbols and their channel balances
+  // A map between currency ticker symbols and their channel balances.
   map<string, ChannelBalance> balances = 1 [json_name = "orders"];
 }
 
 message ConnectRequest {
+  // The uri of the node to connect to in "[nodePubKey]@[host]:[port]" format.
   string node_uri = 1 [json_name = "node_uri"];
 }
 message ConnectResponse {}
 
 message BanRequest {
+  // The node pub key of the node to ban.
   string node_pub_key = 1 [json_name = "node_pub_key"];
 }
 message BanResponse {}
 
 message GetInfoRequest {}
 message GetInfoResponse {
+  // The version of this instance of xud.
   string version = 1 [json_name = "version"];
+  // The node pub key of this node.
   string node_pub_key = 2 [json_name = "node_pub_key"];
+  // A list of uris that can be used to connect to this node. These are shared with peers.
   repeated string uris = 3 [json_name = "uris"];
+  // The number of currently connected peers.
   int32 num_peers = 4 [json_name = "num_peers"];
+  // The number of supported trading pairs.
   int32 num_pairs = 5 [json_name = "num_pairs"];
+  // The number of active, standing orders in the order book.
   OrdersCount orders = 6 [json_name = "orders"];
   LndInfo lndbtc = 7 [json_name = "lndbtc"];
   LndInfo lndltc = 8 [json_name = "lndltc"];
@@ -272,36 +293,40 @@ message GetInfoResponse {
 }
 
 message GetOrdersRequest {
-  // The trading pair for which to retrieve orders
+  // The trading pair for which to retrieve orders.
   string pair_id = 1 [json_name = "pair_id"];
-  // Whether own orders should be included in result or not
+  // Whether own orders should be included in result or not.
   bool include_own_orders = 2 [json_name = "include_own_orders"];
 }
 message GetOrdersResponse {
-  // A map between pair ids and their buy and sell orders
+  // A map between pair ids and their buy and sell orders.
   map<string, Orders> orders = 1 [json_name = "orders"];
 }
 
 message ListCurrenciesRequest {}
 message ListCurrenciesResponse {
-  // The ticker symbols of supported currencies
+  // A list of ticker symbols of the supported currencies.
   repeated string currencies = 1 [json_name = "currencies"];
 }
 
 message ListPairsRequest {}
 message ListPairsResponse {
-  // The supported trading pair tickers in formats like "LTC/BTC"
+  // The list of supported trading pair tickers in formats like "LTC/BTC".
   repeated string pairs = 1 [json_name = "pairs"];
 }
 
 message ListPeersRequest {}
 message ListPeersResponse {
+  // The list of connected peers.
   repeated Peer peers = 1 [json_name = "peers"];
 }
 
 message LndChannels {
+  // The number of active/online channels for this lnd instance that can be used for swaps.
   int32 active = 1 [json_name = "active"];
+  // The number of inactive/offline channels for this lnd instance.
   int32 inactive = 2 [json_name = "inactive"];
+  // The number of channels that are pending on-chain confirmation before they can be used.
   int32 pending = 3 [json_name = "pending"];
 }
 
@@ -352,33 +377,35 @@ message OrderRemoval {
 }
 
 message Orders {
-  // A list of buy orders sorted by descending price
+  // A list of buy orders sorted by descending price.
   repeated Order buy_orders = 1 [json_name = "buy_orders"];
-  // A list of sell orders sorted by ascending price
+  // A list of sell orders sorted by ascending price.
   repeated Order sell_orders = 2 [json_name = "sell_orders"];
 }
 
 message OrdersCount {
+  // The number of orders belonging to remote xud nodes.
   int32 peer = 1 [json_name = "peer"];
+  // The number of orders belonging to our local xud node.
   int32 own = 2 [json_name = "own"];
 }
 
 message Peer {
-  // The socket address with host and port for this peer
+  // The socket address with host and port for this peer.
   string address = 1 [json_name = "address"];
-  // The node pub key to uniquely identify this peer
+  // The node pub key to uniquely identify this peer.
   string node_pub_key = 2 [json_name = "node_pub_key"];
-  // The lnd BTC pub key associated with this peer
+  // The lnd BTC pub key associated with this peer.
   string lnd_btc_pub_key = 3 [json_name = "lnd_btc_pub_key"];
-  // The lnd LTC pub key associated with this peer
+  // The lnd LTC pub key associated with this peer.
   string lnd_ltc_pub_key = 4 [json_name = "lnd_ltc_pub_key"];
-  // Indicates whether this peer was connected inbound
+  // Indicates whether this peer was connected inbound.
   bool inbound = 5 [json_name = "inbound"];
-  // A list of trading pair tickers supported by this peer
+  // A list of trading pair tickers supported by this peer.
   repeated string pairs = 6 [json_name = "pairs"]; 
-  // The version of xud being used by the peer
+  // The version of xud being used by the peer.
   string xud_version = 7 [json_name = "xud_version"];
-  // The time in seconds that we have been connected to this peer
+  // The time in seconds that we have been connected to this peer.
   int32 seconds_connected = 8 [json_name = "seconds_connected"];
 }
 
@@ -387,29 +414,29 @@ message PlaceOrderRequest {
   double price = 1 [json_name = "price"];
   // The quantity of the order.
   double quantity = 2 [json_name = "quantity"];
-  // The trading pair that the order is for
+  // The trading pair that the order is for.
   string pair_id = 3 [json_name = "pair_id"];
-  // The local id to assign to the order
+  // The local id to assign to the order.
   string order_id = 4 [json_name = "order_id"];
-  // Whether the order is a Buy or Sell
+  // Whether the order is a Buy or Sell.
   OrderSide side = 5 [json_name = "side"];
 }
 message PlaceOrderResponse {
-  // A list of own orders (or portions thereof) that matched the newly placed order
+  // A list of own orders (or portions thereof) that matched the newly placed order.
   repeated Order internal_matches = 1 [json_name = "internal_matches"];
-  // A list of swap results of peer orders that matched the newly placed order
+  // A list of swap results of peer orders that matched the newly placed order.
   repeated SwapResult swap_results = 2 [json_name = "swap_results"];
-  // The remaining portion of the order, after matches, that enters the order book
+  // The remaining portion of the order, after matches, that enters the order book.
   Order remaining_order = 3 [json_name= "remaining_order"];
 }
 
 message PlaceOrderEvent {
   oneof event {
-    // An own orders (or portions thereof) that matched the newly placed order
+    // An own orders (or portions thereof) that matched the newly placed order.
     Order internal_match = 1 [json_name = "internal_match"];
-    // A swap results of peer orders that matched the newly placed order
+    // A swap results of peer orders that matched the newly placed order.
     SwapResult swap_result = 2 [json_name = "swap_result"];
-    // The remaining portion of the order, after matches, that enters the order book
+    // The remaining portion of the order, after matches, that enters the order book.
     Order remaining_order = 3 [json_name= "remaining_order"];
   }
 }
@@ -428,7 +455,7 @@ message RemoveCurrencyRequest {
 message RemoveCurrencyResponse {}
 
 message RemovePairRequest {
-  // The trading pair ticker to remove, such as "LTC/BTC"
+  // The trading pair ticker to remove in a format such as "LTC/BTC".
   string pair_id = 1 [json_name = "pair_id"];
 }
 message RemovePairResponse {}
@@ -463,12 +490,14 @@ message SwapResult {
     TAKER = 0;
     MAKER = 1;
   }
-  // Our role in the swap, either MAKER or TAKER
+  // Our role in the swap, either MAKER or TAKER.
   Role role = 9 [json_name = "role"];
 }
 
 message UnbanRequest {
+  // The node pub key of the peer to unban.
   string node_pub_key = 1 [json_name = "node_pub_key"];
+  // Whether to attempt to connect to the peer after it is unbanned.
   bool reconnect = 2  [json_name = "reconnect"];
 }
 message UnbanResponse {}


### PR DESCRIPTION
This attempts to provide more clarity, consistency, and detail in the proto comments. It is an incremental change and more detail should follow.

I intentionally left the order-related messages and calls alone until after we've finalized no matching mode.