### PR TITLE
feat(swaps): check that swap request is valid

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -554,6 +554,15 @@ class OrderBook extends EventEmitter {
     assert(this.swaps, 'swaps module is disabled');
     const { r_hash, proposedQuantity, orderId, pairId } = requestPacket.body!;
 
+    if (!Swaps.validateSwapRequest(requestPacket.body!)) {
+      // TODO: penalize peer for invalid swap request
+      peer.sendPacket(new SwapErrorPacket({
+        r_hash,
+        errorMessage: SwapFailureReason[SwapFailureReason.InvalidSwapRequest],
+      }, requestPacket.header.id));
+      return;
+    }
+
     const order = this.tryGetOwnOrder(orderId, pairId);
     if (!order) {
       peer.sendPacket(new SwapErrorPacket({

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -55,6 +55,17 @@ class Swaps extends EventEmitter {
   }
 
   /**
+   * Checks if a swap request is valid. This is a shallow check that only detects critical
+   * inconsistencies and verifies only whether the request can possibly lead to a successful swap.
+   * @returns `true` if the request is valid, otherwise `false`
+   */
+  public static validateSwapRequest = ({ proposedQuantity, r_hash }: packets.SwapRequestPacketBody) => {
+    // proposed quantity must be a positive number
+    // r_hash must be exactly 64 characters
+    return proposedQuantity > 0 && r_hash.length === 64;
+  }
+
+  /**
    * Calculates the amount of subunits/satoshis each side of a swap should receive.
    * @param quantity The quantity being swapped
    * @param price The price for the swap
@@ -486,8 +497,9 @@ class Swaps extends EventEmitter {
   /**
    * Verifies that the request from LND is valid. Checks the received amount vs
    * the expected amount and the CltvDelta vs the expected one.
+   * @returns `true` if the resolve request is valid, `false` otherwise
    */
-  private validateRequest = (deal: SwapDeal, resolveRequest: lndrpc.ResolveRequest)  => {
+  private validateResolveRequest = (deal: SwapDeal, resolveRequest: lndrpc.ResolveRequest)  => {
     const amount = resolveRequest.getAmount();
     let expectedAmount = 0;
     let cltvDelta = 0;
@@ -547,7 +559,7 @@ class Swaps extends EventEmitter {
       return msg;
     }
 
-    if (!this.validateRequest(deal, resolveRequest)) {
+    if (!this.validateResolveRequest(deal, resolveRequest)) {
       return deal.errorReason;
     }
 

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -54,4 +54,6 @@ export enum SwapFailureReason {
   OrderNotFound,
   /** The order specified by a swap request is on hold for a different ongoing swap. */
   OrderOnHold,
+  /** The swap request contained invalid data. */
+  InvalidSwapRequest,
 }

--- a/test/unit/Swaps.spec.ts
+++ b/test/unit/Swaps.spec.ts
@@ -3,22 +3,28 @@ import Swaps from '../../lib/swaps/Swaps';
 import { SwapDeal } from '../../lib/swaps/types';
 import Logger, { Level } from '../../lib/Logger';
 import { SwapPhase, SwapState, SwapRole } from '../../lib/types/enums';
+import { SwapRequestPacketBody } from '../../lib/p2p/packets';
 
 const loggers = Logger.createLoggers(Level.Warn);
 
 describe('Swaps', () => {
   const quantity = 0.01;
   const price = 0.005;
+  const takerCltvDelta = 144;
+  const orderId = 'f8a85c66-7e73-43cd-9ac4-176ff4cc28a8';
+  const r_hash = '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2';
 
   /** A swap deal for a buy order. */
   const buyDeal: SwapDeal = {
     quantity,
     price,
+    takerCltvDelta,
+    orderId,
+    r_hash,
     role: SwapRole.Maker,
     phase: SwapPhase.SwapCreated,
     state: SwapState.Active,
     peerPubKey: '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8',
-    orderId: 'f8a85c66-7e73-43cd-9ac4-176ff4cc28a8',
     localId: '1',
     proposedQuantity: quantity,
     isBuy: true,
@@ -27,9 +33,6 @@ describe('Swaps', () => {
     takerCurrency: 'BTC',
     makerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity,
     takerAmount: Swaps['SATOSHIS_PER_COIN'] * quantity * price,
-    makerCltvDelta: 144,
-    takerCltvDelta: 144,
-    r_hash: '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2',
     createTime: 1540716251106,
   };
 
@@ -43,13 +46,21 @@ describe('Swaps', () => {
     makerAmount: buyDeal.takerAmount,
   };
 
+  const swapRequest: SwapRequestPacketBody = {
+    takerCltvDelta,
+    orderId,
+    r_hash,
+    proposedQuantity: quantity,
+    pairId: 'LTC/BTC',
+  };
+
   it('should derive currencies for a buy order', () => {
     const { makerCurrency, takerCurrency } = Swaps['deriveCurrencies'](buyDeal.pairId, buyDeal.isBuy);
     expect(makerCurrency).to.equal(buyDeal.makerCurrency);
     expect(takerCurrency).to.equal(buyDeal.takerCurrency);
   });
 
-  it('should calculate swap amounts for a sell order', () => {
+  it('should derive currencies for a sell order', () => {
     const { makerCurrency, takerCurrency } = Swaps['deriveCurrencies'](sellDeal.pairId, sellDeal.isBuy);
     expect(makerCurrency).to.equal(sellDeal.makerCurrency);
     expect(takerCurrency).to.equal(sellDeal.takerCurrency);
@@ -65,5 +76,18 @@ describe('Swaps', () => {
     const { makerAmount, takerAmount } = Swaps['calculateSwapAmounts'](sellDeal.quantity!, sellDeal.price, sellDeal.isBuy);
     expect(makerAmount).to.equal(sellDeal.makerAmount);
     expect(takerAmount).to.equal(sellDeal.takerAmount);
+  });
+
+  it(`should validate a good swap request`, () => {
+    expect(Swaps.validateSwapRequest(swapRequest)).to.be.true;
+  });
+
+  it(`should flag a swap request with a non-positive proposed quantity`, () => {
+    expect(Swaps.validateSwapRequest({ ...swapRequest, proposedQuantity: 0 })).to.be.false;
+    expect(Swaps.validateSwapRequest({ ...swapRequest, proposedQuantity: -1 })).to.be.false;
+  });
+
+  it(`should flag a swap request with an rHash that is not 64 characters`, () => {
+    expect(Swaps.validateSwapRequest({ ...swapRequest, r_hash: 'notavalidhash' })).to.be.false;
   });
 });


### PR DESCRIPTION
This adds a check when deciding whether to accept a swap request to ensure that it is valid. For now, a swap is considered invalid if it has non-positive proposed quantity or if its rHash is not exactly 64 characters.