### PR TITLE
Streamline matching logic and add log statements

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -312,6 +312,7 @@ class TradingPair {
         } else if (remainingFullyMatched) {
           // taker order quantity is not sufficient. maker order will split
           const matchedMakerOrder = TradingPair.splitOrderByQuantity(makerOrder, matchingQuantity);
+          this.logger.debug(`reduced order ${makerOrder.id} by ${matchingQuantity} quantity while matching order ${takerOrder.id}`);
           matches.push({ maker: matchedMakerOrder, taker: remainingOrder });
         } else if (makerFullyMatched) {
           // maker order quantity is not sufficient. taker order will split
@@ -329,6 +330,7 @@ class TradingPair {
           assert(queue.poll() === makerOrder);
           const map = this.getOrderMap(makerOrder)!;
           map.delete(makerOrder.id);
+          this.logger.debug(`removed order ${makerOrder.id} while matching order ${takerOrder.id}`);
         }
       }
     }

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -79,7 +79,7 @@ describe('OrderBook', () => {
     return;
   };
 
-  it('should have pairs and matchingEngines equivalent loaded', () => {
+  it('should have trading pairs loaded', () => {
     orderBook.pairs.forEach((pair) => {
       expect(orderBook.tradingPairs).to.have.key(pair.id);
     });

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -54,7 +54,7 @@ const init = () => {
 
 describe('TradingPair.getMatchingQuantity', () => {
   it('should not match buy order with a lower price then a sell order', () => {
-    const res = TradingPair.getMatchingQuantity(
+    const res = TradingPair['getMatchingQuantity'](
       createOwnOrder(5, 10, true),
       createOwnOrder(5.5, 10, false),
     );
@@ -62,7 +62,7 @@ describe('TradingPair.getMatchingQuantity', () => {
   });
 
   it('should match buy order with a higher then a sell order', () => {
-    const res = TradingPair.getMatchingQuantity(
+    const res = TradingPair['getMatchingQuantity'](
       createOwnOrder(5.5, 10, true),
       createOwnOrder(5, 10, false),
     );
@@ -70,7 +70,7 @@ describe('TradingPair.getMatchingQuantity', () => {
   });
 
   it('should match buy order with an equal price to a sell order', () => {
-    const res = TradingPair.getMatchingQuantity(
+    const res = TradingPair['getMatchingQuantity'](
       createOwnOrder(5, 10, true),
       createOwnOrder(5, 10, false),
     );
@@ -78,7 +78,7 @@ describe('TradingPair.getMatchingQuantity', () => {
   });
 
   it('should match with lowest quantity of both orders', () => {
-    const res = TradingPair.getMatchingQuantity(
+    const res = TradingPair['getMatchingQuantity'](
       createOwnOrder(5, 5, true),
       createOwnOrder(5, 10, false),
     );
@@ -143,30 +143,17 @@ describe('TradingPair.getOrdersPriorityQueueComparator', () => {
 });
 
 describe('TradingPair.splitOrderByQuantity', () => {
-  it('should split buy orders properly', () => {
+  it('should split an order properly', () => {
     const orderQuantity = 10;
     const matchingQuantity = 6;
-    const { matched, remaining } = TradingPair.splitOrderByQuantity(
-      createOwnOrder(5, orderQuantity, true),
-      matchingQuantity,
-    );
-    expect(matched.quantity).to.equal(matchingQuantity);
-    expect(remaining.quantity).to.equal(orderQuantity - matchingQuantity);
-  });
-
-  it('should split sell orders properly', () => {
-    const orderQuantity = 10;
-    const matchingQuantity = 4;
-    const { matched, remaining } = TradingPair.splitOrderByQuantity(
-      createOwnOrder(5, orderQuantity, false),
-      matchingQuantity,
-    );
-    expect(matched.quantity).to.equal(matchingQuantity);
-    expect(remaining.quantity).to.equal(orderQuantity - matchingQuantity);
+    const order = createOwnOrder(5, orderQuantity, true);
+    const matchedOrder = TradingPair['splitOrderByQuantity'](order, matchingQuantity);
+    expect(matchedOrder.quantity).to.equal(matchingQuantity);
+    expect(order.quantity).to.equal(orderQuantity - matchingQuantity);
   });
 
   it('should not work when matchingQuantity higher than quantity of order', () => {
-    expect(() => TradingPair.splitOrderByQuantity(
+    expect(() => TradingPair['splitOrderByQuantity'](
       createOwnOrder(5, 5, true),
       10,
     )).to.throw('order quantity must be greater than matchingQuantity');
@@ -271,7 +258,7 @@ describe('TradingPair.removePeerOrders', () => {
 
 });
 
-describe('MatchingEngine queues and maps integrity', () => {
+describe('TradingPair queues and maps integrity', () => {
   beforeEach(init);
 
   it('queue and map should both remove an own order', () => {


### PR DESCRIPTION
This is a follow-up to resolving #649. Previously it wasn't straightforward to log when orders were removed from the orderbook due to matching, because the matching routine would *always* remove the top order from the queue and then add back a part of it if it was only partially matched. Adding and removing orders executes in `O(log n)`, as opposed to `O(1)` for peeking the top of the queue. 

Instead, this handles partial matches by creating only one new object with the matching quantity while reducing the quantity of the existing order (similar to how order invalidations or removes from the API are handles). Orders are only removed from the queue when they are fully matched. By reducing the number of adds/removes to the queue and new objects being created, this should improve performance of the matching logic somewhat.

With that in place, I added logging statements for when orders are removed or have their quantity reduced due to matching with a newly placed order.

I figure it might be worthwhile to optimize the matching logic further to not create a copy of the taker order for every order that it matches with, but it's not a priority and I'll maybe come back to it another time.


