### PR TITLE
 feat(rpc/orderbook): handle remove order with hold

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -699,7 +699,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| hold | [double](#double) |  | Any portion of the order that was on hold due to ongoing swaps at the time of the request and could not be removed until after the swaps finish. |
+| quantity_on_hold | [double](#double) |  | Any portion of the order that was on hold due to ongoing swaps at the time of the request and could not be removed until after the swaps finish. |
 
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -697,6 +697,11 @@
 
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| hold | [double](#double) |  | Any portion of the order that was on hold due to ongoing swaps at the time of the request and could not be removed until after the swaps finish. |
+
+
 
 
 
@@ -878,7 +883,7 @@
 | ----------- | ------------ | ------------- | ------------|
 | AddCurrency | [AddCurrencyRequest](#xudrpc.AddCurrencyRequest) | [AddCurrencyResponse](#xudrpc.AddCurrencyResponse) | Adds a currency to the list of supported currencies. Once added, the currency may be used for new trading pairs. |
 | AddPair | [AddPairRequest](#xudrpc.AddPairRequest) | [AddPairResponse](#xudrpc.AddPairResponse) | Adds a trading pair to the list of supported trading pairs. The newly supported pair is advertised to peers so they may begin sending orders for it. |
-| RemoveOrder | [RemoveOrderRequest](#xudrpc.RemoveOrderRequest) | [RemoveOrderResponse](#xudrpc.RemoveOrderResponse) | Removes an order from the order book by its local id. This should be called when an order is canceled or filled outside of xud. Removed orders become immediately unavailable for swaps, and peers are notified that the order is no longer valid. |
+| RemoveOrder | [RemoveOrderRequest](#xudrpc.RemoveOrderRequest) | [RemoveOrderResponse](#xudrpc.RemoveOrderResponse) | Removes an order from the order book by its local id. This should be called when an order is canceled or filled outside of xud. Removed orders become immediately unavailable for swaps, and peers are notified that the order is no longer valid. Any portion of the order that is on hold due to ongoing swaps will not be removed until after the swap attempts complete. |
 | ChannelBalance | [ChannelBalanceRequest](#xudrpc.ChannelBalanceRequest) | [ChannelBalanceResponse](#xudrpc.ChannelBalanceResponse) | Gets the total balance available across all payment channels for one or all currencies. |
 | Connect | [ConnectRequest](#xudrpc.ConnectRequest) | [ConnectResponse](#xudrpc.ConnectResponse) | Attempts to connect to a node. Once connected, the node is added to the list of peers and becomes available for swaps and trading. A handshake exchanges information about the peer&#39;s supported trading and swap clients. Orders will be shared with the peer upon connection and upon new order placements. |
 | Ban | [BanRequest](#xudrpc.BanRequest) | [BanResponse](#xudrpc.BanResponse) | Bans a node and immediately disconnects from it. This can be used to prevent any connections to a specific node. |

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -185,9 +185,9 @@ class GrpcService {
    */
   public removeOrder: grpc.handleUnaryCall<xudrpc.RemoveOrderRequest, xudrpc.RemoveOrderResponse> = async (call, callback) => {
     try {
-      const hold = this.service.removeOrder(call.request.toObject());
+      const quantityOnHold = this.service.removeOrder(call.request.toObject());
       const response = new xudrpc.RemoveOrderResponse();
-      response.setHold(hold);
+      response.setQuantityOnHold(quantityOnHold);
       callback(null, response);
     } catch (err) {
       callback(this.getGrpcError(err), null);

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -185,8 +185,9 @@ class GrpcService {
    */
   public removeOrder: grpc.handleUnaryCall<xudrpc.RemoveOrderRequest, xudrpc.RemoveOrderResponse> = async (call, callback) => {
     try {
-      await this.service.removeOrder(call.request.toObject());
+      const hold = this.service.removeOrder(call.request.toObject());
       const response = new xudrpc.RemoveOrderResponse();
+      response.setHold(hold);
       callback(null, response);
     } catch (err) {
       callback(this.getGrpcError(err), null);

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -443,6 +443,7 @@ class OrderBook extends EventEmitter {
     if (order.hold) {
       let remainingHold = order.hold;
       // we can't remove the entire order as some of it is on hold, start by removing any available portion
+      this.logger.debug(`can't remove local order ${localId} yet because it has a hold of ${order.hold}`);
       const availableQuantity = order.quantity - order.hold;
       if (availableQuantity) {
         this.removeOwnOrder(orderIdentifier.id, orderIdentifier.pairId, availableQuantity);
@@ -450,6 +451,7 @@ class OrderBook extends EventEmitter {
 
       const cleanup = (quantity: number) => {
         remainingHold -= quantity;
+        this.logger.debug(`removed hold of ${quantity} on local order ${localId}, ${remainingHold} remaining`);
         if (remainingHold === 0) {
           // we can stop listening for swaps once all holds are cleared
           this.swaps!.removeListener('swap.failed', failedHandler);

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1088,7 +1088,7 @@
     "xudrpcRemoveOrderResponse": {
       "type": "object",
       "properties": {
-        "hold": {
+        "quantity_on_hold": {
           "type": "number",
           "format": "double",
           "description": "Any portion of the order that was on hold due to ongoing swaps at the time of the request\nand could not be removed until after the swaps finish."

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -387,7 +387,7 @@
     },
     "/v1/removeorder": {
       "post": {
-        "summary": "Removes an order from the order book by its local id. This should be called when an order is\ncanceled or filled outside of xud. Removed orders become immediately unavailable for swaps,\nand peers are notified that the order is no longer valid.",
+        "summary": "Removes an order from the order book by its local id. This should be called when an order is\ncanceled or filled outside of xud. Removed orders become immediately unavailable for swaps,\nand peers are notified that the order is no longer valid. Any portion of the order that is \non hold due to ongoing swaps will not be removed until after the swap attempts complete.",
         "operationId": "RemoveOrder",
         "responses": {
           "200": {
@@ -1086,7 +1086,14 @@
       }
     },
     "xudrpcRemoveOrderResponse": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "hold": {
+          "type": "number",
+          "format": "double",
+          "description": "Any portion of the order that was on hold due to ongoing swaps at the time of the request\nand could not be removed until after the swaps finish."
+        }
+      }
     },
     "xudrpcRemovePairRequest": {
       "type": "object",

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -518,7 +518,8 @@ var XudService = exports.XudService = {
   },
   // Removes an order from the order book by its local id. This should be called when an order is
   // canceled or filled outside of xud. Removed orders become immediately unavailable for swaps,
-  // and peers are notified that the order is no longer valid. 
+  // and peers are notified that the order is no longer valid. Any portion of the order that is 
+  // on hold due to ongoing swaps will not be removed until after the swap attempts complete. 
   removeOrder: {
     path: '/xudrpc.Xud/RemoveOrder',
     requestStream: false,

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -126,8 +126,8 @@ export namespace RemoveOrderRequest {
 }
 
 export class RemoveOrderResponse extends jspb.Message { 
-    getHold(): number;
-    setHold(value: number): void;
+    getQuantityOnHold(): number;
+    setQuantityOnHold(value: number): void;
 
 
     serializeBinary(): Uint8Array;
@@ -142,7 +142,7 @@ export class RemoveOrderResponse extends jspb.Message {
 
 export namespace RemoveOrderResponse {
     export type AsObject = {
-        hold: number,
+        quantityOnHold: number,
     }
 }
 

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -126,6 +126,9 @@ export namespace RemoveOrderRequest {
 }
 
 export class RemoveOrderResponse extends jspb.Message { 
+    getHold(): number;
+    setHold(value: number): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): RemoveOrderResponse.AsObject;
@@ -139,6 +142,7 @@ export class RemoveOrderResponse extends jspb.Message {
 
 export namespace RemoveOrderResponse {
     export type AsObject = {
+        hold: number,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -885,7 +885,7 @@ proto.xudrpc.RemoveOrderResponse.prototype.toObject = function(opt_includeInstan
  */
 proto.xudrpc.RemoveOrderResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    hold: +jspb.Message.getFieldWithDefault(msg, 1, 0.0)
+    quantityOnHold: +jspb.Message.getFieldWithDefault(msg, 1, 0.0)
   };
 
   if (includeInstance) {
@@ -924,7 +924,7 @@ proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader = function(msg, rea
     switch (field) {
     case 1:
       var value = /** @type {number} */ (reader.readDouble());
-      msg.setHold(value);
+      msg.setQuantityOnHold(value);
       break;
     default:
       reader.skipField();
@@ -955,7 +955,7 @@ proto.xudrpc.RemoveOrderResponse.prototype.serializeBinary = function() {
  */
 proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getHold();
+  f = message.getQuantityOnHold();
   if (f !== 0.0) {
     writer.writeDouble(
       1,
@@ -966,16 +966,16 @@ proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter = function(message, wri
 
 
 /**
- * optional double hold = 1;
+ * optional double quantity_on_hold = 1;
  * @return {number}
  */
-proto.xudrpc.RemoveOrderResponse.prototype.getHold = function() {
+proto.xudrpc.RemoveOrderResponse.prototype.getQuantityOnHold = function() {
   return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 1, 0.0));
 };
 
 
 /** @param {number} value */
-proto.xudrpc.RemoveOrderResponse.prototype.setHold = function(value) {
+proto.xudrpc.RemoveOrderResponse.prototype.setQuantityOnHold = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -885,7 +885,7 @@ proto.xudrpc.RemoveOrderResponse.prototype.toObject = function(opt_includeInstan
  */
 proto.xudrpc.RemoveOrderResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-
+    hold: +jspb.Message.getFieldWithDefault(msg, 1, 0.0)
   };
 
   if (includeInstance) {
@@ -922,6 +922,10 @@ proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader = function(msg, rea
     }
     var field = reader.getFieldNumber();
     switch (field) {
+    case 1:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setHold(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -951,6 +955,28 @@ proto.xudrpc.RemoveOrderResponse.prototype.serializeBinary = function() {
  */
 proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getHold();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional double hold = 1;
+ * @return {number}
+ */
+proto.xudrpc.RemoveOrderResponse.prototype.getHold = function() {
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 1, 0.0));
+};
+
+
+/** @param {number} value */
+proto.xudrpc.RemoveOrderResponse.prototype.setHold = function(value) {
+  jspb.Message.setField(this, 1, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -113,11 +113,11 @@ class Service extends EventEmitter {
   /*
    * Remove placed order from the orderbook.
    */
-  public removeOrder = async (args: { orderId: string }) => {
+  public removeOrder = (args: { orderId: string }) => {
     const { orderId } = args;
     argChecks.HAS_ORDER_ID(args);
 
-    this.orderBook.removeOwnOrderByLocalId(orderId);
+    return this.orderBook.removeOwnOrderByLocalId(orderId);
   }
 
   /** Gets the total lightning network channel balance for a given currency. */

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -260,7 +260,7 @@ message RemoveOrderRequest {
 message RemoveOrderResponse {
   // Any portion of the order that was on hold due to ongoing swaps at the time of the request
   // and could not be removed until after the swaps finish.
-  double hold = 1 [json_name = "hold"];
+  double quantity_on_hold = 1 [json_name = "hold"];
 }
 
 message ChannelBalance {

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -45,7 +45,8 @@ service Xud {
 
   /* Removes an order from the order book by its local id. This should be called when an order is
    * canceled or filled outside of xud. Removed orders become immediately unavailable for swaps,
-   * and peers are notified that the order is no longer valid. */
+   * and peers are notified that the order is no longer valid. Any portion of the order that is 
+   * on hold due to ongoing swaps will not be removed until after the swap attempts complete. */
   rpc RemoveOrder(RemoveOrderRequest) returns (RemoveOrderResponse) {
     option (google.api.http) = {
       post: "/v1/removeorder"
@@ -256,7 +257,11 @@ message RemoveOrderRequest {
   // The local id of the order to remove.
   string order_id = 1 [json_name = "order_id"];
 }
-message RemoveOrderResponse {}
+message RemoveOrderResponse {
+  // Any portion of the order that was on hold due to ongoing swaps at the time of the request
+  // and could not be removed until after the swaps finish.
+  double hold = 1 [json_name = "hold"];
+}
 
 message ChannelBalance {
   // Sum of channels balances denominated in satoshis or equivalent.


### PR DESCRIPTION
Closes #552.

This handles the possibility that we attempt to remove an order via the rpc layer while that order has a hold for a pending swap. Instead of removing the entire order immediately, this only removes the available portion of the order and then waits until any swaps finish before removing the portions that were on hold.

It also adds a field to the `RemoveOrder` rpc response which indicates whether any portion of the order was on hold. This gives feedback up front as to whether an order was removed immediately, or whether there are ongoing swaps which are being allowed to finish.

It also adds some assertions to the `removeOrder` logic to ensure that we don't try to remove any part of an order that is on hold.