### PR TITLE
fix(swaps): correctly set taker & maker amounts

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -77,6 +77,9 @@ class Swaps extends EventEmitter {
   /** A map between r_hash and swap deals. */
   private deals = new Map<string, SwapDeal>();
 
+  /** The number of satoshis in a bitcoin. */
+  private static readonly SATOSHIS_PER_COIN = 100000000;
+
   constructor(private logger: Logger, private pool: Pool, private lndBtcClient: LndClient, private lndLtcClient: LndClient) {
     super();
 
@@ -90,8 +93,8 @@ class Swaps extends EventEmitter {
    */
   private static calculateSwapAmounts = (quantity: number, price: number) => {
     // TODO: use configurable amount of subunits/satoshis per token for each currency
-    const baseCurrencyAmount = Math.round(quantity * 100000000);
-    const quoteCurrencyAmount = Math.round(quantity * price * 100000000);
+    const baseCurrencyAmount = Math.round(quantity * Swaps.SATOSHIS_PER_COIN);
+    const quoteCurrencyAmount = Math.round(quantity * price * Swaps.SATOSHIS_PER_COIN);
 
     return { baseCurrencyAmount, quoteCurrencyAmount };
   }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -90,10 +90,10 @@ class Swaps extends EventEmitter {
    */
   private static calculateSwapAmounts = (quantity: number, price: number) => {
     // TODO: use configurable amount of subunits/satoshis per token for each currency
-    const takerAmount = Math.round(quantity * price * 100000000);
-    const makerAmount = Math.round(quantity * 100000000);
+    const baseCurrencyAmount = Math.round(quantity * 100000000);
+    const quoteCurrencyAmount = Math.round(quantity * price * 100000000);
 
-    return { takerAmount, makerAmount };
+    return { baseCurrencyAmount, quoteCurrencyAmount };
   }
 
   private bind() {
@@ -112,7 +112,7 @@ class Swaps extends EventEmitter {
   }
 
   /**
-   * Sends an error to peer. set reqId if packet is a response to a request.
+   * Sends an error to peer. Sets reqId if packet is a response to a request.
    */
   private sendErrorToPeer = (peer: Peer, r_hash: string, errorMessage: string, reqId?: string) => {
     const errorBody: packets.SwapErrorPacketBody = {
@@ -235,17 +235,24 @@ class Swaps extends EventEmitter {
     const peer = this.pool.getPeer(maker.peerPubKey);
 
     const [baseCurrency, quoteCurrency] = maker.pairId.split('/');
+    const { baseCurrencyAmount, quoteCurrencyAmount } = Swaps.calculateSwapAmounts(taker.quantity, maker.price);
 
     let takerCurrency: string;
     let makerCurrency: string;
+    let takerAmount: number;
+    let makerAmount: number;
     if (taker.isBuy) {
       // we are buying the base currency
       takerCurrency = baseCurrency;
       makerCurrency = quoteCurrency;
+      takerAmount = baseCurrencyAmount;
+      makerAmount = quoteCurrencyAmount;
     } else {
       // we are selling the base currency
       takerCurrency = quoteCurrency;
       makerCurrency = baseCurrency;
+      takerAmount = quoteCurrencyAmount;
+      makerAmount = baseCurrencyAmount;
     }
 
     let takerCltvDelta = 0;
@@ -257,7 +264,6 @@ class Swaps extends EventEmitter {
         takerCltvDelta = this.lndLtcClient.cltvDelta;
         break;
     }
-    const { takerAmount, makerAmount } = Swaps.calculateSwapAmounts(taker.quantity, maker.price);
     const preimage = randomBytes(32);
 
     const swapRequestBody: packets.SwapRequestPacketBody = {
@@ -490,8 +496,8 @@ class Swaps extends EventEmitter {
   }
 
   /**
-   * Verifies that the request from LND is valid. check the received amount vs
-   * the expected amount and the CltvDelta vs the expected on.
+   * Verifies that the request from LND is valid. Checks the received amount vs
+   * the expected amount and the CltvDelta vs the expected one.
    */
   private validateRequest = (deal: SwapDeal, resolveRequest: lndrpc.ResolveRequest)  => {
     const amount = resolveRequest.getAmount();
@@ -522,18 +528,17 @@ class Swaps extends EventEmitter {
     expectedAmount = expectedAmount * 1000;
 
     if (amount < expectedAmount) {
-      this.logger.error('received ' + amount + ' mSat, expected ' + expectedAmount + ' mSat');
+      this.logger.error(`received ${amount} mSat, expected ${expectedAmount} mSat`);
       this.setDealState(deal, SwapState.Error,
-          'Amount sent from ' + source + ' to ' + 'destination' + 'is too small');
+          `Amount sent from ${source} to ${destination} is too small`);
       return false;
     }
 
     if (cltvDelta > resolveRequest.getTimeout() - resolveRequest.getHeightNow()) {
-      this.logger.error('got timeout ' + resolveRequest.getTimeout() + ' at height ' + resolveRequest.getHeightNow());
-      this.logger.error('cltvDelta is ' + (resolveRequest.getTimeout() - resolveRequest.getHeightNow()) +
-          ' expected delta of ' + cltvDelta);
+      this.logger.error(`got timeout ${resolveRequest.getTimeout()} at height ${resolveRequest.getHeightNow()}`);
+      this.logger.error(`cltvDelta is ${resolveRequest.getTimeout() - resolveRequest.getHeightNow()} expected delta of ${cltvDelta}`);
       this.setDealState(deal, SwapState.Error,
-          'cltvDelta sent from ' + source + ' to ' + 'destination' + 'is too small');
+          `cltvDelta sent from ${source} to ${destination} is too small`);
       return false;
     }
     return true;
@@ -664,8 +669,8 @@ class Swaps extends EventEmitter {
         localId: deal.localOrderId,
         pairId: deal.pairId,
         quantity: deal.quantity!,
-        amountReceived: deal.makerAmount,
-        amountSent: deal.takerAmount,
+        amountReceived: deal.role === SwapRole.Maker ? deal.makerAmount : deal.takerAmount,
+        amountSent: deal.role === SwapRole.Maker ? deal.takerAmount : deal.makerAmount,
         r_hash: deal.r_hash,
         peerPubKey: deal.peerPubKey,
         role: deal.role,

--- a/test/unit/Swaps.spec.ts
+++ b/test/unit/Swaps.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import Swaps, { SwapDeal } from '../../lib/swaps/Swaps';
+import Logger, { Level } from '../../lib/Logger';
+import { SwapPhase, SwapState, SwapRole } from '../../lib/types/enums';
+
+const loggers = Logger.createLoggers(Level.Warn);
+
+describe('Swaps', () => {
+  const quantity = 0.01;
+  const price = 0.005;
+
+  /** A swap deal where we are the taker. */
+  const takerDeal: SwapDeal = {
+    quantity,
+    price,
+    role: SwapRole.Taker,
+    phase: SwapPhase.SwapCreated,
+    state: SwapState.Active,
+    peerPubKey: '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8',
+    orderId: 'f8a85c66-7e73-43cd-9ac4-176ff4cc28a8',
+    localOrderId: '1',
+    proposedQuantity: quantity,
+    pairId: 'LTC/BTC',
+    takerCurrency: 'LTC',
+    makerCurrency: 'BTC',
+    takerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity,
+    makerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity * price,
+    takerCltvDelta: 144,
+    r_hash: '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2',
+    createTime: 1540716251106,
+  };
+
+  /** A swap deal where we are the maker, mirrored from the taker deal for convenience. */
+  const makerDeal = {
+    ...takerDeal,
+    role: SwapRole.Maker,
+    takerCurrency: takerDeal.makerCurrency,
+    makerCurrency: takerDeal.takerCurrency,
+    takerAmount: takerDeal.makerAmount,
+    makerAmount: takerDeal.takerAmount,
+  };
+
+  it(`should calculate swap amounts`, () => {
+    expect(takerDeal.role).to.equal(SwapRole.Taker);
+    expect(makerDeal.role).to.equal(SwapRole.Maker);
+
+    const { baseCurrencyAmount, quoteCurrencyAmount } = Swaps['calculateSwapAmounts'](takerDeal.quantity!, takerDeal.price);
+    expect(baseCurrencyAmount).to.equal(takerDeal.takerAmount);
+    expect(quoteCurrencyAmount).to.equal(takerDeal.makerAmount);
+    expect(baseCurrencyAmount).to.equal(makerDeal.makerAmount);
+    expect(quoteCurrencyAmount).to.equal(makerDeal.takerAmount);
+  });
+});


### PR DESCRIPTION
This fixes a bug in the `SwapDeal` and `SwapResult` logic for setting values for `takerAmount`, `makerAmount`, `amountReceived`, and `amountSent`. Previously the values could be mistakenly switched.

Fixes #604.