### PR TITLE
refactor(p2p/orderbook): group peer orders by peerPubKey

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -39,7 +39,7 @@ type PoolConfig = {
 interface Pool {
   on(event: 'packet.order', listener: (order: StampedPeerOrder) => void): this;
   on(event: 'packet.getOrders', listener: (peer: Peer, reqId: string, pairIds: string[]) => void): this;
-  on(event: 'packet.orderInvalidation', listener: (orderInvalidation: OrderPortion) => void): this;
+  on(event: 'packet.orderInvalidation', listener: (orderInvalidation: OrderPortion, peer: string) => void): this;
   on(event: 'peer.close', listener: (peer: Peer) => void): this;
   on(event: 'packet.swapRequest', listener: (packet: packets.SwapRequestPacket, peer: Peer) => void): this;
   on(event: 'packet.swapResponse', listener: (packet: packets.SwapResponsePacket, peer: Peer) => void): this;
@@ -47,7 +47,7 @@ interface Pool {
   on(event: 'packet.swapError', listener: (packet: packets.SwapErrorPacket) => void): this;
   emit(event: 'packet.order', order: StampedPeerOrder): boolean;
   emit(event: 'packet.getOrders', peer: Peer, reqId: string, pairIds: string[]): boolean;
-  emit(event: 'packet.orderInvalidation', orderInvalidation: OrderPortion): boolean;
+  emit(event: 'packet.orderInvalidation', orderInvalidation: OrderPortion, peer: string): boolean;
   emit(event: 'peer.close', peer: Peer): boolean;
   emit(event: 'packet.swapRequest', packet: packets.SwapRequestPacket, peer: Peer): boolean;
   emit(event: 'packet.swapResponse', packet: packets.SwapResponsePacket, peer: Peer): boolean;
@@ -463,7 +463,7 @@ class Pool extends EventEmitter {
       case PacketType.OrderInvalidation: {
         const order = (packet as packets.OrderInvalidationPacket).body!;
         this.logger.verbose(`canceled order from ${peer.nodePubKey}: ${JSON.stringify(order)}`);
-        this.emit('packet.orderInvalidation', order);
+        this.emit('packet.orderInvalidation', order, peer.nodePubKey as string);
         break;
       }
       case PacketType.GetOrders: {


### PR DESCRIPTION
This PR is a clone of https://github.com/ExchangeUnion/xud/pull/589 because Travis builds were rejected for the latter.

* rename `this.peerOrders` to `this.peersOrders`.
* change `this.peersOrders` so that instead of having two maps of `orderId` to `StampedPeerOrder` for buys and sells, we now have multiple pairs of buy/sell maps like that nested within a map of `peerPubKeys`.
* remove basic type `orderId: string`
* log generic error message for order invalidation (remove error
handling from `Orderbook.removePeerOrder`