### PR TITLE
feat(swaps): calculate swap amounts locally

### DIFF
--- a/lib/p2p/packets/types/SwapRequestPacket.ts
+++ b/lib/p2p/packets/types/SwapRequestPacket.ts
@@ -4,10 +4,6 @@ import PacketType from '../PacketType';
 export type SwapRequestPacketBody = {
   proposedQuantity: number;
   pairId: string;
-  takerAmount: number;
-  takerCurrency: string;
-  makerAmount: number;
-  makerCurrency: string;
   orderId: string;
   r_hash: string;
   takerCltvDelta: number;

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -17,13 +17,15 @@ export type SwapDeal = {
   peerPubKey: string;
   /** The global order id in the XU network for the maker order being executed. */
   orderId: string;
+  /** Whether the maker order is a buy order. */
+  isBuy: boolean;
   /** The local id of the own order involved in the swap. */
   localId: string;
   /** The quantity of the order to execute as proposed by the taker. */
   proposedQuantity: number;
-  /** The accepted quantity of the order to execute as accepted by the maker. */
+  /** The quantity of the order to execute as accepted by the maker. */
   quantity?: number;
-  /** The trading pair of the order. The pairId together with the orderId are needed to find the deal in orderBook. */
+  /** The trading pair for the swap. The pairId together with the orderId are needed to find the maker order in the order book. */
   pairId: string;
   /** The number of satoshis (or equivalent) the taker is expecting to receive. */
   takerAmount: number;
@@ -52,10 +54,11 @@ export type SwapDeal = {
 };
 
 /** The result of a successful swap. */
-export type SwapResult = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'quantity' | 'r_hash' | 'peerPubKey' | 'role'> & {
+export type SwapResult = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'r_hash' | 'peerPubKey' | 'role'> & {
   /** The amount of satoshis (or equivalent) received. */
   amountReceived: number;
   /** The amount of satoshis (or equivalent) sent. */
   amountSent: number;
+  /** The quantity that was swapped. */
   quantity: number;
 };

--- a/lib/types/db.ts
+++ b/lib/types/db.ts
@@ -28,7 +28,7 @@ export type CurrencyAttributes = CurrencyFactory & {
 export type CurrencyInstance = CurrencyAttributes & Sequelize.Instance<CurrencyAttributes>;
 
 /* SwapDeal */
-export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes'>>;
+export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes' | 'isBuy'>>;
 
 export type SwapDealAttributes = SwapDealFactory & {
   makerCltvDelta: number;

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -53,5 +53,5 @@ export enum SwapFailureReason {
   /** Could not find the order specified by a swap request. */
   OrderNotFound,
   /** The order specified by a swap request is on hold for a different ongoing swap. */
-  OrderUnavailable,
+  OrderOnHold,
 }

--- a/test/unit/Swaps.spec.ts
+++ b/test/unit/Swaps.spec.ts
@@ -10,45 +10,60 @@ describe('Swaps', () => {
   const quantity = 0.01;
   const price = 0.005;
 
-  /** A swap deal where we are the taker. */
-  const takerDeal: SwapDeal = {
+  /** A swap deal for a buy order. */
+  const buyDeal: SwapDeal = {
     quantity,
     price,
-    role: SwapRole.Taker,
+    role: SwapRole.Maker,
     phase: SwapPhase.SwapCreated,
     state: SwapState.Active,
     peerPubKey: '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8',
     orderId: 'f8a85c66-7e73-43cd-9ac4-176ff4cc28a8',
     localId: '1',
     proposedQuantity: quantity,
+    isBuy: true,
     pairId: 'LTC/BTC',
-    takerCurrency: 'LTC',
-    makerCurrency: 'BTC',
-    takerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity,
-    makerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity * price,
+    makerCurrency: 'LTC',
+    takerCurrency: 'BTC',
+    makerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity,
+    takerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity * price,
+    makerCltvDelta: 144,
     takerCltvDelta: 144,
     r_hash: '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2',
     createTime: 1540716251106,
   };
 
-  /** A swap deal where we are the maker, mirrored from the taker deal for convenience. */
-  const makerDeal = {
-    ...takerDeal,
-    role: SwapRole.Maker,
-    takerCurrency: takerDeal.makerCurrency,
-    makerCurrency: takerDeal.takerCurrency,
-    takerAmount: takerDeal.makerAmount,
-    makerAmount: takerDeal.takerAmount,
+  /** A swap deal for a sell order, mirrored from the buy deal for convenience. */
+  const sellDeal = {
+    ...buyDeal,
+    isBuy: false,
+    takerCurrency: buyDeal.makerCurrency,
+    makerCurrency: buyDeal.takerCurrency,
+    takerAmount: buyDeal.makerAmount,
+    makerAmount: buyDeal.takerAmount,
   };
 
-  it(`should calculate swap amounts`, () => {
-    expect(takerDeal.role).to.equal(SwapRole.Taker);
-    expect(makerDeal.role).to.equal(SwapRole.Maker);
+  it('should derive currencies for a buy order', () => {
+    const { makerCurrency, takerCurrency } = Swaps['deriveCurrencies'](buyDeal.pairId, buyDeal.isBuy);
+    expect(makerCurrency).to.equal(buyDeal.makerCurrency);
+    expect(takerCurrency).to.equal(buyDeal.takerCurrency);
+  });
 
-    const { baseCurrencyAmount, quoteCurrencyAmount } = Swaps['calculateSwapAmounts'](takerDeal.quantity!, takerDeal.price);
-    expect(baseCurrencyAmount).to.equal(takerDeal.takerAmount);
-    expect(quoteCurrencyAmount).to.equal(takerDeal.makerAmount);
-    expect(baseCurrencyAmount).to.equal(makerDeal.makerAmount);
-    expect(quoteCurrencyAmount).to.equal(makerDeal.takerAmount);
+  it('should calculate swap amounts for a sell order', () => {
+    const { makerCurrency, takerCurrency } = Swaps['deriveCurrencies'](sellDeal.pairId, sellDeal.isBuy);
+    expect(makerCurrency).to.equal(sellDeal.makerCurrency);
+    expect(takerCurrency).to.equal(sellDeal.takerCurrency);
+  });
+
+  it('should calculate swap amounts for a buy order', () => {
+    const { makerAmount, takerAmount } = Swaps['calculateSwapAmounts'](buyDeal.quantity!, buyDeal.price, buyDeal.isBuy);
+    expect(makerAmount).to.equal(buyDeal.makerAmount);
+    expect(takerAmount).to.equal(buyDeal.takerAmount);
+  });
+
+  it('should calculate swap amounts for a sell order', () => {
+    const { makerAmount, takerAmount } = Swaps['calculateSwapAmounts'](sellDeal.quantity!, sellDeal.price, sellDeal.isBuy);
+    expect(makerAmount).to.equal(sellDeal.makerAmount);
+    expect(takerAmount).to.equal(sellDeal.takerAmount);
   });
 });


### PR DESCRIPTION
This makes each node involved in a swap determine the swap amounts and currencies (`makerCurrency`, `takerCurrency`, `makerAmount`, and `takerAmount`) independently. If there is any discrepancy in these
values, the swap will fail. These values are no longer sent as part of the `SwapRequestPacket`. Previously, only the taker (who initiates the swap) would determine these values and the maker would blindly accept them.

It also updates the Swap unit tests to align with the new methods and logic used in the `beginSwap` and `acceptDeal` routines.

Closes #615.