### PR TITLE
refactor(orderbook): localId does not exist error

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -111,6 +111,8 @@ class GrpcService {
       case orderErrorCodes.PAIR_DOES_NOT_EXIST:
       case p2pErrorCodes.COULD_NOT_CONNECT:
       case p2pErrorCodes.NODE_UNKNOWN:
+      case orderErrorCodes.LOCAL_ID_DOES_NOT_EXIST:
+      case orderErrorCodes.ORDER_NOT_FOUND:
         code = status.NOT_FOUND;
         break;
       case orderErrorCodes.DUPLICATE_ORDER:

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -409,7 +409,7 @@ class OrderBook extends EventEmitter {
   public removeOwnOrderByLocalId = (localId: string) => {
     const order = this.localIdMap.get(localId);
     if (!order) {
-      throw errors.ORDER_NOT_FOUND(localId);
+      throw errors.LOCAL_ID_DOES_NOT_EXIST(localId);
     }
 
     this.removeOwnOrder(order.id, order.pairId);

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -10,6 +10,7 @@ const errorCodes = {
   CURRENCY_ALREADY_EXISTS: codesPrefix.concat('.6'),
   PAIR_ALREADY_EXISTS: codesPrefix.concat('.7'),
   MARKET_ORDERS_NOT_ALLOWED: codesPrefix.concat('.8'),
+  LOCAL_ID_DOES_NOT_EXIST: codesPrefix.concat('.9'),
 };
 
 const errors = {
@@ -37,13 +38,17 @@ const errors = {
     message: `currency ${currency} already exists`,
     code: errorCodes.CURRENCY_ALREADY_EXISTS,
   }),
-  PAIR_ALREADY_EXISTS: (pair_id: string) => ({
-    message: `trading pair ${pair_id} already exists`,
+  PAIR_ALREADY_EXISTS: (pairId: string) => ({
+    message: `trading pair ${pairId} already exists`,
     code: errorCodes.PAIR_ALREADY_EXISTS,
   }),
   MARKET_ORDERS_NOT_ALLOWED: () => ({
     message: `market orders are not allowed on nomatching mode`,
     code: errorCodes.MARKET_ORDERS_NOT_ALLOWED,
+  }),
+  LOCAL_ID_DOES_NOT_EXIST: (localId: string) => ({
+    message: `order with local id ${localId} does not exist`,
+    code: errorCodes.LOCAL_ID_DOES_NOT_EXIST,
   }),
 };
 


### PR DESCRIPTION
This creates a `LOCAL_ID_DOES_NOT_EXIST` exist error for when `xud` is asked to look up a local id that does not exist. This error is used in place of the `ORDER_NOT_FOUND` error.