### PR TITLE
Add Order & Trade Models, restructure & rename order types

### DIFF
--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -12,6 +12,8 @@ type Models = {
   SwapDeal: Sequelize.Model<db.SwapDealInstance, db.SwapDealAttributes>;
   Pair: Sequelize.Model<db.PairInstance, db.PairAttributes>;
   ReputationEvent: Sequelize.Model<db.ReputationEventInstance, db.ReputationEventAttributes>;
+  Order: Sequelize.Model<db.OrderInstance, db.OrderAttributes>;
+  Trade: Sequelize.Model<db.TradeInstance, db.TradeAttributes>;
 };
 
 /** A class representing a connection to a SQL database. */
@@ -45,16 +47,24 @@ class DB {
       this.logger.error('unable to connect to the database', err);
       throw err;
     }
-    const { Node, Currency, Pair, ReputationEvent, SwapDeal } = this.models;
+    const { Node, Currency, Pair, ReputationEvent, SwapDeal, Order, Trade } = this.models;
     // sync schemas with the database in phases, according to FKs dependencies
     await Promise.all([
       Node.sync(),
       Currency.sync(),
-      ReputationEvent.sync(),
-      SwapDeal.sync(),
     ]);
+    // Pair is dependent on Currency, ReputationEvent is dependent on Node
     await Promise.all([
       Pair.sync(),
+      ReputationEvent.sync(),
+    ]);
+    // Order is dependent on Pair
+    await Promise.all([
+      Order.sync(),
+    ]);
+    await Promise.all([
+      Trade.sync(),
+      SwapDeal.sync(),
     ]);
 
     if (newDb && initDb) {

--- a/lib/db/models/Currency.ts
+++ b/lib/db/models/Currency.ts
@@ -16,5 +16,18 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
 
   const Currency = sequelize.define<db.CurrencyInstance, db.CurrencyAttributes>('Currency', attributes, options);
 
+  Currency.associate = (models: Sequelize.Models) => {
+    models.Currency.hasMany(models.Pair, {
+      as: 'quoteCurrencies',
+      foreignKey: 'quoteCurrency',
+      constraints: true,
+    });
+    models.Currency.hasMany(models.Pair, {
+      as: 'baseCurrencies',
+      foreignKey: 'baseCurrency',
+      constraints: true,
+    });
+  };
+
   return Currency;
 };

--- a/lib/db/models/Node.ts
+++ b/lib/db/models/Node.ts
@@ -48,5 +48,12 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
 
   const Node = sequelize.define<db.NodeInstance, db.NodeAttributes>('Node', attributes, options);
 
+  Node.associate = (models: Sequelize.Models) => {
+    models.Node.hasMany(models.ReputationEvent, {
+      foreignKey: 'nodeId',
+      constraints: true,
+    });
+  };
+
   return Node;
 };

--- a/lib/db/models/Order.ts
+++ b/lib/db/models/Order.ts
@@ -1,0 +1,49 @@
+import Sequelize from 'sequelize';
+import { db } from '../../types';
+
+export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) => {
+  const attributes: db.SequelizeAttributes<db.OrderAttributes> = {
+    id: { type: DataTypes.STRING, primaryKey: true, allowNull: false },
+    nodeId: { type: DataTypes.INTEGER, allowNull: true },
+    localId: { type: DataTypes.STRING, allowNull: true },
+    initialQuantity: { type: DataTypes.DECIMAL(8), allowNull: true },
+    pairId: { type: DataTypes.STRING, allowNull: false },
+    price: { type: DataTypes.DECIMAL(8), allowNull: true },
+    isBuy: { type: DataTypes.BOOLEAN, allowNull: false },
+    createdAt: { type: DataTypes.BIGINT, allowNull: false },
+  };
+
+  const options: Sequelize.DefineOptions<db.OrderInstance>  = {
+    tableName: 'orders',
+    timestamps: false,
+  };
+
+  const Order = sequelize.define<db.OrderInstance, db.OrderAttributes>('Order', attributes, options);
+
+  Order.associate = (models: Sequelize.Models) => {
+    models.Order.belongsTo(models.Node, {
+      foreignKey: 'nodeId',
+      constraints: true,
+    });
+    models.Order.belongsTo(models.Pair, {
+      foreignKey: 'pairId',
+      constraints: false,
+    });
+    models.Order.hasMany(models.Trade, {
+      as: 'makerTrades',
+      foreignKey: 'makerOrderId',
+      constraints: true,
+    });
+    models.Order.hasMany(models.Trade, {
+      as: 'takerTrades',
+      foreignKey: 'takerOrderId',
+      constraints: true,
+    });
+    models.Order.hasMany(models.SwapDeal, {
+      foreignKey: 'orderId',
+      constraints: true,
+    });
+  };
+
+  return Order;
+};

--- a/lib/db/models/Pair.ts
+++ b/lib/db/models/Pair.ts
@@ -18,10 +18,14 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
 
   Pair.associate = (models: Sequelize.Models) => {
     models.Pair.belongsTo(models.Currency, {
+      as: 'baseCurrencyInstance',
+      constraints: true,
       foreignKey: 'baseCurrency',
     });
 
     models.Pair.belongsTo(models.Currency, {
+      as: 'takerCurrencyInstance',
+      constraints: true,
       foreignKey: 'quoteCurrency',
     });
 

--- a/lib/db/models/ReputationEvent.ts
+++ b/lib/db/models/ReputationEvent.ts
@@ -19,6 +19,7 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
   ReputationEvent.associate = (models: Sequelize.Models) => {
     models.ReputationEvent.belongsTo(models.Node, {
       foreignKey: 'nodeId',
+      constraints: true,
     });
   };
 

--- a/lib/db/models/SwapDeal.ts
+++ b/lib/db/models/SwapDeal.ts
@@ -3,22 +3,20 @@ import { db } from '../../types';
 
 export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) => {
   const attributes: db.SequelizeAttributes<db.SwapDealAttributes> = {
+    rHash: { type: DataTypes.STRING, primaryKey: true },
     role: { type: DataTypes.TINYINT, allowNull: false },
     state: { type: DataTypes.TINYINT, allowNull: false },
     phase: { type: DataTypes.TINYINT, allowNull: false },
     errorReason: { type: DataTypes.STRING, allowNull: true },
-    rHash: { type: DataTypes.STRING, allowNull: false, unique: true },
     rPreimage: { type: DataTypes.STRING, allowNull: true },
-    peerPubKey: { type: DataTypes.STRING, allowNull: false },
+    nodeId: { type: DataTypes.INTEGER, allowNull: false },
     orderId: { type: DataTypes.STRING, allowNull: false },
     localId: { type: DataTypes.STRING, allowNull: false },
     proposedQuantity: { type: DataTypes.DECIMAL(8), allowNull: false },
     quantity: { type: DataTypes.DECIMAL(8), allowNull: true },
-    pairId: { type: DataTypes.STRING, allowNull: false },
     takerAmount: { type: DataTypes.BIGINT , allowNull: false },
     takerCurrency: { type: DataTypes.STRING , allowNull: false },
     takerPubKey: { type: DataTypes.STRING , allowNull: true },
-    price: { type: DataTypes.DECIMAL(8), allowNull: false },
     takerCltvDelta: { type: DataTypes.SMALLINT, allowNull: false },
     makerCltvDelta: { type: DataTypes.SMALLINT, allowNull: true },
     makerAmount: { type: DataTypes.BIGINT, allowNull: false },
@@ -34,6 +32,17 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
   };
 
   const SwapDeal = sequelize.define<db.SwapDealInstance, db.SwapDealAttributes>('SwapDeal', attributes, options);
+
+  SwapDeal.associate = (models: Sequelize.Models) => {
+    models.SwapDeal.belongsTo(models.Order, {
+      foreignKey: 'orderId',
+      constraints: true,
+    });
+    models.SwapDeal.belongsTo(models.Node, {
+      foreignKey: 'nodeId',
+      constraints: true,
+    });
+  };
 
   return SwapDeal;
 };

--- a/lib/db/models/Trade.ts
+++ b/lib/db/models/Trade.ts
@@ -1,0 +1,33 @@
+import Sequelize from 'sequelize';
+import { db } from '../../types';
+
+export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) => {
+  const attributes: db.SequelizeAttributes<db.TradeAttributes> = {
+    makerOrderId: { type: DataTypes.STRING, primaryKey: true },
+    takerOrderId: { type: DataTypes.STRING, primaryKey: true },
+    quantity: { type: DataTypes.DECIMAL(8), allowNull: false },
+  };
+
+  const options: Sequelize.DefineOptions<db.TradeInstance>  = {
+    tableName: 'trades',
+    timestamps: true,
+    updatedAt: false,
+  };
+
+  const Trade = sequelize.define<db.TradeInstance, db.TradeAttributes>('Trade', attributes, options);
+
+  Trade.associate = (models: Sequelize.Models) => {
+    models.Trade.belongsTo(models.Order, {
+      as: 'makerOrder',
+      foreignKey: 'makerOrderId',
+      constraints: true,
+    });
+    models.Trade.belongsTo(models.Order, {
+      as: 'takerOrder',
+      foreignKey: 'takerOrderId',
+      constraints: true,
+    });
+  };
+
+  return Trade;
+};

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -4,20 +4,19 @@ import Logger from '../Logger';
 import Service from '../service/Service';
 import * as xudrpc from '../proto/xudrpc_pb';
 import { ResolveRequest, ResolveResponse } from '../proto/lndrpc_pb';
-import { StampedOrder, isOwnOrder, OrderPortion } from '../types/orders';
+import { Order, isOwnOrder, OrderPortion } from '../types/orders';
 import { errorCodes as orderErrorCodes } from '../orderbook/errors';
 import { errorCodes as serviceErrorCodes } from '../service/errors';
 import { errorCodes as p2pErrorCodes } from '../p2p/errors';
 import { errorCodes as lndErrorCodes } from '../lndclient/errors';
 import { LndInfo } from '../lndclient/LndClient';
 import { PlaceOrderResult, PlaceOrderEvent, PlaceOrderEventCase } from '../types/orderBook';
-import P2PRepository from '../p2p/P2PRepository';
 import { SwapResult } from 'lib/swaps/types';
 
 /**
  * Creates an xudrpc Order message from a [[StampedOrder]].
  */
-const createOrder = (order: StampedOrder) => {
+const createOrder = (order: Order) => {
   const grpcOrder = new xudrpc.Order();
   grpcOrder.setCreatedAt(order.createdAt);
   grpcOrder.setId(order.id);
@@ -78,13 +77,13 @@ const createPlaceOrderEvent = (e: PlaceOrderEvent) => {
   const response = new xudrpc.PlaceOrderEvent();
   switch (e.case) {
     case PlaceOrderEventCase.InternalMatch:
-      response.setInternalMatch(createOrder(e.payload as StampedOrder));
+      response.setInternalMatch(createOrder(e.payload as Order));
       break;
     case PlaceOrderEventCase.SwapResult:
       response.setSwapResult(createSwapResult(e.payload as SwapResult));
       break;
     case PlaceOrderEventCase.RemainingOrder:
-      response.setRemainingOrder(createOrder(e.payload as StampedOrder));
+      response.setRemainingOrder(createOrder(e.payload as Order));
       break;
   }
   return response;
@@ -338,9 +337,9 @@ class GrpcService {
       const getOrdersResponse = this.service.getOrders(call.request.toObject());
       const response = new xudrpc.GetOrdersResponse();
 
-      const getOrdersList = <T extends StampedOrder>(orders: T[]) => {
+      const getOrdersList = <T extends Order>(orders: T[]) => {
         const ordersList: xudrpc.Order[] = [];
-        orders.forEach(order => ordersList.push(createOrder(<StampedOrder>order)));
+        orders.forEach(order => ordersList.push(createOrder(<Order>order)));
         return ordersList;
       };
 
@@ -501,7 +500,7 @@ class GrpcService {
    * See [[Service.subscribeAddedOrders]]
    */
   public subscribeAddedOrders: grpc.handleServerStreamingCall<xudrpc.SubscribeAddedOrdersRequest, xudrpc.Order> = (call) => {
-    this.service.subscribeAddedOrders((order: StampedOrder) => {
+    this.service.subscribeAddedOrders((order: Order) => {
       call.write(createOrder(order));
     });
   }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -398,7 +398,7 @@ class OrderBook extends EventEmitter {
       return false;
     }
 
-    const stampedOrder: orders.PeerOrder = { ...order, createdAt: ms() };
+    const stampedOrder: orders.PeerOrder = { ...order, createdAt: ms(), initialQuantity: order.quantity };
 
     if (!tp.addPeerOrder(stampedOrder)) {
       this.logger.debug(`incoming peer order is duplicated: ${order.id}`);
@@ -525,7 +525,7 @@ class OrderBook extends EventEmitter {
       throw errors.DUPLICATE_ORDER(order.localId);
     }
 
-    return { ...order, id: uuidv1(), createdAt: ms() };
+    return { ...order, initialQuantity: order.quantity, id: uuidv1(), createdAt: ms() };
   }
 
   private createOutgoingOrder = (order: orders.OwnOrder): orders.OutgoingOrder => {

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -311,6 +311,7 @@ class OrderBook extends EventEmitter {
         }
 
         try {
+          await this.repository.addOrderIfNotExists(maker);
           const swapResult = await this.swaps.executeSwap(maker, taker);
           this.emit('peerOrder.filled', portion);
           result.swapResults.push(swapResult);
@@ -356,6 +357,7 @@ class OrderBook extends EventEmitter {
       hold: 0,
     });
 
+    await this.repository.addOrderIfNotExists(maker);
     try {
       const swapResult = await this.swaps!.executeSwap(maker, taker);
       this.emit('peerOrder.filled', maker);
@@ -589,7 +591,9 @@ class OrderBook extends EventEmitter {
         isBuy: order.isBuy,
       };
       const dealAccepted = await this.swaps!.acceptDeal(orderToAccept, requestPacket, peer);
-      if (!dealAccepted) {
+      if (dealAccepted) {
+        await this.repository.addOrderIfNotExists(order);
+      } else {
         this.removeOrderHold(order.id, pairId, quantity);
       }
     } else {

--- a/lib/orderbook/OrderBookRepository.ts
+++ b/lib/orderbook/OrderBookRepository.ts
@@ -2,6 +2,7 @@ import { db } from '../types';
 import Logger from '../Logger';
 import Bluebird from 'bluebird';
 import { Models } from '../db/DB';
+import { OrderAttributes } from 'lib/types/db';
 
 class OrderbookRepository {
 
@@ -29,6 +30,15 @@ class OrderbookRepository {
 
   public addPairs = (pairs: db.PairFactory[]): Bluebird<db.PairInstance[]> => {
     return this.models.Pair.bulkCreate(<db.PairAttributes[]>pairs);
+  }
+
+  public addOrderIfNotExists = async (order: db.OrderFactory) => {
+    const count = await this.models.Order.count({
+      where: { id: order.id },
+    });
+    if (count === 0) {
+      await this.models.Order.create(order as OrderAttributes);
+    }
   }
 }
 

--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -3,29 +3,29 @@ import FastPriorityQueue from 'fastpriorityqueue';
 import { matchingEngine, orders } from '../types';
 import { OrderingDirection } from '../types/enums';
 import Logger from '../Logger';
-import { isOwnOrder, StampedOrder, StampedOwnOrder, StampedPeerOrder } from '../types/orders';
+import { isOwnOrder, Order, OwnOrder, PeerOrder } from '../types/orders';
 import errors from './errors';
 
 type SplitOrder = {
-  matched: StampedOrder;
-  remaining: StampedOrder;
+  matched: Order;
+  remaining: Order;
 };
 
-type OrderMap<T extends orders.StampedOrder> = Map<string, T>;
+type OrderMap<T extends orders.Order> = Map<string, T>;
 
-type OrderSidesMaps<T extends orders.StampedOrder> = {
+type OrderSidesMaps<T extends orders.Order> = {
   buy: OrderMap<T>,
   sell: OrderMap<T>,
 };
 
-type OrderSidesArrays<T extends orders.StampedOrder> = {
+type OrderSidesArrays<T extends orders.Order> = {
   buy: T[],
   sell: T[],
 };
 
 type OrderSidesQueues = {
-  buy: FastPriorityQueue<StampedOrder>,
-  sell: FastPriorityQueue<StampedOrder>,
+  buy: FastPriorityQueue<Order>,
+  sell: FastPriorityQueue<Order>,
 };
 
 /**
@@ -36,9 +36,9 @@ class TradingPair {
   /** A pair of priority queues for the buy and sell sides of this trading pair */
   public queues?: OrderSidesQueues;
   /** A pair of maps between active own orders ids and orders for the buy and sell sides of this trading pair. */
-  public ownOrders: OrderSidesMaps<orders.StampedOwnOrder>;
+  public ownOrders: OrderSidesMaps<orders.OwnOrder>;
   /** A map between peerPubKey and a pair of maps between active peer orders ids and orders for the buy and sell sides of this trading pair. */
-  public peersOrders: Map<string, OrderSidesMaps<StampedPeerOrder>>;
+  public peersOrders: Map<string, OrderSidesMaps<PeerOrder>>;
 
   constructor(private logger: Logger, public pairId: string, private nomatching = false) {
     if (!nomatching) {
@@ -49,14 +49,14 @@ class TradingPair {
     }
 
     this.ownOrders = {
-      buy: new Map<string, StampedOwnOrder>(),
-      sell: new Map<string, StampedOwnOrder>(),
+      buy: new Map<string, OwnOrder>(),
+      sell: new Map<string, OwnOrder>(),
     };
 
-    this.peersOrders = new Map<string, OrderSidesMaps<StampedPeerOrder>>();
+    this.peersOrders = new Map<string, OrderSidesMaps<PeerOrder>>();
   }
 
-  private static createPriorityQueue = (orderingDirection: OrderingDirection): FastPriorityQueue<StampedOrder> => {
+  private static createPriorityQueue = (orderingDirection: OrderingDirection): FastPriorityQueue<Order> => {
     const comparator = TradingPair.getOrdersPriorityQueueComparator(orderingDirection);
     return new FastPriorityQueue(comparator);
   }
@@ -66,7 +66,7 @@ class TradingPair {
       ? (a: number, b: number) => a < b
       : (a: number, b: number) => a > b;
 
-    return (a: StampedOrder, b: StampedOrder) => {
+    return (a: Order, b: Order) => {
       if (a.price === b.price) {
         return a.createdAt < b.createdAt;
       } else {
@@ -79,7 +79,7 @@ class TradingPair {
    * Get the matching quantity between two orders.
    * @returns the smaller of the quantity between the two orders if their price matches, 0 otherwise
    */
-  public static getMatchingQuantity = (buyOrder: StampedOrder, sellOrder: StampedOrder): number => {
+  public static getMatchingQuantity = (buyOrder: Order, sellOrder: Order): number => {
     if (buyOrder.price >= sellOrder.price) {
       return Math.min(buyOrder.quantity, sellOrder.quantity);
     } else {
@@ -90,7 +90,7 @@ class TradingPair {
   /**
    * Split an order by quantity into a matched portion and a remaining portion.
    */
-  public static splitOrderByQuantity = (order: StampedOrder, matchingQuantity: number): SplitOrder => {
+  public static splitOrderByQuantity = (order: Order, matchingQuantity: number): SplitOrder => {
     const { quantity } = order;
     assert(quantity > matchingQuantity, 'order quantity must be greater than matchingQuantity');
 
@@ -104,12 +104,12 @@ class TradingPair {
    * Add peer order
    * @returns false if it's a duplicated order, otherwise true
    */
-  public addPeerOrder = (order: StampedPeerOrder): boolean => {
+  public addPeerOrder = (order: PeerOrder): boolean => {
     let peerOrdersMaps = this.peersOrders.get(order.peerPubKey);
     if (!peerOrdersMaps) {
       peerOrdersMaps = {
-        buy: new Map<string, StampedPeerOrder>(),
-        sell: new Map<string, StampedPeerOrder>(),
+        buy: new Map<string, PeerOrder>(),
+        sell: new Map<string, PeerOrder>(),
       };
       this.peersOrders.set(order.peerPubKey, peerOrdersMaps);
     }
@@ -117,11 +117,11 @@ class TradingPair {
     return this.addOrder(order, peerOrdersMaps);
   }
 
-  public addOwnOrder = (order: StampedOwnOrder): boolean => {
+  public addOwnOrder = (order: OwnOrder): boolean => {
     return this.addOrder(order, this.ownOrders);
   }
 
-  private addOrder = (order: StampedOrder, maps: OrderSidesMaps<StampedOrder>): boolean => {
+  private addOrder = (order: Order, maps: OrderSidesMaps<Order>): boolean => {
     const map = order.isBuy ? maps.buy : maps.sell;
     if (map.has(order.id)) {
       return false;
@@ -140,7 +140,7 @@ class TradingPair {
   /**
    * Remove all orders given a peer pubKey.
    */
-  public removePeerOrders = (peerPubKey: string): StampedPeerOrder[] => {
+  public removePeerOrders = (peerPubKey: string): PeerOrder[] => {
     // if incoming peerPubKey is undefined or empty, don't even try to find it in order queues
     if (!peerPubKey) return [];
 
@@ -148,7 +148,7 @@ class TradingPair {
     if (!peerOrders) return [];
 
     if (!this.nomatching) {
-      const callback = (order: StampedOrder) => (order as StampedPeerOrder).peerPubKey === peerPubKey;
+      const callback = (order: Order) => (order as PeerOrder).peerPubKey === peerPubKey;
       this.queues!.buy.removeMany(callback);
       this.queues!.sell.removeMany(callback);
     }
@@ -163,7 +163,7 @@ class TradingPair {
    * quantity then the entire order is removed
    * @returns the removed order or order portion, otherwise undefined if the order wasn't found
    */
-  public removePeerOrder = (orderId: string, peerPubKey: string, quantityToRemove?: number): { order: StampedPeerOrder, fullyRemoved: boolean} => {
+  public removePeerOrder = (orderId: string, peerPubKey: string, quantityToRemove?: number): { order: PeerOrder, fullyRemoved: boolean} => {
     const peerOrdersMaps = this.peersOrders.get(peerPubKey);
     if (!peerOrdersMaps) {
       throw errors.ORDER_NOT_FOUND(orderId);
@@ -177,11 +177,11 @@ class TradingPair {
    * quantity then the entire order is removed
    * @returns true if the entire order was removed, or false if only part of the order was removed
    */
-  public removeOwnOrder = (orderId: string, quantityToRemove?: number): { order: StampedOwnOrder, fullyRemoved: boolean} => {
+  public removeOwnOrder = (orderId: string, quantityToRemove?: number): { order: OwnOrder, fullyRemoved: boolean} => {
     return this.removeOrder(orderId, this.ownOrders, quantityToRemove);
   }
 
-  private removeOrder = <T extends StampedOrder>(orderId: string, maps: OrderSidesMaps<StampedOrder>, quantityToRemove?: number):
+  private removeOrder = <T extends Order>(orderId: string, maps: OrderSidesMaps<Order>, quantityToRemove?: number):
     { order: T, fullyRemoved: boolean } => {
     const order = maps.buy.get(orderId) || maps.sell.get(orderId);
     if (!order) {
@@ -208,7 +208,7 @@ class TradingPair {
     }
   }
 
-  private getOrderMap = (order: StampedOrder): OrderMap<StampedOrder> | undefined => {
+  private getOrderMap = (order: Order): OrderMap<Order> | undefined => {
     if (isOwnOrder(order)) {
       return order.isBuy ? this.ownOrders.buy : this.ownOrders.sell;
     } else {
@@ -218,15 +218,15 @@ class TradingPair {
     }
   }
 
-  private getOrders = <T extends orders.StampedOrder>(lists: OrderSidesMaps<T>): OrderSidesArrays<T> => {
+  private getOrders = <T extends orders.Order>(lists: OrderSidesMaps<T>): OrderSidesArrays<T> => {
     return {
       buy: Array.from(lists.buy.values()),
       sell: Array.from(lists.sell.values()),
     };
   }
 
-  public getPeersOrders = (): OrderSidesArrays<StampedPeerOrder> => {
-    const res: OrderSidesArrays<StampedPeerOrder> = { buy: [], sell: [] };
+  public getPeersOrders = (): OrderSidesArrays<PeerOrder> => {
+    const res: OrderSidesArrays<PeerOrder> = { buy: [], sell: [] };
     this.peersOrders.forEach((peerOrders) => {
       const peerOrdersArrs = this.getOrders(peerOrders);
       res.buy = res.buy.concat(peerOrdersArrs.buy);
@@ -236,11 +236,11 @@ class TradingPair {
     return res;
   }
 
-  public getOwnOrders = (): OrderSidesArrays<StampedOwnOrder> => {
+  public getOwnOrders = (): OrderSidesArrays<OwnOrder> => {
     return this.getOrders(this.ownOrders);
   }
 
-  public getOwnOrder = (orderId: string): StampedOwnOrder => {
+  public getOwnOrder = (orderId: string): OwnOrder => {
     const order =  this.getOrder(orderId, this.ownOrders);
     if (!order) {
       throw errors.ORDER_NOT_FOUND(orderId);
@@ -249,7 +249,7 @@ class TradingPair {
     return order;
   }
 
-  public getPeerOrder = (orderId: string, peerPubKey: string): StampedPeerOrder => {
+  public getPeerOrder = (orderId: string, peerPubKey: string): PeerOrder => {
     const peerOrders = this.peersOrders.get(peerPubKey);
     if (!peerOrders) {
       throw errors.ORDER_NOT_FOUND(orderId, peerPubKey);
@@ -263,7 +263,7 @@ class TradingPair {
     return order;
   }
 
-  private getOrder = <T extends StampedOrder>(orderId: string, maps: OrderSidesMaps<T>): T | undefined => {
+  private getOrder = <T extends Order>(orderId: string, maps: OrderSidesMaps<T>): T | undefined => {
     return maps.buy.get(orderId) || maps.sell.get(orderId);
   }
 
@@ -285,15 +285,15 @@ class TradingPair {
    * Match an order against its opposite queue. Matched maker orders will be removed from the repository
    * @returns a [[MatchingResult]] with the matches as well as the remaining, unmatched portion of the order
    */
-  public match = (takerOrder: StampedOwnOrder): matchingEngine.MatchingResult => {
+  public match = (takerOrder: OwnOrder): matchingEngine.MatchingResult => {
     assert(!this.nomatching);
 
     const matches: matchingEngine.OrderMatch[] = [];
     /** The unmatched remaining taker order, if there is still leftover quantity after matching is complete it will enter the queue. */
-    let remainingOrder: StampedOwnOrder | undefined = { ...takerOrder };
+    let remainingOrder: OwnOrder | undefined = { ...takerOrder };
 
     const queue = takerOrder.isBuy ? this.queues!.sell : this.queues!.buy;
-    const getMatchingQuantity = (remainingOrder: StampedOwnOrder, oppositeOrder: StampedOrder) => takerOrder.isBuy
+    const getMatchingQuantity = (remainingOrder: OwnOrder, oppositeOrder: Order) => takerOrder.isBuy
       ? TradingPair.getMatchingQuantity(remainingOrder, oppositeOrder)
       : TradingPair.getMatchingQuantity(oppositeOrder, remainingOrder);
 
@@ -329,8 +329,8 @@ class TradingPair {
           remainingOrder = undefined;
         } else if (makerOrder.quantity === matchingQuantity) { // maker order quantity is not sufficient. taker order will split
           const splitOrder = TradingPair.splitOrderByQuantity(remainingOrder, matchingQuantity);
-          matches.push({ maker: makerOrder, taker: splitOrder.matched as StampedOwnOrder });
-          remainingOrder = splitOrder.remaining as StampedOwnOrder;
+          matches.push({ maker: makerOrder, taker: splitOrder.matched as OwnOrder });
+          remainingOrder = splitOrder.remaining as OwnOrder;
         } else {
           assert(false, 'matchingQuantity should not be lower than both orders quantity values');
         }

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -3,7 +3,7 @@ import Logger from '../Logger';
 import BaseClient, { ClientStatus } from '../BaseClient';
 import errors from './errors';
 import { ms } from '../utils/utils';
-import { StampedOrder } from '../types/orders';
+import { Order } from '../types/orders';
 
 /**
  * A utility function to parse the payload from an http response.
@@ -88,8 +88,8 @@ type ChannelEvent = {
 };
 
 interface RaidenClient {
-  on(event: 'swap', listener: (order: StampedOrder) => void): this;
-  emit(event: 'swap', order: StampedOrder): boolean;
+  on(event: 'swap', listener: (order: Order) => void): this;
+  emit(event: 'swap', order: Order): boolean;
 }
 
 /**
@@ -100,7 +100,7 @@ class RaidenClient extends BaseClient {
   private port: number;
   private host: string;
   /** Map of token swap identifiers to order ids */
-  private swapIdOrderMap = new Map<number, StampedOrder>();
+  private swapIdOrderMap = new Map<number, Order>();
 
   /**
    * Create a raiden client.
@@ -258,7 +258,7 @@ class RaidenClient extends BaseClient {
    * @param target_address the address of the intended swap counterparty
    * @param payload the token swap payload
    */
-  public tokenSwap = async (target_address: string, payload: TokenSwapPayload, order?: StampedOrder): Promise<void> => {
+  public tokenSwap = async (target_address: string, payload: TokenSwapPayload, order?: Order): Promise<void> => {
     const identifier = ms();
     const endpoint = `token_swaps/${target_address}/${identifier}`;
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -8,7 +8,7 @@ import errors from './errors';
 import { SwapClients, OrderSide, SwapRole } from '../types/enums';
 import { parseUri, getUri, UriParts } from '../utils/utils';
 import * as lndrpc from '../proto/lndrpc_pb';
-import { Pair, StampedOrder, OrderPortion, StampedOwnOrder } from '../types/orders';
+import { Pair, Order, OrderPortion } from '../types/orders';
 import { PlaceOrderEvent } from '../types/orderBook';
 import Swaps from '../swaps/Swaps';
 import { OrderSidesArrays } from '../orderbook/TradingPair';
@@ -355,7 +355,7 @@ class Service extends EventEmitter {
   /*
    * Subscribe to orders being added to the order book.
    */
-  public subscribeAddedOrders = (callback: (order: StampedOrder) => void) => {
+  public subscribeAddedOrders = (callback: (order: Order) => void) => {
     this.orderBook.on('peerOrder.incoming', order => callback(order));
     this.orderBook.on('ownOrder.added', order => callback(order));
   }

--- a/lib/swaps/SwapRepository.ts
+++ b/lib/swaps/SwapRepository.ts
@@ -18,8 +18,14 @@ class SwapRepository {
     });
   }
 
-  public addSwapDeal = (swapDeal: db.SwapDealFactory): Bluebird<db.SwapDealInstance> => {
-    return this.models.SwapDeal.create(<db.SwapDealAttributes>swapDeal);
+  public addSwapDeal = async (swapDeal: db.SwapDealFactory): Promise<db.SwapDealInstance> => {
+    const node = await this.models.Node.findOne({
+      where: {
+        nodePubKey: swapDeal.peerPubKey,
+      },
+    });
+    const attributes = { ...swapDeal, nodeId: node!.id } as db.SwapDealAttributes;
+    return this.models.SwapDeal.create(attributes);
   }
 }
 export default SwapRepository;

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -8,7 +8,7 @@ import LndClient from '../lndclient/LndClient';
 import Pool from '../p2p/Pool';
 import { EventEmitter } from 'events';
 import SwapRepository from './SwapRepository';
-import { StampedOwnOrder, StampedPeerOrder } from '../types/orders';
+import { OwnOrder, PeerOrder } from '../types/orders';
 import assert from 'assert';
 import { Models } from '../db/DB';
 import { SwapDealInstance } from 'lib/types/db';
@@ -176,7 +176,7 @@ class Swaps extends EventEmitter {
    * Checks if a swap for two given orders can be executed.
    * @returns `true` if the swap can be executed, `false` otherwise
    */
-  private verifyExecution = (maker: StampedPeerOrder, taker: StampedOwnOrder): boolean => {
+  private verifyExecution = (maker: PeerOrder, taker: OwnOrder): boolean => {
     if (maker.pairId !== taker.pairId || !this.isPairSupported(maker.pairId)) {
       return false;
     }
@@ -192,7 +192,7 @@ class Swaps extends EventEmitter {
    * @param taker our local taker order
    * @returns A promise that is resolved once the swap is completed, or rejects otherwise
    */
-  public executeSwap = (maker: StampedPeerOrder, taker: StampedOwnOrder): Promise<SwapResult> => {
+  public executeSwap = (maker: PeerOrder, taker: OwnOrder): Promise<SwapResult> => {
     return new Promise((resolve, reject) => {
       if (!this.verifyExecution(maker, taker)) {
         reject();
@@ -235,7 +235,7 @@ class Swaps extends EventEmitter {
    * @param taker Our local taker order
    * @returns The rHash for the swap, or `undefined` if the swap could not be initiated
    */
-  private beginSwap = (maker: StampedPeerOrder, taker: StampedOwnOrder) => {
+  private beginSwap = (maker: PeerOrder, taker: OwnOrder) => {
     const peer = this.pool.getPeer(maker.peerPubKey);
 
     const { makerCurrency, takerCurrency } = Swaps.deriveCurrencies(maker.pairId, maker.isBuy);

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -43,8 +43,9 @@ export type SwapDeal = {
   makerCltvDelta?: number;
   /** The price of the order that's being executed. */
   price: number;
-  /** The hash of the preimage. */
+  /** The hex-encoded hash of the preimage. */
   rHash: string;
+  /** The hex-encoded preimage. */
   rPreimage?: string;
   /** The routes the maker should use to send to the taker. */
   makerToTakerRoutes?: Route[];

--- a/lib/types/db.ts
+++ b/lib/types/db.ts
@@ -1,7 +1,7 @@
 import Sequelize, { DataTypeAbstract, DefineAttributeColumnOptions } from 'sequelize';
 import { Address, NodeConnectionInfo } from './p2p';
 import { SwapDeal } from '../swaps/types';
-import { Currency, Pair } from './orders';
+import { Currency, Pair, OwnOrder, Order } from './orders';
 import { ReputationEvent } from './enums';
 
 export type SequelizeAttributes<T extends { [key: string]: any }> = {
@@ -28,9 +28,9 @@ export type CurrencyAttributes = CurrencyFactory & {
 export type CurrencyInstance = CurrencyAttributes & Sequelize.Instance<CurrencyAttributes>;
 
 /* SwapDeal */
-export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes' | 'isBuy'>>;
+export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes' | 'price' | 'pairId' | 'isBuy'>>;
 
-export type SwapDealAttributes = SwapDealFactory & {
+export type SwapDealAttributes = Pick<SwapDealFactory, Exclude<keyof SwapDealFactory, 'peerPubKey'>> & {
   makerCltvDelta: number;
   rPreimage: string;
   errorReason: string;
@@ -38,9 +38,34 @@ export type SwapDealAttributes = SwapDealFactory & {
   takerPubKey: string;
   executeTime: number;
   completeTime: number;
+  /** The internal db node id of the counterparty peer for this swap deal. */
+  nodeId: number;
 };
 
 export type SwapDealInstance = SwapDealAttributes & Sequelize.Instance<SwapDealAttributes>;
+
+export type OrderFactory = Pick<Order, Exclude<keyof Order, 'quantity' | 'hold'>>;
+
+export type OrderAttributes = OrderFactory & {
+  /** The internal db node id of the peer that created this order. */
+  nodeId: number;
+  localId: string;
+};
+
+export type OrderInstance = OrderAttributes & Sequelize.Instance<OrderAttributes>;
+
+export type TradeFactory = {
+  /** The order id of the maker order involved in this trade. */
+  makerOrderId: string,
+  /** The order id of the taker order involved in this trade. */
+  takerOrderId: string,
+  /** The quantity transacted in this trade. */
+  quantity: number,
+};
+
+export type TradeAttributes = TradeFactory;
+
+export type TradeInstance = TradeAttributes & Sequelize.Instance<TradeAttributes>;
 
 /* Node */
 export type NodeFactory = NodeConnectionInfo;

--- a/lib/types/matchingEngine.ts
+++ b/lib/types/matchingEngine.ts
@@ -1,11 +1,11 @@
-import { StampedOrder, StampedOwnOrder } from './orders';
+import { Order, OwnOrder } from './orders';
 
 export type OrderMatch = {
-  maker: StampedOrder;
-  taker: StampedOwnOrder;
+  maker: Order;
+  taker: OwnOrder;
 };
 
 export type MatchingResult = {
   matches: OrderMatch[];
-  remainingOrder?: StampedOwnOrder;
+  remainingOrder?: OwnOrder;
 };

--- a/lib/types/orderBook.ts
+++ b/lib/types/orderBook.ts
@@ -1,15 +1,15 @@
-import { StampedOwnOrder } from './orders';
+import { OwnOrder } from './orders';
 import { SwapResult } from 'lib/swaps/types';
 
 export type PlaceOrderResult = {
-  internalMatches: StampedOwnOrder[];
+  internalMatches: OwnOrder[];
   swapResults: SwapResult[];
-  remainingOrder?: StampedOwnOrder;
+  remainingOrder?: OwnOrder;
 };
 
 export type PlaceOrderEvent = {
   case: PlaceOrderEventCase;
-  payload: StampedOwnOrder | SwapResult;
+  payload: OwnOrder | SwapResult;
 };
 
 export enum PlaceOrderEventCase {

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -41,6 +41,8 @@ type Remote = {
 type Stamp = OrderIdentifier & {
   /** Epoch timestamp when this order was created locally. */
   createdAt: number;
+  /** The number of base currency tokens initially available for the order, before any actions such as trades reduced the available quantity. */
+  initialQuantity: number;
 };
 
 export type OwnMarketOrder = MarketOrder & Local;
@@ -54,7 +56,7 @@ export type PeerOrder = LimitOrder & Stamp & Remote;
 export type Order = OwnOrder | PeerOrder;
 
 /** An outgoing version of a local own order without fields that are not useful for peers. */
-export type OutgoingOrder = Pick<OwnOrder, Exclude<keyof OwnOrder, 'localId' | 'createdAt' | 'hold'>>;
+export type OutgoingOrder = Pick<OwnOrder, Exclude<keyof OwnOrder, 'localId' | 'createdAt' | 'hold' | 'initialQuantity'>>;
 
 /** An outgoing version of a local own order without fields that are not useful for peers. */
 export type IncomingOrder = OutgoingOrder & Remote;

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -3,7 +3,7 @@ import * as lndrpc from '../proto/lndrpc_pb';
 
 /** An order without a price that is intended to match against any available orders on the opposite side of the book for its trading pair. */
 type MarketOrder = {
-  /** The number of base currency tokens for the order. */
+  /** The number of currently available base currency tokens for the order. */
   quantity: number;
   /** A trading pair symbol with the base currency first followed by a '/' separator and the quote currency */
   pairId: string;
@@ -12,9 +12,15 @@ type MarketOrder = {
 };
 
 /** A limit order with a specified price that will enter the order book if it is not immediately matched. */
-type Order = MarketOrder & {
+type LimitOrder = MarketOrder & {
   /** The price for the order expressed in units of the quote currency. */
   price: number;
+};
+
+/** Properties that can be used to uniquely identify and fetch an order within an order book. */
+export type OrderIdentifier = Pick<MarketOrder, 'pairId'> & {
+  /** The global identifier for this order on the XU network. */
+  id: string;
 };
 
 /** Properties that apply only to orders placed by the local xud. */
@@ -31,33 +37,27 @@ type Remote = {
   peerPubKey: string;
 };
 
-/** Properties that uniquely identify an order and make it ready for sending to peers. */
-type Stamp = {
-  /** The global identifier for this order on the XU network. */
-  id: string;
-  /** Epoch timestamp when this order was created. */
+/** Properties that uniquely identify an order and make it ready to enter the order book. */
+type Stamp = OrderIdentifier & {
+  /** Epoch timestamp when this order was created locally. */
   createdAt: number;
 };
 
 export type OwnMarketOrder = MarketOrder & Local;
 
-export type OwnOrder = Order & Local;
+export type OwnLimitOrder = LimitOrder & Local;
 
-export type StampedOwnOrder = OwnOrder & Stamp;
+export type OwnOrder = OwnLimitOrder & Stamp;
 
-export type StampedPeerOrder = Order & Remote & Stamp;
+export type PeerOrder = LimitOrder & Stamp & Remote;
 
-export type StampedOrder = StampedOwnOrder | StampedPeerOrder;
+export type Order = OwnOrder | PeerOrder;
 
-/** An outgoing version of a local own order without the localId and createdAt timestamp */
-export type OutgoingOrder = Pick<StampedOwnOrder, Exclude<keyof StampedOwnOrder, 'localId' | 'createdAt'>>;
+/** An outgoing version of a local own order without fields that are not useful for peers. */
+export type OutgoingOrder = Pick<OwnOrder, Exclude<keyof OwnOrder, 'localId' | 'createdAt' | 'hold'>>;
 
-/** Properties that can be used to uniquely identify and fetch an order within an order book. */
-export type OrderIdentifier = {
-  /** The global identifier for this order on the XU network. */
-  id: string;
-  pairId: string;
-};
+/** An outgoing version of a local own order without fields that are not useful for peers. */
+export type IncomingOrder = OutgoingOrder & Remote;
 
 /** A reference to a portion of an existing order. */
 export type OrderPortion = OrderIdentifier & {
@@ -87,14 +87,10 @@ export type Pair = {
   quoteCurrency: string;
 };
 
-export function isOwnOrder(order: StampedOrder): order is StampedOwnOrder {
-  return (order as StampedPeerOrder).peerPubKey === undefined && typeof (order as StampedOwnOrder).localId === 'string';
+export function isOwnOrder(order: Order): order is OwnOrder {
+  return (order as PeerOrder).peerPubKey === undefined && typeof (order as OwnOrder).localId === 'string';
 }
 
-export function isStampedOwnOrder(order: OwnOrder): order is StampedOwnOrder {
-  return typeof (order as StampedOwnOrder).id === 'string' && typeof (order as StampedOwnOrder).createdAt === 'number';
-}
-
-export function isPeerOrder(order: StampedOrder): order is StampedPeerOrder {
-  return (order as StampedOwnOrder).localId === undefined && typeof (order as StampedPeerOrder).peerPubKey === 'string';
+export function isPeerOrder(order: Order): order is PeerOrder {
+  return (order as OwnOrder).localId === undefined && typeof (order as PeerOrder).peerPubKey === 'string';
 }

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -12,7 +12,7 @@ const PAIR_ID = 'LTC/BTC';
 const currencies = PAIR_ID.split('/');
 const loggers = Logger.createLoggers(Level.Warn);
 
-const createOwnOrder = (price: number, quantity: number, isBuy: boolean, createdAt = ms()): orders.StampedOwnOrder => ({
+const createOwnOrder = (price: number, quantity: number, isBuy: boolean, createdAt = ms()): orders.OwnOrder => ({
   price,
   quantity,
   isBuy,
@@ -29,7 +29,7 @@ const createPeerOrder = (
   isBuy: boolean,
   createdAt = ms(),
   peerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345',
-): orders.StampedPeerOrder => ({
+): orders.PeerOrder => ({
   quantity,
   price,
   isBuy,
@@ -64,7 +64,7 @@ describe('OrderBook', () => {
     await orderBook.init();
   });
 
-  const getOwnOrder = (order: orders.StampedOwnOrder): orders.StampedOwnOrder | undefined => {
+  const getOwnOrder = (order: orders.OwnOrder): orders.OwnOrder | undefined => {
     const ownOrders = orderBook.getOwnOrders(order.pairId);
     const arr = order.isBuy ? ownOrders.buy : ownOrders.sell;
 
@@ -99,8 +99,8 @@ describe('OrderBook', () => {
     expect(firstMatch).to.not.be.undefined;
     expect(secondMatch).to.not.be.undefined;
 
-    const firstMakerOrder = getOwnOrder(<orders.StampedOwnOrder>firstMatch);
-    const secondMakerOrder = getOwnOrder(<orders.StampedOwnOrder>secondMatch);
+    const firstMakerOrder = getOwnOrder(<orders.OwnOrder>firstMatch);
+    const secondMakerOrder = getOwnOrder(<orders.OwnOrder>secondMatch);
     expect(firstMakerOrder).to.be.undefined;
     expect(secondMakerOrder).to.not.be.undefined;
     expect(secondMakerOrder!.quantity).to.equal(4);
@@ -111,11 +111,11 @@ describe('OrderBook', () => {
     const result = await orderBook.placeMarketOrder(order);
     const match = result.internalMatches[0];
     expect(result.remainingOrder).to.be.undefined;
-    expect(getOwnOrder(<orders.StampedOwnOrder>match)).to.be.undefined;
+    expect(getOwnOrder(<orders.OwnOrder>match)).to.be.undefined;
   });
 
   it('should create, partially match, and remove an order', async () => {
-    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 10, isBuy: true, hold: 0 };
+    const order: orders.OwnLimitOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 10, isBuy: true, hold: 0 };
     await orderBook.placeLimitOrder(order);
     const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 5, isBuy: false, hold: 0 };
     await orderBook.placeMarketOrder(takerOrder);
@@ -123,7 +123,7 @@ describe('OrderBook', () => {
   });
 
   it('should not add a new own order with a duplicated localId', async () => {
-    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 100, isBuy: false, hold: 0 };
+    const order: orders.OwnLimitOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 100, isBuy: false, hold: 0 };
 
     expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -17,6 +17,7 @@ const createOwnOrder = (price: number, quantity: number, isBuy: boolean, created
   quantity,
   isBuy,
   createdAt,
+  initialQuantity: quantity,
   id: uuidv1(),
   localId: uuidv1(),
   pairId: PAIR_ID,
@@ -35,6 +36,7 @@ const createPeerOrder = (
   isBuy,
   createdAt,
   peerPubKey,
+  initialQuantity: quantity,
   id: uuidv1(),
   pairId: PAIR_ID,
 });
@@ -115,7 +117,7 @@ describe('OrderBook', () => {
   });
 
   it('should create, partially match, and remove an order', async () => {
-    const order: orders.OwnLimitOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 10, isBuy: true, hold: 0 };
+    const order: orders.OwnOrder = createOwnOrder(10, 10, true);
     await orderBook.placeLimitOrder(order);
     const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 5, isBuy: false, hold: 0 };
     await orderBook.placeMarketOrder(takerOrder);
@@ -123,7 +125,7 @@ describe('OrderBook', () => {
   });
 
   it('should not add a new own order with a duplicated localId', async () => {
-    const order: orders.OwnLimitOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 100, isBuy: false, hold: 0 };
+    const order: orders.OwnOrder = createOwnOrder(100, 10, false);
 
     expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -1,0 +1,122 @@
+import chai, { expect } from 'chai';
+import uuidv1 from 'uuid/v1';
+import DB from '../../lib/db/DB';
+import OrderBookRepository from '../../lib/orderbook/OrderBookRepository';
+import Logger, { Level } from '../../lib/Logger';
+import { SwapClients, SwapRole, SwapState, SwapPhase } from '../../lib/types/enums';
+import { ms } from '../../lib/utils/utils';
+import SwapRepository from '../../lib/swaps/SwapRepository';
+import chaiAsPromised = require('chai-as-promised');
+import { OwnOrder } from '../../lib/types/orders';
+import { SwapDeal } from '../../lib/swaps/types';
+import P2PRepository from '../../lib/p2p/P2PRepository';
+import { p2p } from '../../lib/types';
+
+chai.use(chaiAsPromised);
+
+const PAIR_ID = 'LTC/BTC';
+const loggers = Logger.createLoggers(Level.Warn);
+
+const price = 0.005;
+const quantity = 0.1;
+const peerPubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+
+const order: OwnOrder = {
+  price,
+  quantity,
+  isBuy: true,
+  createdAt: ms(),
+  initialQuantity: quantity,
+  id: uuidv1(),
+  localId: uuidv1(),
+  pairId: PAIR_ID,
+  hold: 0,
+};
+
+const deal: SwapDeal = {
+  quantity,
+  price,
+  peerPubKey,
+  role: SwapRole.Maker,
+  phase: SwapPhase.SwapCompleted,
+  state: SwapState.Completed,
+  orderId: order.id,
+  localId: order.localId,
+  isBuy: order.isBuy,
+  proposedQuantity: quantity,
+  pairId: PAIR_ID,
+  takerCurrency: 'BTC',
+  makerCurrency: 'LTC',
+  takerAmount: 5000,
+  makerAmount: 1000000,
+  takerCltvDelta: 144,
+  makerCltvDelta: 144,
+  rHash: '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2',
+  rPreimage: '60743C0B6BFA885E30F101705764F43F8EF7E613DD0F07AD5178C7D9B1682B9E',
+  createTime: 1540716251106,
+  executeTime: 1540717251106,
+  completeTime: 1540718251106,
+};
+
+describe('Database', () => {
+  const db = new DB(loggers.db);
+  let orderBookRepo: OrderBookRepository;
+  let p2pRepo: P2PRepository;
+  let swapRepo: SwapRepository;
+
+  before(async () => {
+    await db.init();
+    orderBookRepo = new OrderBookRepository(loggers.db, db.models);
+    p2pRepo = new P2PRepository(db.models);
+    swapRepo = new SwapRepository(db.models);
+  });
+
+  it('should add two currencies', async () => {
+    const btcPromise = orderBookRepo.addCurrency({
+      id: 'BTC',
+      swapClient: SwapClients.Lnd,
+      decimalPlaces: 8,
+    });
+    const ltcPromise = orderBookRepo.addCurrency({
+      id: 'LTC',
+      swapClient: SwapClients.Lnd,
+      decimalPlaces: 8,
+    });
+    await Promise.all([btcPromise, ltcPromise]);
+    await expect(orderBookRepo.getCurrencies()).to.eventually.have.lengthOf(2);
+  });
+
+  it('should add a trading pair', async () => {
+    await orderBookRepo.addPair({
+      baseCurrency: 'LTC',
+      quoteCurrency: 'BTC',
+    });
+    await expect(orderBookRepo.getPairs()).to.eventually.have.lengthOf(1);
+  });
+
+  it('should add a node', async () => {
+    await p2pRepo.addNode({
+      nodePubKey: peerPubKey,
+      addresses: [],
+    });
+  });
+
+  it('should add an order', async () => {
+    await orderBookRepo.addOrderIfNotExists(order);
+    await expect(db.models.Order.count()).to.eventually.equal(1);
+  });
+
+  it('should not add the same order twice', async () => {
+    await orderBookRepo.addOrderIfNotExists(order);
+    await expect(db.models.Order.count()).to.eventually.equal(1);
+  });
+
+  it('should add a swap for the order', async () => {
+    await swapRepo.addSwapDeal(deal);
+    await expect(db.models.SwapDeal.count()).to.eventually.equal(1);
+  });
+
+  after(async () => {
+    await db.close();
+  });
+});

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -14,6 +14,7 @@ const createOwnOrder = (price: number, quantity: number, isBuy: boolean, created
   quantity,
   isBuy,
   createdAt,
+  initialQuantity: quantity,
   id: uuidv1(),
   localId: uuidv1(),
   pairId: PAIR_ID,
@@ -32,6 +33,7 @@ const createPeerOrder = (
   isBuy,
   createdAt,
   peerPubKey,
+  initialQuantity: quantity,
   id: uuidv1(),
   pairId: PAIR_ID,
 });

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -9,7 +9,7 @@ import { ms } from '../../lib/utils/utils';
 const PAIR_ID = 'LTC/BTC';
 const loggers = Logger.createLoggers(Level.Warn);
 
-const createOwnOrder = (price: number, quantity: number, isBuy: boolean, createdAt = ms()): orders.StampedOwnOrder => ({
+const createOwnOrder = (price: number, quantity: number, isBuy: boolean, createdAt = ms()): orders.OwnOrder => ({
   price,
   quantity,
   isBuy,
@@ -26,7 +26,7 @@ const createPeerOrder = (
   isBuy: boolean,
   createdAt = ms(),
   peerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345',
-): orders.StampedPeerOrder => ({
+): orders.PeerOrder => ({
   quantity,
   price,
   isBuy,


### PR DESCRIPTION
This PR closes #621 and resolves the first part of #437.

I set out to restructure the database models ahead of persisting trades to the database as we'd discussed, it wound up being a bit more complicated than anticipated (and this PR bigger than expected) but I tried to separate every conceptually distinct change into its own commit. Details are in the body of each commit message but I'll go over the important parts here:

- `initialQuantity` on stamped orders: Currently all `quantity` usage in `xud` refers only to the currently available quantity for an order, but we had nothing to track the initial quantity of an order before being matched, canceled, etc... I added this new property to stamped orders because I expect that it will be useful info when saving orders to the database. `initialQuantity` is set when we stamp an own order or when we receive a peer order.

- Renaming order types: Previously we'd discussed renaming the order types since the `StampedOrder`/`StampedOwnOrder`/`StampedPeerOrder` tyeps are ubiquitous whereas the plain `Order` type was unused. I renamed the three above to simply `Order`/`OwnOrder`/`PeerOrder` and renamed the previous `Order` type to `LimitOrder` which is just the existing `MarketOrder` type . The `LimitOrder` and `MarketOrder` types are just base types that aren't in use aside from inheritance. I also tried to use the `Pick` operator wherever possible so that types properly inherit properties (along with the comments) from base types. Functionally this doesn't change anything for now, but I did remove the `hold` property from the `OrderPacketBody` (since this is strictly local data that is not relevant to peers, in addition to being privileged info) which will make a difference when we start checking that packet bodies adhere to the defined structure.

- `Order` and `Trade` models. The `Order` model essentially mimics the info we have for `Order` in our proto definition - it has all the properties of the `Order` type (previously `StampedOrder`) minus `quantity` and `hold` since these are mutable properties that can be changed. The `Trade` model refers to a maker order, a taker order, and a quantity. Let me know if you think I've missed any properties, although we can always add them later if necessary.

- Since the `SwapDeal` model no longer has order-specific information, I added logic to check if a swapped order exists in the database and create it if it does not.

- Finally I figured some tests of the database models were in order. I only had time to go through basic "happy path" cases but I figure this would be a good suite of tests to expand in the future.