### PR TITLE
refactor(orderbook): change ORDER_NOT_FOUND msg

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -252,12 +252,12 @@ class TradingPair {
   public getPeerOrder = (orderId: string, peerPubKey: string): StampedPeerOrder => {
     const peerOrders = this.peersOrders.get(peerPubKey);
     if (!peerOrders) {
-      throw errors.ORDER_NOT_FOUND(`${peerPubKey}/${orderId}`);
+      throw errors.ORDER_NOT_FOUND(orderId, peerPubKey);
     }
 
     const order = this.getOrder(orderId, peerOrders);
     if (!order) {
-      throw errors.ORDER_NOT_FOUND(`${peerPubKey}/${orderId}`);
+      throw errors.ORDER_NOT_FOUND(orderId, peerPubKey);
     }
 
     return order;

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -21,8 +21,8 @@ const errors = {
     message: `order with local id ${localId} already exists`,
     code: errorCodes.DUPLICATE_ORDER,
   }),
-  ORDER_NOT_FOUND: (orderId: string) => ({
-    message: `order with id ${orderId} could not be found`,
+  ORDER_NOT_FOUND: (orderId: string, peerPubKey?: string) => ({
+    message: `order with id ${orderId}${peerPubKey ? ' for peer ' + peerPubKey : ''} could not be found`,
     code: errorCodes.ORDER_NOT_FOUND,
   }),
   CURRENCY_DOES_NOT_EXIST: (currency: string) => ({

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -334,7 +334,7 @@ describe('MatchingEngine queues and maps integrity', () => {
     expect(() => tp.getPeerOrder(
       peerOrder.id,
       peerOrder.peerPubKey,
-    )).to.throw(`order with id ${peerOrder.peerPubKey}/${peerOrder.id} could not be found`);
+    )).to.throw(`order with id ${peerOrder.id} for peer ${peerOrder.peerPubKey} could not be found`);
     const queueRemainingOrder = tp.queues!.sell.peek();
     expect(queueRemainingOrder).to.be.undefined;
   });


### PR DESCRIPTION
This is a minor change to the `ORDER_NOT_FOUND` error message to make it more readable. Instead of `peerPubKey` and `orderId` being separated by only a `/` for peer orders, they are clearly differentiated.

I'd found myself confused when reading the old error message, thinking that it was using `peerPubKey` in place of `orderId`.