### PR TITLE
fix(p2p): connect to peers with lastAddress only

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -126,10 +126,10 @@ class Pool extends EventEmitter {
     this.handshakeData = handshakeData;
     this.handshakeData.addresses = this.addresses;
 
-    this.logger.info('Connecting to known / previously connected peers');
     this.bindNodeList();
 
     this.nodes.load().then(() => {
+      this.logger.info('Connecting to known / previously connected peers');
       return this.connectNodes(this.nodes, false, true);
     }).then(() => {
       this.logger.info('Completed start-up connections to known peers.');
@@ -232,7 +232,7 @@ class Pool extends EventEmitter {
       const isNotUs = node.nodePubKey !== this.handshakeData.nodePubKey;
 
       // check that it has listening addresses,
-      const hasAddresses = node.addresses.length > 0;
+      const hasAddresses = node.lastAddress || node.addresses.length;
 
       // ignore nodes that we already know if ignoreKnown is true
       const isNotIgnored = this.nodes.has(node.nodePubKey) && !ignoreKnown;


### PR DESCRIPTION
This fixes a bug whereby we would not connect to nodes that did not have listening addresses advertised but *did* have a `lastAddress` that we'd used to connect to them in the past and should use again.

Fixes #606.