### PR TITLE
 feat(db): join swapdeal to order & node

### DIFF
--- a/lib/db/models/SwapDeal.ts
+++ b/lib/db/models/SwapDeal.ts
@@ -9,6 +9,12 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
     phase: { type: DataTypes.TINYINT, allowNull: false },
     errorReason: { type: DataTypes.STRING, allowNull: true },
     rPreimage: { type: DataTypes.STRING, allowNull: true },
+    peerPubKey: {
+      type: DataTypes.VIRTUAL,
+      get(this: db.SwapDealInstance) {
+        return this.Node ? this.Node.nodePubKey : undefined;
+      },
+    },
     nodeId: { type: DataTypes.INTEGER, allowNull: false },
     orderId: { type: DataTypes.STRING, allowNull: false },
     localId: { type: DataTypes.STRING, allowNull: false },

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -321,7 +321,9 @@ class GrpcService {
     try {
       const { banned, reputationScore } = await this.service.getNodeInfo(call.request.toObject());
       const response = new xudrpc.GetNodeInfoResponse();
-      response.setBanned(banned);
+      if (banned) {
+        response.setBanned(banned);
+      }
       response.setReputationscore(reputationScore);
       callback(null, response);
     } catch (err) {

--- a/lib/orderbook/OrderBookRepository.ts
+++ b/lib/orderbook/OrderBookRepository.ts
@@ -37,7 +37,7 @@ class OrderbookRepository {
       where: { id: order.id },
     });
     if (count === 0) {
-      await this.models.Order.create(order as OrderAttributes);
+      await this.models.Order.create(order);
     }
   }
 }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -38,7 +38,7 @@ type PoolConfig = {
 
 type NodeReputationInfo = {
   reputationScore: ReputationEvent;
-  banned: boolean;
+  banned?: boolean;
 };
 
 interface Pool {

--- a/lib/swaps/SwapRepository.ts
+++ b/lib/swaps/SwapRepository.ts
@@ -7,7 +7,7 @@ class SwapRepository {
   constructor(private models: Models) {}
 
   public getSwapDeals = (): Bluebird<db.SwapDealInstance[]> => {
-    return this.models.SwapDeal.findAll();
+    return this.models.SwapDeal.findAll({ include: [this.models.Node, this.models.Order] });
   }
 
   public getSwapDeal = async (rHash: string): Promise<db.SwapDealInstance | null> => {
@@ -15,6 +15,7 @@ class SwapRepository {
       where: {
         rHash,
       },
+      include: [this.models.Node, this.models.Order],
     });
   }
 

--- a/lib/types/db.ts
+++ b/lib/types/db.ts
@@ -30,12 +30,17 @@ export type CurrencyInstance = CurrencyAttributes & Sequelize.Instance<CurrencyA
 /* SwapDeal */
 export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes' | 'price' | 'pairId' | 'isBuy'>>;
 
-export type SwapDealAttributes = Pick<SwapDealFactory, Exclude<keyof SwapDealFactory, 'peerPubKey'>> & {
+export type SwapDealAttributes = SwapDealFactory & {
   /** The internal db node id of the counterparty peer for this swap deal. */
   nodeId: number;
+  Node?: NodeAttributes;
+  Order?: OrderAttributes;
 };
 
-export type SwapDealInstance = SwapDealAttributes & Sequelize.Instance<SwapDealAttributes>;
+export type SwapDealInstance = SwapDealAttributes & Sequelize.Instance<SwapDealAttributes> & {
+  getNode: Sequelize.BelongsToGetAssociationMixin<NodeInstance>;
+  getOrder: Sequelize.BelongsToGetAssociationMixin<OrderInstance>;
+};
 
 export type OrderFactory = Pick<Order, Exclude<keyof Order, 'quantity' | 'hold' | 'price'>> & {
   /** The internal db node id of the peer that created this order. */

--- a/lib/types/db.ts
+++ b/lib/types/db.ts
@@ -1,10 +1,10 @@
-import Sequelize, { DataTypeAbstract, DefineAttributeColumnOptions } from 'sequelize';
+import Sequelize, { DataTypeAbstract, DefineAttributeColumnOptions, DefineAttributes } from 'sequelize';
 import { Address, NodeConnectionInfo } from './p2p';
 import { SwapDeal } from '../swaps/types';
 import { Currency, Pair, OwnOrder, Order } from './orders';
 import { ReputationEvent } from './enums';
 
-export type SequelizeAttributes<T extends { [key: string]: any }> = {
+export type SequelizeAttributes<T extends { [key: string]: any }> = DefineAttributes & {
   [P in keyof T]: string | DataTypeAbstract | DefineAttributeColumnOptions
 };
 
@@ -31,25 +31,21 @@ export type CurrencyInstance = CurrencyAttributes & Sequelize.Instance<CurrencyA
 export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes' | 'price' | 'pairId' | 'isBuy'>>;
 
 export type SwapDealAttributes = Pick<SwapDealFactory, Exclude<keyof SwapDealFactory, 'peerPubKey'>> & {
-  makerCltvDelta: number;
-  rPreimage: string;
-  errorReason: string;
-  quantity: number;
-  takerPubKey: string;
-  executeTime: number;
-  completeTime: number;
   /** The internal db node id of the counterparty peer for this swap deal. */
   nodeId: number;
 };
 
 export type SwapDealInstance = SwapDealAttributes & Sequelize.Instance<SwapDealAttributes>;
 
-export type OrderFactory = Pick<Order, Exclude<keyof Order, 'quantity' | 'hold'>>;
+export type OrderFactory = Pick<Order, Exclude<keyof Order, 'quantity' | 'hold' | 'price'>> & {
+  /** The internal db node id of the peer that created this order. */
+  nodeId?: number;
+  localId?: string;
+  /** The price for the order expressed in units of the quote currency. */
+  price?: number;
+};
 
 export type OrderAttributes = OrderFactory & {
-  /** The internal db node id of the peer that created this order. */
-  nodeId: number;
-  localId: string;
 };
 
 export type OrderInstance = OrderAttributes & Sequelize.Instance<OrderAttributes>;

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -10,7 +10,6 @@ import chaiAsPromised = require('chai-as-promised');
 import { OwnOrder } from '../../lib/types/orders';
 import { SwapDeal } from '../../lib/swaps/types';
 import P2PRepository from '../../lib/p2p/P2PRepository';
-import { p2p } from '../../lib/types';
 
 chai.use(chaiAsPromised);
 
@@ -20,6 +19,8 @@ const loggers = Logger.createLoggers(Level.Warn);
 const price = 0.005;
 const quantity = 0.1;
 const peerPubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+const rHash = '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2';
+const orderId = uuidv1();
 
 const order: OwnOrder = {
   price,
@@ -27,7 +28,7 @@ const order: OwnOrder = {
   isBuy: true,
   createdAt: ms(),
   initialQuantity: quantity,
-  id: uuidv1(),
+  id: orderId,
   localId: uuidv1(),
   pairId: PAIR_ID,
   hold: 0,
@@ -37,6 +38,7 @@ const deal: SwapDeal = {
   quantity,
   price,
   peerPubKey,
+  rHash,
   role: SwapRole.Maker,
   phase: SwapPhase.SwapCompleted,
   state: SwapState.Completed,
@@ -51,7 +53,6 @@ const deal: SwapDeal = {
   makerAmount: 1000000,
   takerCltvDelta: 144,
   makerCltvDelta: 144,
-  rHash: '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2',
   rPreimage: '60743C0B6BFA885E30F101705764F43F8EF7E613DD0F07AD5178C7D9B1682B9E',
   createTime: 1540716251106,
   executeTime: 1540717251106,
@@ -114,6 +115,20 @@ describe('Database', () => {
   it('should add a swap for the order', async () => {
     await swapRepo.addSwapDeal(deal);
     await expect(db.models.SwapDeal.count()).to.eventually.equal(1);
+  });
+
+  it('should get a swap along with the order for the swap', async () => {
+    const swap = (await swapRepo.getSwapDeal(rHash))!;
+    expect(swap.Order!.id).to.equal(orderId);
+    const order = (await swap.getOrder())!;
+    expect(order.id).to.equal(orderId);
+  });
+
+  it('should get a swap along with its peer node', async () => {
+    const swap = (await swapRepo.getSwapDeal(rHash))!;
+    expect(swap.peerPubKey).to.equal(peerPubKey);
+    const node = (await swap.getNode())!;
+    expect(node.nodePubKey).to.equal(peerPubKey);
   });
 
   after(async () => {


### PR DESCRIPTION
This modifies `SwapDealAttributes` to include a references to its corresponding `Order` and `Node` attributes. When swap deals are fetches from the database, it now also fetches info about the order and node.

This also amends the type definitions for the attributes passed to `sequelize.define` to allow nullable attributes. Previously, we had to make all attribute type definitions non-nullable to avoid compilation errors, even on attributes that were nullable in the database.

This will be helpful for #625, @ImmanuelSegol after this is merged you can get everything you need for the `ListSwapDeals` call from `getSwapDeals`.