### PR TITLE
feat(rpc): add UNAVAILABLE grpc error status code

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -109,7 +109,6 @@ class GrpcService {
         code = status.INVALID_ARGUMENT;
         break;
       case orderErrorCodes.PAIR_DOES_NOT_EXIST:
-      case p2pErrorCodes.COULD_NOT_CONNECT:
       case p2pErrorCodes.NODE_UNKNOWN:
         code = status.NOT_FOUND;
         break;
@@ -125,12 +124,15 @@ class GrpcService {
       case p2pErrorCodes.NODE_NOT_BANNED:
       case p2pErrorCodes.NODE_IS_BANNED:
       case lndErrorCodes.LND_IS_DISABLED:
-      case lndErrorCodes.LND_IS_DISCONNECTED:
       case orderErrorCodes.CURRENCY_DOES_NOT_EXIST:
       case orderErrorCodes.CURRENCY_CANNOT_BE_REMOVED:
       case orderErrorCodes.MARKET_ORDERS_NOT_ALLOWED:
       case serviceErrorCodes.NOMATCHING_MODE_IS_REQUIRED:
         code = status.FAILED_PRECONDITION;
+        break;
+      case lndErrorCodes.LND_IS_UNAVAILABLE:
+      case p2pErrorCodes.COULD_NOT_CONNECT:
+        code = status.UNAVAILABLE;
         break;
     }
 

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -132,7 +132,7 @@ class LndClient extends BaseClient {
     if (this.isDisabled()) {
       error = errors.LND_IS_DISABLED.message;
     } else if (!this.isConnected()) {
-      error = errors.LND_IS_DISCONNECTED.message;
+      error = errors.LND_IS_UNAVAILABLE.message;
     } else {
       try {
         const lnd = await this.getInfo();
@@ -295,7 +295,7 @@ class LndClient extends BaseClient {
       throw(errors.LND_IS_DISABLED);
     }
     if (this.isDisconnected()) {
-      throw(errors.LND_IS_DISCONNECTED);
+      throw(errors.LND_IS_UNAVAILABLE);
     }
     const request = new lndrpc.CloseChannelRequest();
     const channelPoint = new lndrpc.ChannelPoint();

--- a/lib/lndclient/errors.ts
+++ b/lib/lndclient/errors.ts
@@ -3,7 +3,7 @@ import errorCodesPrefix from '../constants/errorCodesPrefix';
 const codesPrefix = errorCodesPrefix.LND;
 const errorCodes = {
   LND_IS_DISABLED: codesPrefix.concat('.1'),
-  LND_IS_DISCONNECTED: codesPrefix.concat('.2'),
+  LND_IS_UNAVAILABLE: codesPrefix.concat('.2'),
 };
 
 const errors = {
@@ -11,9 +11,9 @@ const errors = {
     message: 'lnd is disabled',
     code: errorCodes.LND_IS_DISABLED,
   },
-  LND_IS_DISCONNECTED: {
-    message: 'lnd is not connected',
-    code: errorCodes.LND_IS_DISCONNECTED,
+  LND_IS_UNAVAILABLE: {
+    message: 'lnd is not available',
+    code: errorCodes.LND_IS_UNAVAILABLE,
   },
 };
 


### PR DESCRIPTION
This adds the `UNAVAILABLE` code as one of the possible grpc status codes that can be returned by `xud`. This status is intended for calls that can fail due to transient conditions and may be successful if tried again at a later time. The two existing errors that meet that description are `LND_IS_UNAVAILABLE` (renamed from `LND_IS_DISCONNECTED` because lnd may be reachable via grpc but out of sync with the chain)) and `COULD_NOT_CONNECT` from the p2p context. We automatically attempt to reestablish a connection to lnd, and nodes that are offline may come back online.