### PR TITLE
Docker auto-generated files added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ dist/
 # typedoc
 typedoc/
 .DS_Store
+
+# Docker auto-generated files
+docker/xud/nodekey.dat
+docker/xud/tls.cert
+docker/xud/tls.key
+docker/xud/xud.db


### PR DESCRIPTION
Here's the auto-generated files as in https://github.com/ExchangeUnion/xud-wiki/blob/7c561a22663ba6590f68baa9c094085a0cf921c5/Docker.md

```
git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   package-lock.json

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	docker/xud/nodekey.dat
	docker/xud/tls.cert
	docker/xud/tls.key
	docker/xud/xud.db

no changes added to commit (use "git add" and/or "git commit -a")
```
I believe it's okay to not gitignore the `package-lock.json` file. However, please correct me if wrong if that's not the case for the Docker-generated files in the `docker/xud` folder.