### PR TITLE
feat(cli): format buy & sell output

### DIFF
--- a/lib/cli/commands/getorders.ts
+++ b/lib/cli/commands/getorders.ts
@@ -4,7 +4,7 @@ import { GetOrdersRequest, GetOrdersResponse, Order, OrderSide } from '../../pro
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
 
-type FormatedTradingPairOrders = {
+type FormattedTradingPairOrders = {
   pairId: string,
   orders: string[][],
 };
@@ -39,7 +39,7 @@ const addSide = (orderSide: Order.AsObject[]): string[] => {
 };
 
 export const formatOrders = (orders: GetOrdersResponse.AsObject) => {
-  const formatedOrders: FormatedTradingPairOrders[] = [];
+  const formattedOrders: FormattedTradingPairOrders[] = [];
   orders.ordersMap.forEach((tradingPair) => {
     const buy = sortOrders(tradingPair[1].buyOrdersList, true);
     const sell = sortOrders(tradingPair[1].sellOrdersList, false);
@@ -49,12 +49,12 @@ export const formatOrders = (orders: GetOrdersResponse.AsObject) => {
       .map(() => {
         return addSide(buy).concat(addSide(sell));
       });
-    formatedOrders.push({
+    formattedOrders.push({
       pairId: tradingPair[0],
       orders: tradingPairOrders,
     });
   });
-  return formatedOrders;
+  return formattedOrders;
 };
 
 const createTable = () => {
@@ -77,7 +77,7 @@ const sortOrders = (orderSide: Order.AsObject[], isBuy: boolean) => {
   });
 };
 
-const displayOrdersTable = (tradingPair: FormatedTradingPairOrders) => {
+const displayOrdersTable = (tradingPair: FormattedTradingPairOrders) => {
   const table = createTable();
   tradingPair.orders.forEach(order => table.push(order));
   console.log(colors.underline(colors.bold(`\nTrading pair: ${tradingPair.pairId}`)));

--- a/lib/cli/utils.ts
+++ b/lib/cli/utils.ts
@@ -1,6 +1,6 @@
 import { Arguments, Argv } from 'yargs';
 import { callback, loadXudClient } from './command';
-import { PlaceOrderRequest, PlaceOrderEvent, OrderSide } from '../proto/xudrpc_pb';
+import { PlaceOrderRequest, PlaceOrderEvent, OrderSide, PlaceOrderResponse, Order, SwapResult } from '../proto/xudrpc_pb';
 
 export const orderBuilder = (argv: Argv, command: string) => argv
   .option('quantity', {
@@ -49,10 +49,59 @@ export const orderHandler = (argv: Arguments, isSell = false) => {
 
   if (argv.stream) {
     const subscription = loadXudClient(argv).placeOrder(request);
+    let noMatches = true;
     subscription.on('data', (response: PlaceOrderEvent) => {
-      console.log(JSON.stringify(response.toObject(), undefined, 2));
+      if (argv.json) {
+        console.log(JSON.stringify(response.toObject(), undefined, 2));
+      } else {
+        const internalMatch = response.getInternalMatch();
+        const swapResult = response.getSwapResult();
+        const remainingOrder = response.getRemainingOrder();
+        if (internalMatch) {
+          noMatches = false;
+          formatInternalMatch(internalMatch.toObject());
+        } else if (swapResult) {
+          noMatches = false;
+          formatSwapResult(swapResult.toObject());
+        } else if (remainingOrder) {
+          if (noMatches) {
+            console.log('no matches found');
+          }
+          formatRemainingOrder(remainingOrder.toObject());
+        }
+      }
     });
   } else {
-    loadXudClient(argv).placeOrderSync(request, callback(argv));
+    loadXudClient(argv).placeOrderSync(request, callback(argv, formatPlaceOrderOutput));
   }
 };
+
+const formatPlaceOrderOutput = (response: PlaceOrderResponse.AsObject) => {
+  const { internalMatchesList, swapResultsList, remainingOrder } = response;
+  if (internalMatchesList.length === 0 && swapResultsList.length === 0) {
+    console.log('no matches found');
+  } else {
+    internalMatchesList.forEach(formatInternalMatch);
+    swapResultsList.forEach(formatSwapResult);
+  }
+  if (remainingOrder) {
+    formatRemainingOrder(remainingOrder);
+  }
+};
+
+const formatInternalMatch = (order: Order.AsObject) => {
+  const baseCurrency = getBaseCurrency(order.pairId);
+  console.log(`matched ${order.quantity} ${baseCurrency} @ ${order.price} with own order ${order.id}`);
+};
+
+const formatSwapResult = (swapResult: SwapResult.AsObject) => {
+  const baseCurrency = getBaseCurrency(swapResult.pairId);
+  console.log(`swapped ${swapResult.quantity} ${baseCurrency} with peer order ${swapResult.orderId}`);
+};
+
+const formatRemainingOrder = (order: Order.AsObject) => {
+  const baseCurrency = getBaseCurrency(order.pairId);
+  console.log(`remaining ${order.quantity} ${baseCurrency} entered the order book as ${order.id}`);
+};
+
+const getBaseCurrency = (pairId: string) => pairId.substring(0, pairId.indexOf('/'));


### PR DESCRIPTION
This attempts to make the cli output for the `buy` and `sell` commands more human-readable and succint.

Closes #620.

The missing features that will need to be added in separate PRs are adding `price` to the swap result (#656) and adding an event for failed swaps to the streaming `placeOrder` rpc call (#609).