### PR TITLE
fix(lnd): don't default lnd clients as disabled

### DIFF
--- a/lib/BaseClient.ts
+++ b/lib/BaseClient.ts
@@ -2,6 +2,7 @@ import Logger from './Logger';
 import { EventEmitter } from 'events';
 
 enum ClientStatus {
+  NotInitialized,
   Disabled,
   Disconnected,
   ConnectionVerified,
@@ -12,7 +13,7 @@ enum ClientStatus {
  * A base class to represent a client for an external service such as LND or Raiden.
  */
 abstract class BaseClient extends EventEmitter {
-  protected status: ClientStatus = ClientStatus.Disabled;
+  protected status: ClientStatus = ClientStatus.NotInitialized;
 
   constructor(protected logger: Logger) {
     super();

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -70,15 +70,11 @@ class Xud extends EventEmitter {
       this.db = new DB(loggers.db, this.config.dbpath);
       await this.db.init(this.config.initdb);
 
-      // setup LND clients and connect if configured
+      // setup LND clients and initialize
       this.lndbtcClient = new LndClient(this.config.lndbtc, loggers.lnd);
-      if (!this.lndbtcClient.isDisabled()) {
-        initPromises.push(this.lndbtcClient.init());
-      }
+      initPromises.push(this.lndbtcClient.init());
       this.lndltcClient = new LndClient(this.config.lndltc, loggers.lnd);
-      if (!this.lndltcClient.isDisabled()) {
-        initPromises.push(this.lndltcClient.init());
-      }
+      initPromises.push(this.lndltcClient.init());
 
       // setup raiden client and connect if configured
       this.raidenClient = new RaidenClient(this.config.raiden, loggers.raiden);

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -112,8 +112,8 @@ class RaidenClient extends BaseClient {
     this.port = port;
     this.host = host;
 
-    if (!disable) {
-      this.setStatus(ClientStatus.Disconnected);
+    if (disable) {
+      this.setStatus(ClientStatus.Disabled);
     }
   }
 


### PR DESCRIPTION
This fixes a bug introduced in #672 whereby the lnd clients are not properly initializing. That PR removed synchronous calls to methods that had asynchronous alternatives, which necessitated moving code from the synchronous `LndClient` constructor to an asynchronous init method.

Included in the code that was moved was logic to determine whether to change the client's status from the default value of `Disabled`. This impacted the xud initialization procedure which would only attempt
to initialize (or previously verify a connection for) an lnd client that was not disabled.

This PR creates a new `NotInitialized` status as the default to reflect the status of a newly created client. It gets changed when the `init` method is called.