### PR TITLE
chore: update typedoc script and run on version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "compile:watch": "tsc -w",
     "dev": "npm run compile && npm start",
     "dev:watch": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
-    "docs": "typedoc --out typedoc --module commonjs --target es6 lib",
     "lint": "tslint --fix --project tsconfig.json && tslint --fix --config tslint-alt.json 'bin/*' 'test/**/*.ts' 'tasks/**/*.ts'",
     "lintNoFix": "tslint --project tsconfig.json && tslint --config tslint-alt.json 'bin/*' 'test/**/*.ts' 'tasks/**/*.ts'",
     "nodemon:watch": "nodemon --watch dist -e js dist/Xud.js",
@@ -28,8 +27,9 @@
     "test:unit:watch": "mocha -r ts-node/register test/unit/*  --watch --watch-extensions ts",
     "test:p2p": "mocha -r ts-node/register test/p2p/*",
     "test:p2p:watch": "mocha -r ts-node/register test/p2p/*  --watch --watch-extensions ts",
+    "typedoc": "typedoc --out typedoc --module commonjs --target es6 lib --readme none",
     "preversion": "npm run lintNoFix && npm test && npm run compile",
-    "version": "npm run config && git add sample-xud.conf"
+    "version": "npm run config && git add sample-xud.conf && npm run typedoc"
   },
   "cross-os": {
     "postcompile": {


### PR DESCRIPTION
This renames and updates the script to generate typedoc html and makes it run every time a new version is tagged. It removes the `xud` README from the generated typedoc.