### PR TITLE
feat(orderbook/swaps): release order hold

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -267,6 +267,20 @@ class TradingPair {
     return maps.buy.get(orderId) || maps.sell.get(orderId);
   }
 
+  public addOrderHold = (orderId: string, holdAmount: number) => {
+    const order = this.getOwnOrder(orderId);
+    assert(holdAmount > 0);
+    assert(order.hold + holdAmount <= order.quantity, 'the amount of an order on hold cannot exceed the available quantity');
+    order.hold += holdAmount;
+  }
+
+  public removeOrderHold = (orderId: string, holdAmount: number) => {
+    const order = this.getOwnOrder(orderId);
+    assert(holdAmount > 0);
+    assert(order.hold >= holdAmount, 'cannot remove more than is currently on hold for an order');
+    order.hold -= holdAmount;
+  }
+
   /**
    * Match an order against its opposite queue. Matched maker orders will be removed from the repository
    * @returns a [[MatchingResult]] with the matches as well as the remaining, unmatched portion of the order

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -12,7 +12,7 @@ import { Models } from '../db/DB';
 import Logger from '../Logger';
 import { HandshakeState, Address, NodeConnectionInfo, HandshakeStateUpdate } from '../types/p2p';
 import addressUtils from '../utils/addressUtils';
-import { getExternalIp } from '../utils/utils';
+import { getExternalIp, ms } from '../utils/utils';
 import assert from 'assert';
 import { ReputationEvent } from '../types/enums';
 import { ReputationEventInstance } from '../types/db';
@@ -482,7 +482,7 @@ class Pool extends EventEmitter {
       case PacketType.Order: {
         const order = (packet as packets.OrderPacket).body!;
         this.logger.verbose(`received order from ${peer.nodePubKey}: ${JSON.stringify(order)}`);
-        this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey } as StampedPeerOrder);
+        this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey, createdAt: ms() } as StampedPeerOrder);
         break;
       }
       case PacketType.OrderInvalidation: {
@@ -501,7 +501,7 @@ class Pool extends EventEmitter {
         const orders = (packet as packets.OrdersPacket).body!;
         this.logger.verbose(`received ${orders.length} orders from ${peer.nodePubKey}`);
         orders.forEach((order) => {
-          this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey } as StampedPeerOrder);
+          this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey, createdAt: ms() } as StampedPeerOrder);
         });
         break;
       }

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -329,6 +329,7 @@ class Service extends EventEmitter {
       quantity,
       isBuy: side === OrderSide.Buy,
       localId: orderId,
+      hold: 0,
     };
 
     return price > 0 ? await this.orderBook.placeLimitOrder(order, callback) : await this.orderBook.placeMarketOrder(order, callback);

--- a/lib/types/orders.ts
+++ b/lib/types/orders.ts
@@ -22,7 +22,7 @@ type Local = {
   /** A local identifier for the order. */
   localId: string;
   /** The amount of an order that is on hold pending swap exectuion. */
-  hold?: number;
+  hold: number;
 };
 
 /** Properties that apply only to orders placed by remote peers. */

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -20,6 +20,7 @@ const createOwnOrder = (price: number, quantity: number, isBuy: boolean, created
   id: uuidv1(),
   localId: uuidv1(),
   pairId: PAIR_ID,
+  hold: 0,
 });
 
 const createPeerOrder = (
@@ -83,13 +84,13 @@ describe('OrderBook', () => {
   });
 
   it('should append two new ownOrder', async () => {
-    const order = { pairId: 'LTC/BTC', quantity: 5, price: 55, isBuy: true };
+    const order = { pairId: 'LTC/BTC', quantity: 5, price: 55, isBuy: true, hold: 0 };
     await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
     await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
   });
 
   it('should fully match new ownOrder and remove matches', async () => {
-    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 6, price: 55, isBuy: false };
+    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 6, price: 55, isBuy: false, hold: 0 };
     const matches = await orderBook.placeLimitOrder(order);
     expect(matches.remainingOrder).to.be.undefined;
 
@@ -106,7 +107,7 @@ describe('OrderBook', () => {
   });
 
   it('should partially match new market order and discard remaining order', async () => {
-    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, isBuy: false };
+    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, isBuy: false, hold: 0 };
     const result = await orderBook.placeMarketOrder(order);
     const match = result.internalMatches[0];
     expect(result.remainingOrder).to.be.undefined;
@@ -114,15 +115,15 @@ describe('OrderBook', () => {
   });
 
   it('should create, partially match, and remove an order', async () => {
-    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 10, isBuy: true };
+    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 10, isBuy: true, hold: 0 };
     await orderBook.placeLimitOrder(order);
-    const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 5, isBuy: false };
+    const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 5, isBuy: false, hold: 0 };
     await orderBook.placeMarketOrder(takerOrder);
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
   });
 
   it('should not add a new own order with a duplicated localId', async () => {
-    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 100, isBuy: false };
+    const order: orders.OwnOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, price: 100, isBuy: false, hold: 0 };
 
     expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 


### PR DESCRIPTION
This releases the hold placed on an order when we accept a swap once the swap either completes or fails. Previously, holds would remain on orders post-swap which would make part or all of the order unavailable for future swaps.

Closes #549.