### PR TITLE
feat(p2p/orderbook): drop orders for dropped pairs

### DIFF
--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -8,6 +8,7 @@ import NodeKey from '../../lib/nodekey/NodeKey';
 import Peer from '../../lib/p2p/Peer';
 import { Address } from '../../lib/types/p2p';
 import { DisconnectionReason } from '../../lib/types/enums';
+import { HelloPacket } from '../../lib/p2p/packets/types';
 import sinon from 'sinon';
 
 chai.use(chaiAsPromised);
@@ -26,7 +27,7 @@ describe('P2P Pool Tests', async () => {
       addresses,
       nodePubKey,
       version: 'test',
-      pairs: [],
+      pairs: ['LTC/BTC'],
     };
     peer.socket = {};
     peer.sendPacket = () => {};


### PR DESCRIPTION
This adds logic to drop a peer's orders for a given trading pair when we receive an updated handshake state that does not include a trading pair that was supported according to the previous handshake. Without this, we may keep orders in our order book for a peer that no longer supports (and can swap) those orders.

Closes #599.