### PR TITLE
feat(orderbook): logging enhancements

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -128,6 +128,7 @@ class TradingPair {
     }
 
     map.set(order.id, order);
+    this.logger.debug(`order added: ${JSON.stringify(order)}`);
 
     if (!this.nomatching) {
       const queue = order.isBuy ? this.queues!.buy : this.queues!.sell;
@@ -272,6 +273,7 @@ class TradingPair {
     assert(holdAmount > 0);
     assert(order.hold + holdAmount <= order.quantity, 'the amount of an order on hold cannot exceed the available quantity');
     order.hold += holdAmount;
+    this.logger.debug(`added hold of ${holdAmount} on order ${orderId}`);
   }
 
   public removeOrderHold = (orderId: string, holdAmount: number) => {
@@ -279,6 +281,7 @@ class TradingPair {
     assert(holdAmount > 0);
     assert(order.hold >= holdAmount, 'cannot remove more than is currently on hold for an order');
     order.hold -= holdAmount;
+    this.logger.debug(`removed hold of ${holdAmount} on order ${orderId}`);
   }
 
   /**

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -226,6 +226,11 @@ class Peer extends EventEmitter {
 
   public sendPacket = (packet: Packet): void => {
     this.sendRaw(packet.toRaw());
+    if (this.nodePubKey !== undefined) {
+      this.logger.trace(`Sent packet to ${this.nodePubKey}: ${packet.body ? JSON.stringify(packet.body) : ''}`);
+    } else {
+      this.logger.trace(`Sent packet to ${addressUtils.toString(this.address)}: ${packet.body ? JSON.stringify(packet.body) : ''}`);
+    }
     this.packetCount += 1;
 
     if (packet.direction === PacketDirection.Request) {
@@ -461,9 +466,9 @@ class Peer extends EventEmitter {
       this.lastRecv = Date.now();
       const dataStr = data.toString();
       if (this.nodePubKey !== undefined) {
-        this.logger.trace(`Received data (${this.nodePubKey}): ${dataStr}`);
+        this.logger.trace(`Received data from ${this.nodePubKey}: ${dataStr}`);
       } else {
-        this.logger.trace(`Received data (${addressUtils.toString(this.address)}): ${data.toString()}`);
+        this.logger.trace(`Received data from ${addressUtils.toString(this.address)}: ${data.toString()}`);
       }
       this.parser.feed(dataStr);
     });

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -487,7 +487,7 @@ class Pool extends EventEmitter {
       }
       case PacketType.OrderInvalidation: {
         const orderPortion = (packet as packets.OrderInvalidationPacket).body!;
-        this.logger.verbose(`canceled order from ${peer.nodePubKey}: ${JSON.stringify(orderPortion)}`);
+        this.logger.verbose(`received order invalidation from ${peer.nodePubKey}: ${JSON.stringify(orderPortion)}`);
         this.emit('packet.orderInvalidation', orderPortion, peer.nodePubKey as string);
         break;
       }


### PR DESCRIPTION
This adds debug logging messages in an effort to log each time there is a change regarding the order book. All log statements regarding successful changes to individual orders (adds, removes, reductions, holds) were moved to TradingPair.ts to try to keep them in one place. It also adds trace-level logging when packets are sent to peers.

I still want to add some log statements to the `match()` method in TradingPair.ts, but it was somewhat complicated to do because of the way orders are removed and then added back if not fully matched, so I will try to address that in a separate PR.

Closes #649.