### PR TITLE
perf: use async fs & crypto methods

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import toml from 'toml';
 import { deepMerge } from './utils/utils';
+import { exists, mkdir, readFile } from './utils/fsUtils';
 import { PoolConfig } from './p2p/Pool';
 import { LndClientConfig } from './lndclient/LndClient';
 import { RaidenClientConfig } from './raidenclient/RaidenClient';
@@ -102,7 +102,7 @@ class Config {
     };
   }
 
-  public load(args?: { [argName: string]: any }): Config {
+  public load = async (args?: { [argName: string]: any }): Promise<Config> => {
     if (args) {
       if (args.xudir) {
         this.updateDefaultPaths(args.xudir);
@@ -112,10 +112,10 @@ class Config {
       }
     }
     const configPath = path.join(this.xudir, 'xud.conf');
-    if (!fs.existsSync(this.xudir)) {
-      fs.mkdirSync(this.xudir);
-    } else if (fs.existsSync(configPath)) {
-      const configText = fs.readFileSync(configPath, 'utf8');
+    if (!(await exists(this.xudir))) {
+      await mkdir(this.xudir);
+    } else if (await exists(configPath)) {
+      const configText = await readFile(configPath, 'utf8');
       try {
         const props = toml.parse(configText);
 
@@ -149,16 +149,16 @@ class Config {
       this.loglevel = this.getDefaultLogLevel();
     }
 
-    this.createLogDir(this.logpath);
+    await this.createLogDir(this.logpath);
 
     return this;
   }
 
-  private createLogDir = (logPath: string) => {
+  private createLogDir = async (logPath: string) => {
     const dir = path.dirname(logPath);
 
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir);
+    if (!(await exists(dir))) {
+      await mkdir(dir);
     }
   }
 

--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -1,10 +1,10 @@
-import fs from 'fs';
 import path from 'path';
 import Sequelize from 'sequelize';
 import Bluebird from 'bluebird';
 import Logger from '../Logger';
 import { db } from '../types';
 import { SwapClients } from '../types/enums';
+import { exists, readdir } from '../utils/fsUtils';
 
 type Models = {
   Node: Sequelize.Model<db.NodeInstance, db.NodeAttributes>;
@@ -19,7 +19,7 @@ type Models = {
 /** A class representing a connection to a SQL database. */
 class DB {
   public sequelize: Sequelize.Sequelize;
-  public models: Models;
+  public models!: Models;
 
   /**
    * @param storage the file path for the sqlite database file, if ':memory:' or not specified the db is stored in memory
@@ -31,7 +31,6 @@ class DB {
       dialect: 'sqlite',
       operatorsAliases: false,
     });
-    this.models = this.loadModels();
   }
 
   /**
@@ -39,7 +38,8 @@ class DB {
    * @param initDb whether to intialize a new database with default values if no database exists
    */
   public init = async (initDb = false): Promise<void> => {
-    const newDb = !this.storage || !fs.existsSync(this.storage);
+    this.models = await this.loadModels();
+    const newDb = !this.storage || !(await exists(this.storage));
     try {
       await this.sequelize.authenticate();
       this.logger.info(`connected to database ${this.storage ? this.storage : 'in memory'}`);
@@ -110,10 +110,10 @@ class DB {
     return this.sequelize.drop();
   }
 
-  private loadModels = (): Models => {
+  private loadModels = async (): Promise<Models> => {
     const models: { [index: string]: Sequelize.Model<any, any> } = {};
     const modelsFolder = path.join(__dirname, 'models');
-    fs.readdirSync(modelsFolder)
+    (await readdir(modelsFolder))
       .filter(file => (file.indexOf('.') !== 0) && (file !== path.basename(__filename)) && (file.slice(-3).match(/.js|.ts/)))
       .forEach((file) => {
         const model = this.sequelize.import(path.join(modelsFolder, file));

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { hostname } from 'os';
 import grpc, { Server } from 'grpc';
 import { pki, md } from 'node-forge';
@@ -9,6 +8,7 @@ import Service from '../service/Service';
 import errors from './errors';
 import { XudService } from '../proto/xudrpc_grpc_pb';
 import { HashResolverService } from '../proto/lndrpc_grpc_pb';
+import { exists, readFile, writeFile } from '../utils/fsUtils';
 
 class GrpcServer {
   private server: Server;
@@ -57,15 +57,14 @@ class GrpcServer {
     let certificate: Buffer;
     let privateKey: Buffer;
 
-    if (!fs.existsSync(tlsCertPath) || !fs.existsSync(tlsKeyPath)) {
+    if (!(await exists(tlsCertPath)) || !(await exists(tlsKeyPath))) {
       this.logger.debug('Could not find gRPC TLS certificate. Generating new one');
-      const { tlsCert, tlsKey } = this.generateCertificate(tlsCertPath, tlsKeyPath);
+      const { tlsCert, tlsKey } = await this.generateCertificate(tlsCertPath, tlsKeyPath);
 
       certificate = Buffer.from(tlsCert);
       privateKey = Buffer.from(tlsKey);
     } else {
-      certificate = fs.readFileSync(tlsCertPath);
-      privateKey = fs.readFileSync(tlsKeyPath);
+      [certificate, privateKey] = await Promise.all([readFile(tlsCertPath), readFile(tlsKeyPath)]);
     }
 
     // tslint:disable-next-line:no-null-keyword
@@ -103,7 +102,7 @@ class GrpcServer {
    * Generate a new certificate and save it to the disk
    * @returns the cerificate and its private key
    */
-  private generateCertificate = (tlsCertPath: string, tlsKeyPath: string): { tlsCert: string, tlsKey: string } => {
+  private generateCertificate = async (tlsCertPath: string, tlsKeyPath: string): Promise<{ tlsCert: string, tlsKey: string }> => {
     const keys = pki.rsa.generateKeyPair(1024);
     const cert = pki.createCertificate();
 
@@ -151,9 +150,7 @@ class GrpcServer {
     const certificate = pki.certificateToPem(cert);
     const privateKey = pki.privateKeyToPem(keys.privateKey);
 
-    fs.writeFileSync(tlsCertPath, certificate);
-    fs.writeFileSync(tlsKeyPath, privateKey);
-
+    await Promise.all([writeFile(tlsCertPath, certificate), writeFile(tlsKeyPath, privateKey)]);
     return {
       tlsCert: certificate,
       tlsKey: privateKey,

--- a/lib/grpc/webproxy/GrpcWebProxyServer.ts
+++ b/lib/grpc/webproxy/GrpcWebProxyServer.ts
@@ -6,7 +6,7 @@ import grpcGateway from '@exchangeunion/grpc-dynamic-gateway';
 import express from 'express';
 import swaggerUi from 'swagger-ui-express';
 import grpc from 'grpc';
-import fs from 'fs';
+import { readFile } from '../../utils/fsUtils';
 
 const swaggerDocument = require('../../proto/xudrpc.swagger.json');
 
@@ -25,17 +25,17 @@ class GrpcWebProxyServer {
   /**
    * Start the server and begins listening on the specified proxy port.
    */
-  public listen = (proxyPort: number, grpcPort: number, grpcHost: string, tlsCertPath: string): Promise<void> => {
+  public listen = async (proxyPort: number, grpcPort: number, grpcHost: string, tlsCertPath: string): Promise<void> => {
     // Load the proxy on / URL
     const protoPath = path.join(__dirname, '..', '..', '..', 'proto');
     const gateway = grpcGateway(
       ['xudrpc.proto'],
       `${grpcHost}:${grpcPort}`,
-      grpc.credentials.createSsl(fs.readFileSync(tlsCertPath)),
+      grpc.credentials.createSsl(await readFile(tlsCertPath)),
       protoPath,
     );
     this.app.use('/api/', gateway);
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       /** A handler to handle an error while trying to begin listening. */
       const listenErrHandler = (err: Error) => {
         reject(err);

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -1,11 +1,11 @@
-import grpc, { ChannelCredentials, ClientReadableStream } from 'grpc';
-import fs from 'fs';
+import grpc, { ChannelCredentials } from 'grpc';
 import Logger from '../Logger';
 import BaseClient, { ClientStatus } from '../BaseClient';
 import errors from './errors';
 import { LightningClient } from '../proto/lndrpc_grpc_pb';
 import * as lndrpc from '../proto/lndrpc_pb';
 import assert from 'assert';
+import { exists, readFile } from '../utils/fsUtils';
 
 /** The configurable options for the lnd client. */
 type LndClientConfig = {
@@ -46,7 +46,7 @@ interface LndClient {
 
 /** A class representing a client to interact with lnd. */
 class LndClient extends BaseClient {
-  public readonly cltvDelta: number = 0;
+  public readonly cltvDelta: number;
   private lightning!: LightningClient | LightningMethodIndex;
   private meta!: grpc.Metadata;
   private uri!: string;
@@ -64,40 +64,44 @@ class LndClient extends BaseClient {
    * Create an lnd client.
    * @param config the lnd configuration
    */
-  constructor(config: LndClientConfig, logger: Logger) {
+  constructor(private config: LndClientConfig, logger: Logger) {
     super(logger);
 
+    this.cltvDelta = config.cltvdelta || 0;
+  }
+
+  /** Initializes the client for calls to lnd and verifies that we can connect to it.  */
+  public init = async () => {
     let shouldEnable = true;
-    const { disable, certpath, macaroonpath, cltvdelta, nomacaroons } = config;
+    const { disable, certpath, macaroonpath, nomacaroons, host, port } = this.config;
 
     if (disable) {
       shouldEnable = false;
     }
-    if (!fs.existsSync(certpath)) {
+    if (!(await exists(certpath))) {
       this.logger.error('could not find lnd certificate, is lnd installed?');
       shouldEnable = false;
     }
-    if (!nomacaroons && !fs.existsSync(macaroonpath)) {
+    if (!nomacaroons && !(await exists(macaroonpath))) {
       this.logger.error('could not find lnd macaroon, is lnd installed?');
       shouldEnable = false;
     }
     if (shouldEnable) {
-      this.cltvDelta = cltvdelta;
       assert(this.cltvDelta > 0, 'cltvdelta must be a positive number');
-      this.uri = `${config.host}:${config.port}`;
-      this.cltvDelta = cltvdelta;
-      const lndCert = fs.readFileSync(certpath);
+      this.uri = `${host}:${port}`;
+      const lndCert = await readFile(certpath);
       this.credentials = grpc.credentials.createSsl(lndCert);
 
       this.meta = new grpc.Metadata();
       if (!nomacaroons) {
-        const adminMacaroon = fs.readFileSync(macaroonpath);
+        const adminMacaroon = await readFile(macaroonpath);
         this.meta.add('macaroon', adminMacaroon.toString('hex'));
       } else {
         this.logger.info(`macaroons are disabled for lnd at ${this.uri}`);
       }
       // set status as disconnected until we can verify the connection
       this.setStatus(ClientStatus.Disconnected);
+      await this.verifyConnection();
     }
   }
 

--- a/lib/nodekey/NodeKey.ts
+++ b/lib/nodekey/NodeKey.ts
@@ -1,7 +1,7 @@
 import CryptoJS from 'crypto-js';
-import { randomBytes } from 'crypto';
 import secp256k1 from 'secp256k1';
-import fs from 'fs';
+import { randomBytes } from '../utils/utils';
+import { exists, readFile, writeFile } from '../utils/fsUtils';
 
 /**
  * A class representing an ECDSA public/private key pair that identifies an XU node on the network
@@ -20,12 +20,12 @@ class NodeKey {
   }
 
   /**
-   * Generate a random NodeKey.
+   * Generates a random NodeKey.
    */
-  private static generate = (): NodeKey => {
+  private static generate = async (): Promise<NodeKey> => {
     let privKey: Buffer;
     do {
-      privKey = randomBytes(32);
+      privKey = await randomBytes(32);
     } while (!secp256k1.privateKeyVerify(privKey));
 
     return new NodeKey(privKey);
@@ -37,43 +37,44 @@ class NodeKey {
    * @param password an optional password to decrypt the file
    * @returns a NodeKey if a file containing a valid ECDSA private key exists at the given path
    */
-  private static fromFile = (path: string, password?: string): NodeKey => {
-    let buf: Buffer;
-    if (password) {
-      const encryptedString: string = fs.readFileSync(path, 'utf8');
-      const decryptedString: string = CryptoJS.AES.decrypt(encryptedString, password).toString(CryptoJS.enc.Hex);
-      buf = Buffer.from(decryptedString, 'hex');
-    } else {
-      buf = fs.readFileSync(path);
-    }
+  private static fromFile = (path: string, password?: string): Promise<NodeKey> => {
+    return new Promise(async (resolve, reject) => {
+      let buf = await readFile(path);
 
-    if (secp256k1.privateKeyVerify(buf)) {
-      return new NodeKey(buf);
-    } else {
-      throw new Error(`${path} does not contain a valid ECDSA private key`);
-    }
+      if (password) {
+        const encryptedString = buf.toString('utf8');
+        const decryptedString = CryptoJS.AES.decrypt(encryptedString, password).toString(CryptoJS.enc.Hex);
+        buf = Buffer.from(decryptedString, 'hex');
+      }
+
+      if (secp256k1.privateKeyVerify(buf)) {
+        resolve(new NodeKey(buf));
+      } else {
+        reject(new Error(`${path} does not contain a valid ECDSA private key`));
+      }
+    });
   }
 
   /**
-   * Load a node key from a file or create one if none exists. See [[fromFile]] and [[generate]].
+   * Loads a node key from a file or create one if none exists. See [[fromFile]] and [[generate]].
    */
-  public static load = (xudir: string, instanceId = 0): NodeKey => {
+  public static load = async (xudir: string, instanceId = 0): Promise<NodeKey> => {
     const path: string = instanceId > 0
       ? `${xudir}/nodekey_${instanceId}.dat`
       : `${xudir}/nodekey.dat`;
 
     let nodeKey: NodeKey;
-    if (fs.existsSync(path)) {
-      nodeKey = NodeKey.fromFile(path);
+    if (await exists(path)) {
+      nodeKey = await NodeKey.fromFile(path);
     } else {
-      nodeKey = NodeKey.generate();
-      nodeKey.toFile(path);
+      nodeKey = await NodeKey.generate();
+      await nodeKey.toFile(path);
     }
     return nodeKey;
   }
 
   /**
-   * Sign a message with the private key.
+   * Signs a message with the private key.
    * @param msg the data to sign
    * @returns the signature
    */
@@ -82,11 +83,11 @@ class NodeKey {
   }
 
   /**
-   * Save the private key to a file, optionally encrypted by a password.
+   * Saves the private key to a file, optionally encrypted by a password.
    * @param path the path at which to save the file
    * @param password an optional password parameter for encrypting the private key
    */
-  private toFile = (path: string, password?: string): void => {
+  private toFile = (path: string, password?: string): Promise<void> => {
     let buf: Buffer | CryptoJS.WordArray;
     if (password) {
       const lwa = CryptoJS.lib.WordArray.create(this.privKey.buffer);
@@ -94,7 +95,7 @@ class NodeKey {
     } else {
       buf = this.privKey;
     }
-    fs.writeFileSync(path, buf);
+    return writeFile(path, buf);
   }
 }
 

--- a/lib/utils/fsUtils.ts
+++ b/lib/utils/fsUtils.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import { promisify } from 'util';
+
+// Promisified wrappers for file system methods - only required for support for NodeJS v9 and older
+// NodeJS v10 provides promisified file system methods out of the box
+
+/** A promisified wrapper for the NodeJS `fs.readFile` method. */
+export const readFile = promisify(fs.readFile);
+
+/** A promisified wrapper for the NodeJS `fs.mkdir` method. */
+export const mkdir = promisify(fs.mkdir);
+
+/** A promisified wrapper for the NodeJS `fs.exists` method. */
+export const exists = promisify(fs.exists);
+
+/** A promisified wrapper for the NodeJS `fs.readdir` method. */
+export const readdir = promisify(fs.readdir);
+
+/** A promisified wrapper for the NodeJS `fs.writeFile` method. */
+export const writeFile = promisify(fs.writeFile);

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -2,6 +2,8 @@ import http from 'http';
 import p2pErrors from '../p2p/errors';
 import { assert } from 'chai';
 import { Pair } from '../types/orders';
+import crypto from 'crypto';
+import { promisify } from 'util';
 
 export type UriParts = {
   nodePubKey: string;
@@ -170,3 +172,6 @@ export const isPlainObject = (obj: any) => {
   }
   return Object.getPrototypeOf(obj) === proto;
 };
+
+/** A promisified wrapper for the NodeJS `crypto.randomBytes` method. */
+export const randomBytes = promisify(crypto.randomBytes);

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -10,11 +10,11 @@ import { Address } from '../../lib/types/p2p';
 
 chai.use(chaiAsPromised);
 
-describe('P2P Pool Tests', () => {
+describe('P2P Pool Tests', async () => {
   let db: DB;
   let pool: Pool;
   const loggers = Logger.createLoggers(Level.Warn);
-  const nodePubKeyOne = NodeKey['generate']().nodePubKey;
+  const nodePubKeyOne = (await NodeKey['generate']()).nodePubKey;
 
   const createPeer = (nodePubKey: string, addresses: Address[]) => {
     const peer = new Peer(loggers.p2p, addresses[0]);

--- a/test/unit/NodeKey.spec.ts
+++ b/test/unit/NodeKey.spec.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
+import NodeKey from '../../lib/nodekey/NodeKey';
+import secp256k1 from 'secp256k1';
+
+describe('NodeKey', () => {
+  it('should generate a valid node key', async () => {
+    const nodeKey = await NodeKey['generate']();
+    expect(nodeKey.nodePubKey).to.have.length(66);
+    expect(secp256k1.privateKeyVerify(nodeKey['privKey'])).to.be.true;
+    expect(secp256k1.publicKeyVerify(Buffer.from(nodeKey.nodePubKey, 'hex'))).to.be.true;
+  });
+});


### PR DESCRIPTION
This replaces all synchronous calls to the NodeJS `fs` and `crypto.randomBytes` methods with asynchronous calls. This improves performance by preventing blocking of the event loop. I was inspired after reading [Don't Block the Event Loop](https://nodejs.org/en/docs/guides/dont-block-the-event-loop/). Most of the benefit is during startup/initialization, but there should also be a small benefit when proposing swaps which should happen quite frequently. 

I also added a test suite for NodeKey.ts, I was primarily motivated by having a quick way to test that the async `crypto.randomBytes` call was working but it would also be good expand in the future.