### PR TITLE
feat(orderbook): don’t match with quantity on hold

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -342,7 +342,9 @@ class TradingPair {
           map.delete(makerOrder.id);
           this.logger.debug(`removed order ${makerOrder.id} while matching order ${takerOrder.id}`);
         } else if (makerAvailableQuantityFullyMatched) {
+          // only an own order can be fully matched for available quantity, but not fully matched in the overall
           assert(isOwnOrder(makerOrder));
+
           assert(queue.poll() === makerOrder);
           queueRemovedOrdersWithHold.push(makerOrder as OwnOrder);
         }

--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -303,7 +303,7 @@ class TradingPair {
       const makerOrder = queue.peek()!;
       const makerAvailableQuantityOrder = isOwnOrder(makerOrder)
         ? { ...makerOrder, quantity: makerOrder.quantity - makerOrder.hold, hold: 0 }
-        : { ...makerOrder };
+        : makerOrder;
 
       const matchingQuantity = getMatchingQuantity(remainingOrder, makerAvailableQuantityOrder);
       if (matchingQuantity <= 0) {
@@ -323,7 +323,7 @@ class TradingPair {
           const matchedMakerOrder = TradingPair.splitOrderByQuantity(makerOrder, matchingQuantity);
           this.logger.debug(`reduced order ${makerOrder.id} by ${matchingQuantity} quantity while matching order ${takerOrder.id}`);
           matches.push({ maker: matchedMakerOrder, taker: remainingOrder });
-        } else if (makerFullyMatched || makerAvailableQuantityFullyMatched) {
+        } else if (makerAvailableQuantityFullyMatched) {
           // maker order quantity is not sufficient. taker order will split
           const matchedTakerOrder = TradingPair.splitOrderByQuantity(remainingOrder, matchingQuantity);
           matches.push({ maker: makerAvailableQuantityOrder, taker: matchedTakerOrder });

--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -303,7 +303,7 @@ class TradingPair {
       const makerOrder = queue.peek()!;
       const makerAvailableQuantityOrder = isOwnOrder(makerOrder)
         ? { ...makerOrder, quantity: makerOrder.quantity - makerOrder.hold, hold: 0 }
-        : { ...makerOrder }
+        : { ...makerOrder };
 
       const matchingQuantity = getMatchingQuantity(remainingOrder, makerAvailableQuantityOrder);
       if (matchingQuantity <= 0) {
@@ -342,16 +342,16 @@ class TradingPair {
           map.delete(makerOrder.id);
           this.logger.debug(`removed order ${makerOrder.id} while matching order ${takerOrder.id}`);
         } else if (makerAvailableQuantityFullyMatched) {
-          assert(isOwnOrder(makerOrder))
+          assert(isOwnOrder(makerOrder));
           assert(queue.poll() === makerOrder);
-          queueRemovedOrdersWithHold.push(makerOrder as OwnOrder)
+          queueRemovedOrdersWithHold.push(makerOrder as OwnOrder);
         }
       }
     }
 
     // return the removed orders with hold to the queue.
     // their hold quantity might be released later
-    queueRemovedOrdersWithHold.forEach(order => queue.add(order))
+    queueRemovedOrdersWithHold.forEach(order => queue.add(order));
 
     return { matches, remainingOrder };
   }

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -190,6 +190,61 @@ describe('TradingPair.match', () => {
     expect(peekResult).to.not.be.undefined;
     expect(peekResult!.quantity).to.equal(1);
   });
+
+  it('should not match maker own order hold quantity', () => {
+    const ownOrder = createOwnOrder(5, 5, false)
+    tp.addOwnOrder(ownOrder);
+    tp.addOrderHold(ownOrder.id, 5)
+
+    const { matches, remainingOrder } = tp.match(createOwnOrder(5, 5, true));
+    expect(remainingOrder).to.not.be.undefined
+    expect(remainingOrder!.quantity).to.equal(5)
+    expect(matches.length).to.be.equal(0)
+  });
+
+  it('should not match maker own order hold quantity, and should split the taker order', () => {
+    const ownOrder = createOwnOrder(5, 5, false)
+    tp.addOwnOrder(ownOrder);
+    tp.addOrderHold(ownOrder.id, 3)
+
+    const { matches, remainingOrder } = tp.match(createOwnOrder(5, 5, true));
+    expect(remainingOrder).to.not.be.undefined
+    expect(remainingOrder!.quantity).to.equal(3)
+    expect(matches.length).to.be.equal(1)
+    expect(matches[0].maker.quantity).to.be.equal(2)
+    expect(matches[0].taker.quantity).to.be.equal(2)
+  });
+
+  it('should not match maker own order hold quantity, and should fully match the taker order', () => {
+    const ownOrder = createOwnOrder(5, 5, false)
+    tp.addOwnOrder(ownOrder);
+    tp.addOrderHold(ownOrder.id, 3)
+
+    const { matches, remainingOrder } = tp.match(createOwnOrder(5, 2, true));
+    expect(remainingOrder).to.be.undefined
+    expect(matches.length).to.be.equal(1)
+    expect(matches[0].maker.quantity).to.be.equal(2)
+    expect(matches[0].taker.quantity).to.be.equal(2)
+  });
+
+  it('should not match maker own order hold quantity, but keep the order for the next match', () => {
+    const ownOrder = createOwnOrder(5, 5, false)
+    tp.addOwnOrder(ownOrder);
+    tp.addOrderHold(ownOrder.id, 5)
+
+    let mr = tp.match(createOwnOrder(5, 5, true));
+    expect(mr.remainingOrder).to.not.be.undefined
+    expect(mr.remainingOrder!.quantity).to.equal(5)
+    expect(mr.matches.length).to.be.equal(0)
+
+    tp.removeOrderHold(ownOrder.id, 5)
+
+    mr = tp.match(createOwnOrder(5, 5, true));
+    expect(mr.remainingOrder).to.be.undefined
+    expect(mr.matches.length).to.be.equal(1)
+    expect(mr.matches[0].maker.quantity).to.be.equal(5)
+    expect(mr.matches[0].taker.quantity).to.be.equal(5)
+  });
 });
 
 describe('TradingPair.removeOwnOrder', () => {
@@ -391,3 +446,4 @@ describe('TradingPair.addOrderHold & TradingPair.removeOrderHold', () => {
     expect(() => tp.removeOrderHold(ownOrder.id, 3)).to.throw('cannot remove more than is currently on hold for an order');
   });
 });
+

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -192,58 +192,58 @@ describe('TradingPair.match', () => {
   });
 
   it('should not match maker own order hold quantity', () => {
-    const ownOrder = createOwnOrder(5, 5, false)
+    const ownOrder = createOwnOrder(5, 5, false);
     tp.addOwnOrder(ownOrder);
-    tp.addOrderHold(ownOrder.id, 5)
+    tp.addOrderHold(ownOrder.id, 5);
 
     const { matches, remainingOrder } = tp.match(createOwnOrder(5, 5, true));
-    expect(remainingOrder).to.not.be.undefined
-    expect(remainingOrder!.quantity).to.equal(5)
-    expect(matches.length).to.be.equal(0)
+    expect(remainingOrder).to.not.be.undefined;
+    expect(remainingOrder!.quantity).to.equal(5);
+    expect(matches.length).to.be.equal(0);
   });
 
   it('should not match maker own order hold quantity, and should split the taker order', () => {
-    const ownOrder = createOwnOrder(5, 5, false)
+    const ownOrder = createOwnOrder(5, 5, false);
     tp.addOwnOrder(ownOrder);
-    tp.addOrderHold(ownOrder.id, 3)
+    tp.addOrderHold(ownOrder.id, 3);
 
     const { matches, remainingOrder } = tp.match(createOwnOrder(5, 5, true));
-    expect(remainingOrder).to.not.be.undefined
-    expect(remainingOrder!.quantity).to.equal(3)
-    expect(matches.length).to.be.equal(1)
-    expect(matches[0].maker.quantity).to.be.equal(2)
-    expect(matches[0].taker.quantity).to.be.equal(2)
+    expect(remainingOrder).to.not.be.undefined;
+    expect(remainingOrder!.quantity).to.equal(3);
+    expect(matches.length).to.be.equal(1);
+    expect(matches[0].maker.quantity).to.be.equal(2);
+    expect(matches[0].taker.quantity).to.be.equal(2);
   });
 
   it('should not match maker own order hold quantity, and should fully match the taker order', () => {
-    const ownOrder = createOwnOrder(5, 5, false)
+    const ownOrder = createOwnOrder(5, 5, false);
     tp.addOwnOrder(ownOrder);
-    tp.addOrderHold(ownOrder.id, 3)
+    tp.addOrderHold(ownOrder.id, 3);
 
     const { matches, remainingOrder } = tp.match(createOwnOrder(5, 2, true));
-    expect(remainingOrder).to.be.undefined
-    expect(matches.length).to.be.equal(1)
-    expect(matches[0].maker.quantity).to.be.equal(2)
-    expect(matches[0].taker.quantity).to.be.equal(2)
+    expect(remainingOrder).to.be.undefined;
+    expect(matches.length).to.be.equal(1);
+    expect(matches[0].maker.quantity).to.be.equal(2);
+    expect(matches[0].taker.quantity).to.be.equal(2);
   });
 
   it('should not match maker own order hold quantity, but keep the order for the next match', () => {
-    const ownOrder = createOwnOrder(5, 5, false)
+    const ownOrder = createOwnOrder(5, 5, false);
     tp.addOwnOrder(ownOrder);
-    tp.addOrderHold(ownOrder.id, 5)
+    tp.addOrderHold(ownOrder.id, 5);
 
     let mr = tp.match(createOwnOrder(5, 5, true));
-    expect(mr.remainingOrder).to.not.be.undefined
-    expect(mr.remainingOrder!.quantity).to.equal(5)
-    expect(mr.matches.length).to.be.equal(0)
+    expect(mr.remainingOrder).to.not.be.undefined;
+    expect(mr.remainingOrder!.quantity).to.equal(5);
+    expect(mr.matches.length).to.be.equal(0);
 
-    tp.removeOrderHold(ownOrder.id, 5)
+    tp.removeOrderHold(ownOrder.id, 5);
 
     mr = tp.match(createOwnOrder(5, 5, true));
-    expect(mr.remainingOrder).to.be.undefined
-    expect(mr.matches.length).to.be.equal(1)
-    expect(mr.matches[0].maker.quantity).to.be.equal(5)
-    expect(mr.matches[0].taker.quantity).to.be.equal(5)
+    expect(mr.remainingOrder).to.be.undefined;
+    expect(mr.matches.length).to.be.equal(1);
+    expect(mr.matches[0].maker.quantity).to.be.equal(5);
+    expect(mr.matches[0].taker.quantity).to.be.equal(5);
   });
 });
 
@@ -446,4 +446,3 @@ describe('TradingPair.addOrderHold & TradingPair.removeOrderHold', () => {
     expect(() => tp.removeOrderHold(ownOrder.id, 3)).to.throw('cannot remove more than is currently on hold for an order');
   });
 });
-


### PR DESCRIPTION
Closes #666 

If maker own order has quantity on hold, don't match it, but keep the order in the queue for the next match. 