### PR TITLE
chore: skip current node build to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "node"
   - "lts/*"
 
 cache:


### PR DESCRIPTION
A temporary solution until we can figure out why the build is failing with Node 11.