### PR TITLE
 feat(db): set null price for market orders

### DIFF
--- a/lib/db/models/Order.ts
+++ b/lib/db/models/Order.ts
@@ -6,9 +6,19 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
     id: { type: DataTypes.STRING, primaryKey: true, allowNull: false },
     nodeId: { type: DataTypes.INTEGER, allowNull: true },
     localId: { type: DataTypes.STRING, allowNull: true },
-    initialQuantity: { type: DataTypes.DECIMAL(8), allowNull: true },
+    initialQuantity: { type: DataTypes.DECIMAL(8), allowNull: false },
     pairId: { type: DataTypes.STRING, allowNull: false },
-    price: { type: DataTypes.DECIMAL(8), allowNull: true },
+    price: {
+      type: DataTypes.DECIMAL(8),
+      allowNull: true,
+      set(this: db.OrderInstance, value: number) {
+        if (value === 0 || value === Number.MAX_VALUE) {
+          this.setDataValue('price', undefined);
+        } else {
+          this.setDataValue('price', value);
+        }
+      },
+    },
     isBuy: { type: DataTypes.BOOLEAN, allowNull: false },
     createdAt: { type: DataTypes.BIGINT, allowNull: false },
   };

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -131,6 +131,39 @@ describe('Database', () => {
     expect(node.nodePubKey).to.equal(peerPubKey);
   });
 
+  it('should add market orders and have their price in db be null', async () => {
+    const buyMarketOrder: OwnOrder = {
+      quantity,
+      price: Number.MAX_VALUE,
+      isBuy: true,
+      createdAt: ms(),
+      initialQuantity: quantity,
+      id: uuidv1(),
+      localId: uuidv1(),
+      pairId: PAIR_ID,
+      hold: 0,
+    };
+    const sellMarketOrder: OwnOrder = {
+      quantity,
+      price: 0,
+      isBuy: true,
+      createdAt: ms(),
+      initialQuantity: quantity,
+      id: uuidv1(),
+      localId: uuidv1(),
+      pairId: PAIR_ID,
+      hold: 0,
+    };
+    await orderBookRepo.addOrderIfNotExists(buyMarketOrder);
+    await orderBookRepo.addOrderIfNotExists(sellMarketOrder);
+    const buyOrder = (await db.models.Order.findById(buyMarketOrder.id))!;
+    const sellOrder = (await db.models.Order.findById(sellMarketOrder.id))!;
+    expect(buyOrder.id).to.equal(buyMarketOrder.id);
+    expect(sellOrder.id).to.equal(sellMarketOrder.id);
+    expect(buyOrder.price).to.be.null;
+    expect(sellOrder.price).to.be.null;
+  });
+
   after(async () => {
     await db.close();
   });


### PR DESCRIPTION
This sets the price for market orders as db null when they get saved to the database. We use prices the max number value and 0 for buy and sell orders internally, respectively. This can be helpful for matching purposes but it does not need to be stored in the databases.