### PR TITLE
fix(cli): use correct args for executeswap

### DIFF
--- a/lib/cli/commands/executeswap.ts
+++ b/lib/cli/commands/executeswap.ts
@@ -24,9 +24,9 @@ export const builder = {
 
 export const handler = (argv: Arguments) => {
   const request = new ExecuteSwapRequest();
-  request.setOrderId(argv.maker_order_id);
+  request.setOrderId(argv.order_id);
   request.setPairId(argv.pair_id);
-  request.setPeerPubKey(argv.maker_peer_pub_key);
+  request.setPeerPubKey(argv.peer_pub_key);
   request.setQuantity(argv.quantity);
   loadXudClient(argv).executeSwap(request, callback(argv));
 };


### PR DESCRIPTION
This fixes the argument names passed to the `ExecuteSwap` rpc call in the corresponding cli command.