### PR TITLE
feat(rpc): add currencies to swap result

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -793,6 +793,8 @@
 | amount_sent | [int64](#int64) |  | The amount of subunits (satoshis) sent. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer that executed this order. |
 | role | [SwapResult.Role](#xudrpc.SwapResult.Role) |  | Our role in the swap, either MAKER or TAKER. |
+| currency_received | [string](#string) |  | The ticker symbol of the currency received. |
+| currency_sent | [string](#string) |  | The ticker symbol of the currency sent. |
 
 
 

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -47,6 +47,8 @@ const createSwapResult = (result: SwapResult) => {
   swapResult.setRHash(result.rHash);
   swapResult.setAmountReceived(result.amountReceived);
   swapResult.setAmountSent(result.amountSent);
+  swapResult.setCurrencyReceived(result.currencyReceived);
+  swapResult.setCurrencySent(result.currencySent);
   swapResult.setPeerPubKey(result.peerPubKey);
   swapResult.setRole(result.role as number);
   return swapResult;

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1147,6 +1147,14 @@
         "role": {
           "$ref": "#/definitions/SwapResultRole",
           "description": "Our role in the swap, either MAKER or TAKER."
+        },
+        "currency_received": {
+          "type": "string",
+          "description": "The ticker symbol of the currency received."
+        },
+        "currency_sent": {
+          "type": "string",
+          "description": "The ticker symbol of the currency sent."
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -1263,6 +1263,12 @@ export class SwapResult extends jspb.Message {
     getRole(): SwapResult.Role;
     setRole(value: SwapResult.Role): void;
 
+    getCurrencyReceived(): string;
+    setCurrencyReceived(value: string): void;
+
+    getCurrencySent(): string;
+    setCurrencySent(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SwapResult.AsObject;
@@ -1285,6 +1291,8 @@ export namespace SwapResult {
         amountSent: number,
         peerPubKey: string,
         role: SwapResult.Role,
+        currencyReceived: string,
+        currencySent: string,
     }
 
     export enum Role {

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -8319,7 +8319,9 @@ proto.xudrpc.SwapResult.toObject = function(includeInstance, msg) {
     amountReceived: jspb.Message.getFieldWithDefault(msg, 6, 0),
     amountSent: jspb.Message.getFieldWithDefault(msg, 7, 0),
     peerPubKey: jspb.Message.getFieldWithDefault(msg, 8, ""),
-    role: jspb.Message.getFieldWithDefault(msg, 9, 0)
+    role: jspb.Message.getFieldWithDefault(msg, 9, 0),
+    currencyReceived: jspb.Message.getFieldWithDefault(msg, 10, ""),
+    currencySent: jspb.Message.getFieldWithDefault(msg, 11, "")
   };
 
   if (includeInstance) {
@@ -8391,6 +8393,14 @@ proto.xudrpc.SwapResult.deserializeBinaryFromReader = function(msg, reader) {
     case 9:
       var value = /** @type {!proto.xudrpc.SwapResult.Role} */ (reader.readEnum());
       msg.setRole(value);
+      break;
+    case 10:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCurrencyReceived(value);
+      break;
+    case 11:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCurrencySent(value);
       break;
     default:
       reader.skipField();
@@ -8481,6 +8491,20 @@ proto.xudrpc.SwapResult.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0.0) {
     writer.writeEnum(
       9,
+      f
+    );
+  }
+  f = message.getCurrencyReceived();
+  if (f.length > 0) {
+    writer.writeString(
+      10,
+      f
+    );
+  }
+  f = message.getCurrencySent();
+  if (f.length > 0) {
+    writer.writeString(
+      11,
       f
     );
   }
@@ -8627,6 +8651,36 @@ proto.xudrpc.SwapResult.prototype.getRole = function() {
 /** @param {!proto.xudrpc.SwapResult.Role} value */
 proto.xudrpc.SwapResult.prototype.setRole = function(value) {
   jspb.Message.setField(this, 9, value);
+};
+
+
+/**
+ * optional string currency_received = 10;
+ * @return {string}
+ */
+proto.xudrpc.SwapResult.prototype.getCurrencyReceived = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 10, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.SwapResult.prototype.setCurrencyReceived = function(value) {
+  jspb.Message.setField(this, 10, value);
+};
+
+
+/**
+ * optional string currency_sent = 11;
+ * @return {string}
+ */
+proto.xudrpc.SwapResult.prototype.getCurrencySent = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 11, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.SwapResult.prototype.setCurrencySent = function(value) {
+  jspb.Message.setField(this, 11, value);
 };
 
 

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -699,13 +699,16 @@ class Swaps extends EventEmitter {
     deal.phase = newPhase;
 
     if (deal.phase === SwapPhase.AmountReceived) {
+      const wasMaker = deal.role === SwapRole.Maker;
       const swapResult = {
         orderId: deal.orderId,
         localId: deal.localId,
         pairId: deal.pairId,
         quantity: deal.quantity!,
-        amountReceived: deal.role === SwapRole.Maker ? deal.makerAmount : deal.takerAmount,
-        amountSent: deal.role === SwapRole.Maker ? deal.takerAmount : deal.makerAmount,
+        amountReceived: wasMaker ? deal.makerAmount : deal.takerAmount,
+        amountSent: wasMaker ? deal.takerAmount : deal.makerAmount,
+        currencyReceived: wasMaker ? deal.makerCurrency : deal.takerCurrency,
+        currencySent: wasMaker ? deal.takerCurrency : deal.makerCurrency,
         rHash: deal.rHash,
         peerPubKey: deal.peerPubKey,
         role: deal.role,

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -60,6 +60,10 @@ export type SwapResult = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'rHas
   amountReceived: number;
   /** The amount of satoshis (or equivalent) sent. */
   amountSent: number;
+  /** The ticker symbol of the currency received. */
+  currencyReceived: string;
+  /** The ticker symbol of the currency sent. */
+  currencySent: string;
   /** The quantity that was swapped. */
   quantity: number;
 };

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -531,6 +531,10 @@ message SwapResult {
   }
   // Our role in the swap, either MAKER or TAKER.
   Role role = 9 [json_name = "role"];
+  // The ticker symbol of the currency received.
+  string currency_received = 10 [json_name = "currency_received"];
+  // The ticker symbol of the currency sent.
+  string currency_sent = 11 [json_name = "currency_sent"];
 }
 
 message UnbanRequest {

--- a/test/integration/Swap.spec.ts
+++ b/test/integration/Swap.spec.ts
@@ -8,6 +8,7 @@ import LndClient from '../../lib/lndclient/LndClient';
 import Logger, { Level } from '../../lib/Logger';
 import DB from '../../lib/db/DB';
 import { waitForSpy } from '../utils';
+import { SwapResult } from '../../lib/swaps/types';
 
 chai.use(chaiAsPromised);
 
@@ -46,6 +47,8 @@ const validSwapResult = () => {
     quantity: 0.00001,
     amountReceived: 1000,
     amountSent: 8,
+    currencyReceived: 'LTC',
+    currencySent: 'BTC',
     rHash: 'd94c22a73d2741ed5cdcf3714f9ab3c8664793b03a54c74a08877726007d67c2',
     peerPubKey: '020c9a0fb8dac5b91756fb21509aefc4e95b585510c4de6e6311f18348a4723cdd',
     role: 0,


### PR DESCRIPTION
This adds `currency_received` and `currency_sent` to the gRPC `SwapResult` message. Without these fields, it is not possible to tell from the swap result alone which currency was send or received by either party.

Closes #670.