### PR TITLE
fix(proto): use 64 bit chan_id ints as strings

### DIFF
--- a/lib/proto/annotations_pb.d.ts
+++ b/lib/proto/annotations_pb.d.ts
@@ -1,10 +1,9 @@
 // package: google.api
 // file: annotations.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 import * as google_api_http_pb from "./google/api/http_pb";
 import * as google_protobuf_descriptor_pb from "google-protobuf/google/protobuf/descriptor_pb";
 
-export const http: jspb.ExtensionFieldInfo<google_api_http_pb.HttpRule>;
+  export const http: jspb.ExtensionFieldInfo<google_api_http_pb.HttpRule>;
+

--- a/lib/proto/google/api/http_pb.d.ts
+++ b/lib/proto/google/api/http_pb.d.ts
@@ -1,147 +1,128 @@
 // package: google.api
 // file: google/api/http.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 
-export class Http extends jspb.Message { 
-    clearRulesList(): void;
-    getRulesList(): Array<HttpRule>;
-    setRulesList(value: Array<HttpRule>): void;
-    addRules(value?: HttpRule, index?: number): HttpRule;
+export class Http extends jspb.Message {
+  clearRulesList(): void;
+  getRulesList(): Array<HttpRule>;
+  setRulesList(value: Array<HttpRule>): void;
+  addRules(value?: HttpRule, index?: number): HttpRule;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Http.AsObject;
-    static toObject(includeInstance: boolean, msg: Http): Http.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Http, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Http;
-    static deserializeBinaryFromReader(message: Http, reader: jspb.BinaryReader): Http;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Http.AsObject;
+  static toObject(includeInstance: boolean, msg: Http): Http.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Http, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Http;
+  static deserializeBinaryFromReader(message: Http, reader: jspb.BinaryReader): Http;
 }
 
 export namespace Http {
-    export type AsObject = {
-        rulesList: Array<HttpRule.AsObject>,
-    }
+  export type AsObject = {
+    rulesList: Array<HttpRule.AsObject>,
+  }
 }
 
-export class HttpRule extends jspb.Message { 
-    getSelector(): string;
-    setSelector(value: string): void;
+export class HttpRule extends jspb.Message {
+  getSelector(): string;
+  setSelector(value: string): void;
 
+  hasGet(): boolean;
+  clearGet(): void;
+  getGet(): string;
+  setGet(value: string): void;
 
-    hasGet(): boolean;
-    clearGet(): void;
-    getGet(): string;
-    setGet(value: string): void;
+  hasPut(): boolean;
+  clearPut(): void;
+  getPut(): string;
+  setPut(value: string): void;
 
+  hasPost(): boolean;
+  clearPost(): void;
+  getPost(): string;
+  setPost(value: string): void;
 
-    hasPut(): boolean;
-    clearPut(): void;
-    getPut(): string;
-    setPut(value: string): void;
+  hasDelete(): boolean;
+  clearDelete(): void;
+  getDelete(): string;
+  setDelete(value: string): void;
 
+  hasPatch(): boolean;
+  clearPatch(): void;
+  getPatch(): string;
+  setPatch(value: string): void;
 
-    hasPost(): boolean;
-    clearPost(): void;
-    getPost(): string;
-    setPost(value: string): void;
+  hasCustom(): boolean;
+  clearCustom(): void;
+  getCustom(): CustomHttpPattern | undefined;
+  setCustom(value?: CustomHttpPattern): void;
 
+  getBody(): string;
+  setBody(value: string): void;
 
-    hasDelete(): boolean;
-    clearDelete(): void;
-    getDelete(): string;
-    setDelete(value: string): void;
+  clearAdditionalBindingsList(): void;
+  getAdditionalBindingsList(): Array<HttpRule>;
+  setAdditionalBindingsList(value: Array<HttpRule>): void;
+  addAdditionalBindings(value?: HttpRule, index?: number): HttpRule;
 
-
-    hasPatch(): boolean;
-    clearPatch(): void;
-    getPatch(): string;
-    setPatch(value: string): void;
-
-
-    hasCustom(): boolean;
-    clearCustom(): void;
-    getCustom(): CustomHttpPattern | undefined;
-    setCustom(value?: CustomHttpPattern): void;
-
-    getBody(): string;
-    setBody(value: string): void;
-
-    clearAdditionalBindingsList(): void;
-    getAdditionalBindingsList(): Array<HttpRule>;
-    setAdditionalBindingsList(value: Array<HttpRule>): void;
-    addAdditionalBindings(value?: HttpRule, index?: number): HttpRule;
-
-
-    getPatternCase(): HttpRule.PatternCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): HttpRule.AsObject;
-    static toObject(includeInstance: boolean, msg: HttpRule): HttpRule.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: HttpRule, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): HttpRule;
-    static deserializeBinaryFromReader(message: HttpRule, reader: jspb.BinaryReader): HttpRule;
+  getPatternCase(): HttpRule.PatternCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): HttpRule.AsObject;
+  static toObject(includeInstance: boolean, msg: HttpRule): HttpRule.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: HttpRule, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): HttpRule;
+  static deserializeBinaryFromReader(message: HttpRule, reader: jspb.BinaryReader): HttpRule;
 }
 
 export namespace HttpRule {
-    export type AsObject = {
-        selector: string,
-        get: string,
-        put: string,
-        post: string,
-        pb_delete: string,
-        patch: string,
-        custom?: CustomHttpPattern.AsObject,
-        body: string,
-        additionalBindingsList: Array<HttpRule.AsObject>,
-    }
+  export type AsObject = {
+    selector: string,
+    get: string,
+    put: string,
+    post: string,
+    pb_delete: string,
+    patch: string,
+    custom?: CustomHttpPattern.AsObject,
+    body: string,
+    additionalBindingsList: Array<HttpRule.AsObject>,
+  }
 
-    export enum PatternCase {
-        PATTERN_NOT_SET = 0,
-    
+  export enum PatternCase {
+    PATTERN_NOT_SET = 0,
     GET = 2,
-
     PUT = 3,
-
     POST = 4,
-
     DELETE = 5,
-
     PATCH = 6,
-
     CUSTOM = 8,
-
-    }
-
+  }
 }
 
-export class CustomHttpPattern extends jspb.Message { 
-    getKind(): string;
-    setKind(value: string): void;
+export class CustomHttpPattern extends jspb.Message {
+  getKind(): string;
+  setKind(value: string): void;
 
-    getPath(): string;
-    setPath(value: string): void;
+  getPath(): string;
+  setPath(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CustomHttpPattern.AsObject;
-    static toObject(includeInstance: boolean, msg: CustomHttpPattern): CustomHttpPattern.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CustomHttpPattern, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CustomHttpPattern;
-    static deserializeBinaryFromReader(message: CustomHttpPattern, reader: jspb.BinaryReader): CustomHttpPattern;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CustomHttpPattern.AsObject;
+  static toObject(includeInstance: boolean, msg: CustomHttpPattern): CustomHttpPattern.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CustomHttpPattern, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CustomHttpPattern;
+  static deserializeBinaryFromReader(message: CustomHttpPattern, reader: jspb.BinaryReader): CustomHttpPattern;
 }
 
 export namespace CustomHttpPattern {
-    export type AsObject = {
-        kind: string,
-        path: string,
-    }
+  export type AsObject = {
+    kind: string,
+    path: string,
+  }
 }
+

--- a/lib/proto/google/protobuf/descriptor_pb.d.ts
+++ b/lib/proto/google/protobuf/descriptor_pb.d.ts
@@ -1,357 +1,326 @@
 // package: google.protobuf
 // file: google/protobuf/descriptor.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 
-export class FileDescriptorSet extends jspb.Message { 
-    clearFileList(): void;
-    getFileList(): Array<FileDescriptorProto>;
-    setFileList(value: Array<FileDescriptorProto>): void;
-    addFile(value?: FileDescriptorProto, index?: number): FileDescriptorProto;
+export class FileDescriptorSet extends jspb.Message {
+  clearFileList(): void;
+  getFileList(): Array<FileDescriptorProto>;
+  setFileList(value: Array<FileDescriptorProto>): void;
+  addFile(value?: FileDescriptorProto, index?: number): FileDescriptorProto;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FileDescriptorSet.AsObject;
-    static toObject(includeInstance: boolean, msg: FileDescriptorSet): FileDescriptorSet.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FileDescriptorSet, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FileDescriptorSet;
-    static deserializeBinaryFromReader(message: FileDescriptorSet, reader: jspb.BinaryReader): FileDescriptorSet;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FileDescriptorSet.AsObject;
+  static toObject(includeInstance: boolean, msg: FileDescriptorSet): FileDescriptorSet.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileDescriptorSet, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileDescriptorSet;
+  static deserializeBinaryFromReader(message: FileDescriptorSet, reader: jspb.BinaryReader): FileDescriptorSet;
 }
 
 export namespace FileDescriptorSet {
-    export type AsObject = {
-        fileList: Array<FileDescriptorProto.AsObject>,
-    }
+  export type AsObject = {
+    fileList: Array<FileDescriptorProto.AsObject>,
+  }
 }
 
-export class FileDescriptorProto extends jspb.Message { 
+export class FileDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasPackage(): boolean;
+  clearPackage(): void;
+  getPackage(): string | undefined;
+  setPackage(value: string): void;
 
+  clearDependencyList(): void;
+  getDependencyList(): Array<string>;
+  setDependencyList(value: Array<string>): void;
+  addDependency(value: string, index?: number): string;
 
-    hasPackage(): boolean;
-    clearPackage(): void;
-    getPackage(): string | undefined;
-    setPackage(value: string): void;
+  clearPublicDependencyList(): void;
+  getPublicDependencyList(): Array<number>;
+  setPublicDependencyList(value: Array<number>): void;
+  addPublicDependency(value: number, index?: number): number;
 
-    clearDependencyList(): void;
-    getDependencyList(): Array<string>;
-    setDependencyList(value: Array<string>): void;
-    addDependency(value: string, index?: number): string;
+  clearWeakDependencyList(): void;
+  getWeakDependencyList(): Array<number>;
+  setWeakDependencyList(value: Array<number>): void;
+  addWeakDependency(value: number, index?: number): number;
 
-    clearPublicDependencyList(): void;
-    getPublicDependencyList(): Array<number>;
-    setPublicDependencyList(value: Array<number>): void;
-    addPublicDependency(value: number, index?: number): number;
+  clearMessageTypeList(): void;
+  getMessageTypeList(): Array<DescriptorProto>;
+  setMessageTypeList(value: Array<DescriptorProto>): void;
+  addMessageType(value?: DescriptorProto, index?: number): DescriptorProto;
 
-    clearWeakDependencyList(): void;
-    getWeakDependencyList(): Array<number>;
-    setWeakDependencyList(value: Array<number>): void;
-    addWeakDependency(value: number, index?: number): number;
+  clearEnumTypeList(): void;
+  getEnumTypeList(): Array<EnumDescriptorProto>;
+  setEnumTypeList(value: Array<EnumDescriptorProto>): void;
+  addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
 
-    clearMessageTypeList(): void;
-    getMessageTypeList(): Array<DescriptorProto>;
-    setMessageTypeList(value: Array<DescriptorProto>): void;
-    addMessageType(value?: DescriptorProto, index?: number): DescriptorProto;
+  clearServiceList(): void;
+  getServiceList(): Array<ServiceDescriptorProto>;
+  setServiceList(value: Array<ServiceDescriptorProto>): void;
+  addService(value?: ServiceDescriptorProto, index?: number): ServiceDescriptorProto;
 
-    clearEnumTypeList(): void;
-    getEnumTypeList(): Array<EnumDescriptorProto>;
-    setEnumTypeList(value: Array<EnumDescriptorProto>): void;
-    addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
+  clearExtensionList(): void;
+  getExtensionList(): Array<FieldDescriptorProto>;
+  setExtensionList(value: Array<FieldDescriptorProto>): void;
+  addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
 
-    clearServiceList(): void;
-    getServiceList(): Array<ServiceDescriptorProto>;
-    setServiceList(value: Array<ServiceDescriptorProto>): void;
-    addService(value?: ServiceDescriptorProto, index?: number): ServiceDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): FileOptions | undefined;
+  setOptions(value?: FileOptions): void;
 
-    clearExtensionList(): void;
-    getExtensionList(): Array<FieldDescriptorProto>;
-    setExtensionList(value: Array<FieldDescriptorProto>): void;
-    addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
+  hasSourceCodeInfo(): boolean;
+  clearSourceCodeInfo(): void;
+  getSourceCodeInfo(): SourceCodeInfo | undefined;
+  setSourceCodeInfo(value?: SourceCodeInfo): void;
 
+  hasSyntax(): boolean;
+  clearSyntax(): void;
+  getSyntax(): string | undefined;
+  setSyntax(value: string): void;
 
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): FileOptions | undefined;
-    setOptions(value?: FileOptions): void;
-
-
-    hasSourceCodeInfo(): boolean;
-    clearSourceCodeInfo(): void;
-    getSourceCodeInfo(): SourceCodeInfo | undefined;
-    setSourceCodeInfo(value?: SourceCodeInfo): void;
-
-
-    hasSyntax(): boolean;
-    clearSyntax(): void;
-    getSyntax(): string | undefined;
-    setSyntax(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FileDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: FileDescriptorProto): FileDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FileDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FileDescriptorProto;
-    static deserializeBinaryFromReader(message: FileDescriptorProto, reader: jspb.BinaryReader): FileDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FileDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: FileDescriptorProto): FileDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileDescriptorProto;
+  static deserializeBinaryFromReader(message: FileDescriptorProto, reader: jspb.BinaryReader): FileDescriptorProto;
 }
 
 export namespace FileDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        pb_package?: string,
-        dependencyList: Array<string>,
-        publicDependencyList: Array<number>,
-        weakDependencyList: Array<number>,
-        messageTypeList: Array<DescriptorProto.AsObject>,
-        enumTypeList: Array<EnumDescriptorProto.AsObject>,
-        serviceList: Array<ServiceDescriptorProto.AsObject>,
-        extensionList: Array<FieldDescriptorProto.AsObject>,
-        options?: FileOptions.AsObject,
-        sourceCodeInfo?: SourceCodeInfo.AsObject,
-        syntax?: string,
-    }
+  export type AsObject = {
+    name?: string,
+    pb_package?: string,
+    dependencyList: Array<string>,
+    publicDependencyList: Array<number>,
+    weakDependencyList: Array<number>,
+    messageTypeList: Array<DescriptorProto.AsObject>,
+    enumTypeList: Array<EnumDescriptorProto.AsObject>,
+    serviceList: Array<ServiceDescriptorProto.AsObject>,
+    extensionList: Array<FieldDescriptorProto.AsObject>,
+    options?: FileOptions.AsObject,
+    sourceCodeInfo?: SourceCodeInfo.AsObject,
+    syntax?: string,
+  }
 }
 
-export class DescriptorProto extends jspb.Message { 
+export class DescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  clearFieldList(): void;
+  getFieldList(): Array<FieldDescriptorProto>;
+  setFieldList(value: Array<FieldDescriptorProto>): void;
+  addField(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
 
-    clearFieldList(): void;
-    getFieldList(): Array<FieldDescriptorProto>;
-    setFieldList(value: Array<FieldDescriptorProto>): void;
-    addField(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
+  clearExtensionList(): void;
+  getExtensionList(): Array<FieldDescriptorProto>;
+  setExtensionList(value: Array<FieldDescriptorProto>): void;
+  addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
 
-    clearExtensionList(): void;
-    getExtensionList(): Array<FieldDescriptorProto>;
-    setExtensionList(value: Array<FieldDescriptorProto>): void;
-    addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
+  clearNestedTypeList(): void;
+  getNestedTypeList(): Array<DescriptorProto>;
+  setNestedTypeList(value: Array<DescriptorProto>): void;
+  addNestedType(value?: DescriptorProto, index?: number): DescriptorProto;
 
-    clearNestedTypeList(): void;
-    getNestedTypeList(): Array<DescriptorProto>;
-    setNestedTypeList(value: Array<DescriptorProto>): void;
-    addNestedType(value?: DescriptorProto, index?: number): DescriptorProto;
+  clearEnumTypeList(): void;
+  getEnumTypeList(): Array<EnumDescriptorProto>;
+  setEnumTypeList(value: Array<EnumDescriptorProto>): void;
+  addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
 
-    clearEnumTypeList(): void;
-    getEnumTypeList(): Array<EnumDescriptorProto>;
-    setEnumTypeList(value: Array<EnumDescriptorProto>): void;
-    addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
+  clearExtensionRangeList(): void;
+  getExtensionRangeList(): Array<DescriptorProto.ExtensionRange>;
+  setExtensionRangeList(value: Array<DescriptorProto.ExtensionRange>): void;
+  addExtensionRange(value?: DescriptorProto.ExtensionRange, index?: number): DescriptorProto.ExtensionRange;
 
-    clearExtensionRangeList(): void;
-    getExtensionRangeList(): Array<DescriptorProto.ExtensionRange>;
-    setExtensionRangeList(value: Array<DescriptorProto.ExtensionRange>): void;
-    addExtensionRange(value?: DescriptorProto.ExtensionRange, index?: number): DescriptorProto.ExtensionRange;
+  clearOneofDeclList(): void;
+  getOneofDeclList(): Array<OneofDescriptorProto>;
+  setOneofDeclList(value: Array<OneofDescriptorProto>): void;
+  addOneofDecl(value?: OneofDescriptorProto, index?: number): OneofDescriptorProto;
 
-    clearOneofDeclList(): void;
-    getOneofDeclList(): Array<OneofDescriptorProto>;
-    setOneofDeclList(value: Array<OneofDescriptorProto>): void;
-    addOneofDecl(value?: OneofDescriptorProto, index?: number): OneofDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): MessageOptions | undefined;
+  setOptions(value?: MessageOptions): void;
 
+  clearReservedRangeList(): void;
+  getReservedRangeList(): Array<DescriptorProto.ReservedRange>;
+  setReservedRangeList(value: Array<DescriptorProto.ReservedRange>): void;
+  addReservedRange(value?: DescriptorProto.ReservedRange, index?: number): DescriptorProto.ReservedRange;
 
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): MessageOptions | undefined;
-    setOptions(value?: MessageOptions): void;
+  clearReservedNameList(): void;
+  getReservedNameList(): Array<string>;
+  setReservedNameList(value: Array<string>): void;
+  addReservedName(value: string, index?: number): string;
 
-    clearReservedRangeList(): void;
-    getReservedRangeList(): Array<DescriptorProto.ReservedRange>;
-    setReservedRangeList(value: Array<DescriptorProto.ReservedRange>): void;
-    addReservedRange(value?: DescriptorProto.ReservedRange, index?: number): DescriptorProto.ReservedRange;
-
-    clearReservedNameList(): void;
-    getReservedNameList(): Array<string>;
-    setReservedNameList(value: Array<string>): void;
-    addReservedName(value: string, index?: number): string;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: DescriptorProto): DescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DescriptorProto;
-    static deserializeBinaryFromReader(message: DescriptorProto, reader: jspb.BinaryReader): DescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: DescriptorProto): DescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DescriptorProto;
+  static deserializeBinaryFromReader(message: DescriptorProto, reader: jspb.BinaryReader): DescriptorProto;
 }
 
 export namespace DescriptorProto {
-    export type AsObject = {
-        name?: string,
-        fieldList: Array<FieldDescriptorProto.AsObject>,
-        extensionList: Array<FieldDescriptorProto.AsObject>,
-        nestedTypeList: Array<DescriptorProto.AsObject>,
-        enumTypeList: Array<EnumDescriptorProto.AsObject>,
-        extensionRangeList: Array<DescriptorProto.ExtensionRange.AsObject>,
-        oneofDeclList: Array<OneofDescriptorProto.AsObject>,
-        options?: MessageOptions.AsObject,
-        reservedRangeList: Array<DescriptorProto.ReservedRange.AsObject>,
-        reservedNameList: Array<string>,
-    }
+  export type AsObject = {
+    name?: string,
+    fieldList: Array<FieldDescriptorProto.AsObject>,
+    extensionList: Array<FieldDescriptorProto.AsObject>,
+    nestedTypeList: Array<DescriptorProto.AsObject>,
+    enumTypeList: Array<EnumDescriptorProto.AsObject>,
+    extensionRangeList: Array<DescriptorProto.ExtensionRange.AsObject>,
+    oneofDeclList: Array<OneofDescriptorProto.AsObject>,
+    options?: MessageOptions.AsObject,
+    reservedRangeList: Array<DescriptorProto.ReservedRange.AsObject>,
+    reservedNameList: Array<string>,
+  }
 
-
-    export class ExtensionRange extends jspb.Message { 
-
+  export class ExtensionRange extends jspb.Message {
     hasStart(): boolean;
     clearStart(): void;
     getStart(): number | undefined;
     setStart(value: number): void;
 
-
     hasEnd(): boolean;
     clearEnd(): void;
     getEnd(): number | undefined;
     setEnd(value: number): void;
-
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ExtensionRange.AsObject;
-        static toObject(includeInstance: boolean, msg: ExtensionRange): ExtensionRange.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ExtensionRange, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ExtensionRange;
-        static deserializeBinaryFromReader(message: ExtensionRange, reader: jspb.BinaryReader): ExtensionRange;
-    }
-
-    export namespace ExtensionRange {
-        export type AsObject = {
-        start?: number,
-        end?: number,
-        }
-    }
-
-    export class ReservedRange extends jspb.Message { 
-
-    hasStart(): boolean;
-    clearStart(): void;
-    getStart(): number | undefined;
-    setStart(value: number): void;
-
-
-    hasEnd(): boolean;
-    clearEnd(): void;
-    getEnd(): number | undefined;
-    setEnd(value: number): void;
-
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ReservedRange.AsObject;
-        static toObject(includeInstance: boolean, msg: ReservedRange): ReservedRange.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ReservedRange, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ReservedRange;
-        static deserializeBinaryFromReader(message: ReservedRange, reader: jspb.BinaryReader): ReservedRange;
-    }
-
-    export namespace ReservedRange {
-        export type AsObject = {
-        start?: number,
-        end?: number,
-        }
-    }
-
-}
-
-export class FieldDescriptorProto extends jspb.Message { 
-
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
-
-
-    hasNumber(): boolean;
-    clearNumber(): void;
-    getNumber(): number | undefined;
-    setNumber(value: number): void;
-
-
-    hasLabel(): boolean;
-    clearLabel(): void;
-    getLabel(): FieldDescriptorProto.Label | undefined;
-    setLabel(value: FieldDescriptorProto.Label): void;
-
-
-    hasType(): boolean;
-    clearType(): void;
-    getType(): FieldDescriptorProto.Type | undefined;
-    setType(value: FieldDescriptorProto.Type): void;
-
-
-    hasTypeName(): boolean;
-    clearTypeName(): void;
-    getTypeName(): string | undefined;
-    setTypeName(value: string): void;
-
-
-    hasExtendee(): boolean;
-    clearExtendee(): void;
-    getExtendee(): string | undefined;
-    setExtendee(value: string): void;
-
-
-    hasDefaultValue(): boolean;
-    clearDefaultValue(): void;
-    getDefaultValue(): string | undefined;
-    setDefaultValue(value: string): void;
-
-
-    hasOneofIndex(): boolean;
-    clearOneofIndex(): void;
-    getOneofIndex(): number | undefined;
-    setOneofIndex(value: number): void;
-
-
-    hasJsonName(): boolean;
-    clearJsonName(): void;
-    getJsonName(): string | undefined;
-    setJsonName(value: string): void;
-
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): FieldOptions | undefined;
-    setOptions(value?: FieldOptions): void;
-
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: FieldDescriptorProto): FieldDescriptorProto.AsObject;
+    toObject(includeInstance?: boolean): ExtensionRange.AsObject;
+    static toObject(includeInstance: boolean, msg: ExtensionRange): ExtensionRange.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FieldDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FieldDescriptorProto;
-    static deserializeBinaryFromReader(message: FieldDescriptorProto, reader: jspb.BinaryReader): FieldDescriptorProto;
+    static serializeBinaryToWriter(message: ExtensionRange, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ExtensionRange;
+    static deserializeBinaryFromReader(message: ExtensionRange, reader: jspb.BinaryReader): ExtensionRange;
+  }
+
+  export namespace ExtensionRange {
+    export type AsObject = {
+      start?: number,
+      end?: number,
+    }
+  }
+
+  export class ReservedRange extends jspb.Message {
+    hasStart(): boolean;
+    clearStart(): void;
+    getStart(): number | undefined;
+    setStart(value: number): void;
+
+    hasEnd(): boolean;
+    clearEnd(): void;
+    getEnd(): number | undefined;
+    setEnd(value: number): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ReservedRange.AsObject;
+    static toObject(includeInstance: boolean, msg: ReservedRange): ReservedRange.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ReservedRange, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ReservedRange;
+    static deserializeBinaryFromReader(message: ReservedRange, reader: jspb.BinaryReader): ReservedRange;
+  }
+
+  export namespace ReservedRange {
+    export type AsObject = {
+      start?: number,
+      end?: number,
+    }
+  }
+}
+
+export class FieldDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
+
+  hasNumber(): boolean;
+  clearNumber(): void;
+  getNumber(): number | undefined;
+  setNumber(value: number): void;
+
+  hasLabel(): boolean;
+  clearLabel(): void;
+  getLabel(): FieldDescriptorProto.Label | undefined;
+  setLabel(value: FieldDescriptorProto.Label): void;
+
+  hasType(): boolean;
+  clearType(): void;
+  getType(): FieldDescriptorProto.Type | undefined;
+  setType(value: FieldDescriptorProto.Type): void;
+
+  hasTypeName(): boolean;
+  clearTypeName(): void;
+  getTypeName(): string | undefined;
+  setTypeName(value: string): void;
+
+  hasExtendee(): boolean;
+  clearExtendee(): void;
+  getExtendee(): string | undefined;
+  setExtendee(value: string): void;
+
+  hasDefaultValue(): boolean;
+  clearDefaultValue(): void;
+  getDefaultValue(): string | undefined;
+  setDefaultValue(value: string): void;
+
+  hasOneofIndex(): boolean;
+  clearOneofIndex(): void;
+  getOneofIndex(): number | undefined;
+  setOneofIndex(value: number): void;
+
+  hasJsonName(): boolean;
+  clearJsonName(): void;
+  getJsonName(): string | undefined;
+  setJsonName(value: string): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): FieldOptions | undefined;
+  setOptions(value?: FieldOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldDescriptorProto): FieldDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldDescriptorProto;
+  static deserializeBinaryFromReader(message: FieldDescriptorProto, reader: jspb.BinaryReader): FieldDescriptorProto;
 }
 
 export namespace FieldDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        number?: number,
-        label?: FieldDescriptorProto.Label,
-        type?: FieldDescriptorProto.Type,
-        typeName?: string,
-        extendee?: string,
-        defaultValue?: string,
-        oneofIndex?: number,
-        jsonName?: string,
-        options?: FieldOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    number?: number,
+    label?: FieldDescriptorProto.Label,
+    type?: FieldDescriptorProto.Type,
+    typeName?: string,
+    extendee?: string,
+    defaultValue?: string,
+    oneofIndex?: number,
+    jsonName?: string,
+    options?: FieldOptions.AsObject,
+  }
 
-    export enum Type {
+  export enum Type {
     TYPE_DOUBLE = 1,
     TYPE_FLOAT = 2,
     TYPE_INT64 = 3,
@@ -370,791 +339,711 @@ export namespace FieldDescriptorProto {
     TYPE_SFIXED64 = 16,
     TYPE_SINT32 = 17,
     TYPE_SINT64 = 18,
-    }
+  }
 
-    export enum Label {
+  export enum Label {
     LABEL_OPTIONAL = 1,
     LABEL_REQUIRED = 2,
     LABEL_REPEATED = 3,
-    }
-
+  }
 }
 
-export class OneofDescriptorProto extends jspb.Message { 
+export class OneofDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): OneofOptions | undefined;
+  setOptions(value?: OneofOptions): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): OneofOptions | undefined;
-    setOptions(value?: OneofOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OneofDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: OneofDescriptorProto): OneofDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OneofDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto;
-    static deserializeBinaryFromReader(message: OneofDescriptorProto, reader: jspb.BinaryReader): OneofDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OneofDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: OneofDescriptorProto): OneofDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OneofDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto;
+  static deserializeBinaryFromReader(message: OneofDescriptorProto, reader: jspb.BinaryReader): OneofDescriptorProto;
 }
 
 export namespace OneofDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        options?: OneofOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    options?: OneofOptions.AsObject,
+  }
 }
 
-export class EnumDescriptorProto extends jspb.Message { 
+export class EnumDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  clearValueList(): void;
+  getValueList(): Array<EnumValueDescriptorProto>;
+  setValueList(value: Array<EnumValueDescriptorProto>): void;
+  addValue(value?: EnumValueDescriptorProto, index?: number): EnumValueDescriptorProto;
 
-    clearValueList(): void;
-    getValueList(): Array<EnumValueDescriptorProto>;
-    setValueList(value: Array<EnumValueDescriptorProto>): void;
-    addValue(value?: EnumValueDescriptorProto, index?: number): EnumValueDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): EnumOptions | undefined;
+  setOptions(value?: EnumOptions): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): EnumOptions | undefined;
-    setOptions(value?: EnumOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumDescriptorProto): EnumDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumDescriptorProto;
-    static deserializeBinaryFromReader(message: EnumDescriptorProto, reader: jspb.BinaryReader): EnumDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumDescriptorProto): EnumDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumDescriptorProto;
+  static deserializeBinaryFromReader(message: EnumDescriptorProto, reader: jspb.BinaryReader): EnumDescriptorProto;
 }
 
 export namespace EnumDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        valueList: Array<EnumValueDescriptorProto.AsObject>,
-        options?: EnumOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    valueList: Array<EnumValueDescriptorProto.AsObject>,
+    options?: EnumOptions.AsObject,
+  }
 }
 
-export class EnumValueDescriptorProto extends jspb.Message { 
+export class EnumValueDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasNumber(): boolean;
+  clearNumber(): void;
+  getNumber(): number | undefined;
+  setNumber(value: number): void;
 
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): EnumValueOptions | undefined;
+  setOptions(value?: EnumValueOptions): void;
 
-    hasNumber(): boolean;
-    clearNumber(): void;
-    getNumber(): number | undefined;
-    setNumber(value: number): void;
-
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): EnumValueOptions | undefined;
-    setOptions(value?: EnumValueOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumValueDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): EnumValueDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumValueDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumValueDescriptorProto;
-    static deserializeBinaryFromReader(message: EnumValueDescriptorProto, reader: jspb.BinaryReader): EnumValueDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumValueDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): EnumValueDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValueDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValueDescriptorProto;
+  static deserializeBinaryFromReader(message: EnumValueDescriptorProto, reader: jspb.BinaryReader): EnumValueDescriptorProto;
 }
 
 export namespace EnumValueDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        number?: number,
-        options?: EnumValueOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    number?: number,
+    options?: EnumValueOptions.AsObject,
+  }
 }
 
-export class ServiceDescriptorProto extends jspb.Message { 
+export class ServiceDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  clearMethodList(): void;
+  getMethodList(): Array<MethodDescriptorProto>;
+  setMethodList(value: Array<MethodDescriptorProto>): void;
+  addMethod(value?: MethodDescriptorProto, index?: number): MethodDescriptorProto;
 
-    clearMethodList(): void;
-    getMethodList(): Array<MethodDescriptorProto>;
-    setMethodList(value: Array<MethodDescriptorProto>): void;
-    addMethod(value?: MethodDescriptorProto, index?: number): MethodDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): ServiceOptions | undefined;
+  setOptions(value?: ServiceOptions): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): ServiceOptions | undefined;
-    setOptions(value?: ServiceOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ServiceDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): ServiceDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ServiceDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto;
-    static deserializeBinaryFromReader(message: ServiceDescriptorProto, reader: jspb.BinaryReader): ServiceDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ServiceDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): ServiceDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ServiceDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto;
+  static deserializeBinaryFromReader(message: ServiceDescriptorProto, reader: jspb.BinaryReader): ServiceDescriptorProto;
 }
 
 export namespace ServiceDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        methodList: Array<MethodDescriptorProto.AsObject>,
-        options?: ServiceOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    methodList: Array<MethodDescriptorProto.AsObject>,
+    options?: ServiceOptions.AsObject,
+  }
 }
 
-export class MethodDescriptorProto extends jspb.Message { 
+export class MethodDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasInputType(): boolean;
+  clearInputType(): void;
+  getInputType(): string | undefined;
+  setInputType(value: string): void;
 
+  hasOutputType(): boolean;
+  clearOutputType(): void;
+  getOutputType(): string | undefined;
+  setOutputType(value: string): void;
 
-    hasInputType(): boolean;
-    clearInputType(): void;
-    getInputType(): string | undefined;
-    setInputType(value: string): void;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): MethodOptions | undefined;
+  setOptions(value?: MethodOptions): void;
 
+  hasClientStreaming(): boolean;
+  clearClientStreaming(): void;
+  getClientStreaming(): boolean | undefined;
+  setClientStreaming(value: boolean): void;
 
-    hasOutputType(): boolean;
-    clearOutputType(): void;
-    getOutputType(): string | undefined;
-    setOutputType(value: string): void;
+  hasServerStreaming(): boolean;
+  clearServerStreaming(): void;
+  getServerStreaming(): boolean | undefined;
+  setServerStreaming(value: boolean): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): MethodOptions | undefined;
-    setOptions(value?: MethodOptions): void;
-
-
-    hasClientStreaming(): boolean;
-    clearClientStreaming(): void;
-    getClientStreaming(): boolean | undefined;
-    setClientStreaming(value: boolean): void;
-
-
-    hasServerStreaming(): boolean;
-    clearServerStreaming(): void;
-    getServerStreaming(): boolean | undefined;
-    setServerStreaming(value: boolean): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): MethodDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: MethodDescriptorProto): MethodDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: MethodDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto;
-    static deserializeBinaryFromReader(message: MethodDescriptorProto, reader: jspb.BinaryReader): MethodDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MethodDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: MethodDescriptorProto): MethodDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MethodDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto;
+  static deserializeBinaryFromReader(message: MethodDescriptorProto, reader: jspb.BinaryReader): MethodDescriptorProto;
 }
 
 export namespace MethodDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        inputType?: string,
-        outputType?: string,
-        options?: MethodOptions.AsObject,
-        clientStreaming?: boolean,
-        serverStreaming?: boolean,
-    }
+  export type AsObject = {
+    name?: string,
+    inputType?: string,
+    outputType?: string,
+    options?: MethodOptions.AsObject,
+    clientStreaming?: boolean,
+    serverStreaming?: boolean,
+  }
 }
 
-export class FileOptions extends jspb.Message { 
+export class FileOptions extends jspb.Message {
+  hasJavaPackage(): boolean;
+  clearJavaPackage(): void;
+  getJavaPackage(): string | undefined;
+  setJavaPackage(value: string): void;
 
-    hasJavaPackage(): boolean;
-    clearJavaPackage(): void;
-    getJavaPackage(): string | undefined;
-    setJavaPackage(value: string): void;
+  hasJavaOuterClassname(): boolean;
+  clearJavaOuterClassname(): void;
+  getJavaOuterClassname(): string | undefined;
+  setJavaOuterClassname(value: string): void;
 
+  hasJavaMultipleFiles(): boolean;
+  clearJavaMultipleFiles(): void;
+  getJavaMultipleFiles(): boolean | undefined;
+  setJavaMultipleFiles(value: boolean): void;
 
-    hasJavaOuterClassname(): boolean;
-    clearJavaOuterClassname(): void;
-    getJavaOuterClassname(): string | undefined;
-    setJavaOuterClassname(value: string): void;
+  hasJavaGenerateEqualsAndHash(): boolean;
+  clearJavaGenerateEqualsAndHash(): void;
+  getJavaGenerateEqualsAndHash(): boolean | undefined;
+  setJavaGenerateEqualsAndHash(value: boolean): void;
 
+  hasJavaStringCheckUtf8(): boolean;
+  clearJavaStringCheckUtf8(): void;
+  getJavaStringCheckUtf8(): boolean | undefined;
+  setJavaStringCheckUtf8(value: boolean): void;
 
-    hasJavaMultipleFiles(): boolean;
-    clearJavaMultipleFiles(): void;
-    getJavaMultipleFiles(): boolean | undefined;
-    setJavaMultipleFiles(value: boolean): void;
+  hasOptimizeFor(): boolean;
+  clearOptimizeFor(): void;
+  getOptimizeFor(): FileOptions.OptimizeMode | undefined;
+  setOptimizeFor(value: FileOptions.OptimizeMode): void;
 
+  hasGoPackage(): boolean;
+  clearGoPackage(): void;
+  getGoPackage(): string | undefined;
+  setGoPackage(value: string): void;
 
-    hasJavaGenerateEqualsAndHash(): boolean;
-    clearJavaGenerateEqualsAndHash(): void;
-    getJavaGenerateEqualsAndHash(): boolean | undefined;
-    setJavaGenerateEqualsAndHash(value: boolean): void;
+  hasCcGenericServices(): boolean;
+  clearCcGenericServices(): void;
+  getCcGenericServices(): boolean | undefined;
+  setCcGenericServices(value: boolean): void;
 
+  hasJavaGenericServices(): boolean;
+  clearJavaGenericServices(): void;
+  getJavaGenericServices(): boolean | undefined;
+  setJavaGenericServices(value: boolean): void;
 
-    hasJavaStringCheckUtf8(): boolean;
-    clearJavaStringCheckUtf8(): void;
-    getJavaStringCheckUtf8(): boolean | undefined;
-    setJavaStringCheckUtf8(value: boolean): void;
+  hasPyGenericServices(): boolean;
+  clearPyGenericServices(): void;
+  getPyGenericServices(): boolean | undefined;
+  setPyGenericServices(value: boolean): void;
 
+  hasPhpGenericServices(): boolean;
+  clearPhpGenericServices(): void;
+  getPhpGenericServices(): boolean | undefined;
+  setPhpGenericServices(value: boolean): void;
 
-    hasOptimizeFor(): boolean;
-    clearOptimizeFor(): void;
-    getOptimizeFor(): FileOptions.OptimizeMode | undefined;
-    setOptimizeFor(value: FileOptions.OptimizeMode): void;
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
+  hasCcEnableArenas(): boolean;
+  clearCcEnableArenas(): void;
+  getCcEnableArenas(): boolean | undefined;
+  setCcEnableArenas(value: boolean): void;
 
-    hasGoPackage(): boolean;
-    clearGoPackage(): void;
-    getGoPackage(): string | undefined;
-    setGoPackage(value: string): void;
+  hasObjcClassPrefix(): boolean;
+  clearObjcClassPrefix(): void;
+  getObjcClassPrefix(): string | undefined;
+  setObjcClassPrefix(value: string): void;
 
+  hasCsharpNamespace(): boolean;
+  clearCsharpNamespace(): void;
+  getCsharpNamespace(): string | undefined;
+  setCsharpNamespace(value: string): void;
 
-    hasCcGenericServices(): boolean;
-    clearCcGenericServices(): void;
-    getCcGenericServices(): boolean | undefined;
-    setCcGenericServices(value: boolean): void;
+  hasSwiftPrefix(): boolean;
+  clearSwiftPrefix(): void;
+  getSwiftPrefix(): string | undefined;
+  setSwiftPrefix(value: string): void;
 
+  hasPhpClassPrefix(): boolean;
+  clearPhpClassPrefix(): void;
+  getPhpClassPrefix(): string | undefined;
+  setPhpClassPrefix(value: string): void;
 
-    hasJavaGenericServices(): boolean;
-    clearJavaGenericServices(): void;
-    getJavaGenericServices(): boolean | undefined;
-    setJavaGenericServices(value: boolean): void;
+  hasPhpNamespace(): boolean;
+  clearPhpNamespace(): void;
+  getPhpNamespace(): string | undefined;
+  setPhpNamespace(value: string): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasPyGenericServices(): boolean;
-    clearPyGenericServices(): void;
-    getPyGenericServices(): boolean | undefined;
-    setPyGenericServices(value: boolean): void;
-
-
-    hasPhpGenericServices(): boolean;
-    clearPhpGenericServices(): void;
-    getPhpGenericServices(): boolean | undefined;
-    setPhpGenericServices(value: boolean): void;
-
-
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-
-    hasCcEnableArenas(): boolean;
-    clearCcEnableArenas(): void;
-    getCcEnableArenas(): boolean | undefined;
-    setCcEnableArenas(value: boolean): void;
-
-
-    hasObjcClassPrefix(): boolean;
-    clearObjcClassPrefix(): void;
-    getObjcClassPrefix(): string | undefined;
-    setObjcClassPrefix(value: string): void;
-
-
-    hasCsharpNamespace(): boolean;
-    clearCsharpNamespace(): void;
-    getCsharpNamespace(): string | undefined;
-    setCsharpNamespace(value: string): void;
-
-
-    hasSwiftPrefix(): boolean;
-    clearSwiftPrefix(): void;
-    getSwiftPrefix(): string | undefined;
-    setSwiftPrefix(value: string): void;
-
-
-    hasPhpClassPrefix(): boolean;
-    clearPhpClassPrefix(): void;
-    getPhpClassPrefix(): string | undefined;
-    setPhpClassPrefix(value: string): void;
-
-
-    hasPhpNamespace(): boolean;
-    clearPhpNamespace(): void;
-    getPhpNamespace(): string | undefined;
-    setPhpNamespace(value: string): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FileOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: FileOptions): FileOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FileOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FileOptions;
-    static deserializeBinaryFromReader(message: FileOptions, reader: jspb.BinaryReader): FileOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FileOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: FileOptions): FileOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileOptions;
+  static deserializeBinaryFromReader(message: FileOptions, reader: jspb.BinaryReader): FileOptions;
 }
 
 export namespace FileOptions {
-    export type AsObject = {
-        javaPackage?: string,
-        javaOuterClassname?: string,
-        javaMultipleFiles?: boolean,
-        javaGenerateEqualsAndHash?: boolean,
-        javaStringCheckUtf8?: boolean,
-        optimizeFor?: FileOptions.OptimizeMode,
-        goPackage?: string,
-        ccGenericServices?: boolean,
-        javaGenericServices?: boolean,
-        pyGenericServices?: boolean,
-        phpGenericServices?: boolean,
-        deprecated?: boolean,
-        ccEnableArenas?: boolean,
-        objcClassPrefix?: string,
-        csharpNamespace?: string,
-        swiftPrefix?: string,
-        phpClassPrefix?: string,
-        phpNamespace?: string,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    javaPackage?: string,
+    javaOuterClassname?: string,
+    javaMultipleFiles?: boolean,
+    javaGenerateEqualsAndHash?: boolean,
+    javaStringCheckUtf8?: boolean,
+    optimizeFor?: FileOptions.OptimizeMode,
+    goPackage?: string,
+    ccGenericServices?: boolean,
+    javaGenericServices?: boolean,
+    pyGenericServices?: boolean,
+    phpGenericServices?: boolean,
+    deprecated?: boolean,
+    ccEnableArenas?: boolean,
+    objcClassPrefix?: string,
+    csharpNamespace?: string,
+    swiftPrefix?: string,
+    phpClassPrefix?: string,
+    phpNamespace?: string,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 
-    export enum OptimizeMode {
+  export enum OptimizeMode {
     SPEED = 1,
     CODE_SIZE = 2,
     LITE_RUNTIME = 3,
-    }
-
+  }
 }
 
-export class MessageOptions extends jspb.Message { 
+export class MessageOptions extends jspb.Message {
+  hasMessageSetWireFormat(): boolean;
+  clearMessageSetWireFormat(): void;
+  getMessageSetWireFormat(): boolean | undefined;
+  setMessageSetWireFormat(value: boolean): void;
 
-    hasMessageSetWireFormat(): boolean;
-    clearMessageSetWireFormat(): void;
-    getMessageSetWireFormat(): boolean | undefined;
-    setMessageSetWireFormat(value: boolean): void;
+  hasNoStandardDescriptorAccessor(): boolean;
+  clearNoStandardDescriptorAccessor(): void;
+  getNoStandardDescriptorAccessor(): boolean | undefined;
+  setNoStandardDescriptorAccessor(value: boolean): void;
 
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasNoStandardDescriptorAccessor(): boolean;
-    clearNoStandardDescriptorAccessor(): void;
-    getNoStandardDescriptorAccessor(): boolean | undefined;
-    setNoStandardDescriptorAccessor(value: boolean): void;
+  hasMapEntry(): boolean;
+  clearMapEntry(): void;
+  getMapEntry(): boolean | undefined;
+  setMapEntry(value: boolean): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-
-    hasMapEntry(): boolean;
-    clearMapEntry(): void;
-    getMapEntry(): boolean | undefined;
-    setMapEntry(value: boolean): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): MessageOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: MessageOptions): MessageOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: MessageOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): MessageOptions;
-    static deserializeBinaryFromReader(message: MessageOptions, reader: jspb.BinaryReader): MessageOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MessageOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: MessageOptions): MessageOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MessageOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MessageOptions;
+  static deserializeBinaryFromReader(message: MessageOptions, reader: jspb.BinaryReader): MessageOptions;
 }
 
 export namespace MessageOptions {
-    export type AsObject = {
-        messageSetWireFormat?: boolean,
-        noStandardDescriptorAccessor?: boolean,
-        deprecated?: boolean,
-        mapEntry?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    messageSetWireFormat?: boolean,
+    noStandardDescriptorAccessor?: boolean,
+    deprecated?: boolean,
+    mapEntry?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class FieldOptions extends jspb.Message { 
+export class FieldOptions extends jspb.Message {
+  hasCtype(): boolean;
+  clearCtype(): void;
+  getCtype(): FieldOptions.CType | undefined;
+  setCtype(value: FieldOptions.CType): void;
 
-    hasCtype(): boolean;
-    clearCtype(): void;
-    getCtype(): FieldOptions.CType | undefined;
-    setCtype(value: FieldOptions.CType): void;
+  hasPacked(): boolean;
+  clearPacked(): void;
+  getPacked(): boolean | undefined;
+  setPacked(value: boolean): void;
 
+  hasJstype(): boolean;
+  clearJstype(): void;
+  getJstype(): FieldOptions.JSType | undefined;
+  setJstype(value: FieldOptions.JSType): void;
 
-    hasPacked(): boolean;
-    clearPacked(): void;
-    getPacked(): boolean | undefined;
-    setPacked(value: boolean): void;
+  hasLazy(): boolean;
+  clearLazy(): void;
+  getLazy(): boolean | undefined;
+  setLazy(value: boolean): void;
 
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasJstype(): boolean;
-    clearJstype(): void;
-    getJstype(): FieldOptions.JSType | undefined;
-    setJstype(value: FieldOptions.JSType): void;
+  hasWeak(): boolean;
+  clearWeak(): void;
+  getWeak(): boolean | undefined;
+  setWeak(value: boolean): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasLazy(): boolean;
-    clearLazy(): void;
-    getLazy(): boolean | undefined;
-    setLazy(value: boolean): void;
-
-
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-
-    hasWeak(): boolean;
-    clearWeak(): void;
-    getWeak(): boolean | undefined;
-    setWeak(value: boolean): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FieldOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: FieldOptions): FieldOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FieldOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FieldOptions;
-    static deserializeBinaryFromReader(message: FieldOptions, reader: jspb.BinaryReader): FieldOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FieldOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldOptions): FieldOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldOptions;
+  static deserializeBinaryFromReader(message: FieldOptions, reader: jspb.BinaryReader): FieldOptions;
 }
 
 export namespace FieldOptions {
-    export type AsObject = {
-        ctype?: FieldOptions.CType,
-        packed?: boolean,
-        jstype?: FieldOptions.JSType,
-        lazy?: boolean,
-        deprecated?: boolean,
-        weak?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    ctype?: FieldOptions.CType,
+    packed?: boolean,
+    jstype?: FieldOptions.JSType,
+    lazy?: boolean,
+    deprecated?: boolean,
+    weak?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 
-    export enum CType {
+  export enum CType {
     STRING = 0,
     CORD = 1,
     STRING_PIECE = 2,
-    }
+  }
 
-    export enum JSType {
+  export enum JSType {
     JS_NORMAL = 0,
     JS_STRING = 1,
     JS_NUMBER = 2,
-    }
-
+  }
 }
 
-export class OneofOptions extends jspb.Message { 
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
+export class OneofOptions extends jspb.Message {
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OneofOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: OneofOptions): OneofOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OneofOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OneofOptions;
-    static deserializeBinaryFromReader(message: OneofOptions, reader: jspb.BinaryReader): OneofOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OneofOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: OneofOptions): OneofOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OneofOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OneofOptions;
+  static deserializeBinaryFromReader(message: OneofOptions, reader: jspb.BinaryReader): OneofOptions;
 }
 
 export namespace OneofOptions {
-    export type AsObject = {
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class EnumOptions extends jspb.Message { 
+export class EnumOptions extends jspb.Message {
+  hasAllowAlias(): boolean;
+  clearAllowAlias(): void;
+  getAllowAlias(): boolean | undefined;
+  setAllowAlias(value: boolean): void;
 
-    hasAllowAlias(): boolean;
-    clearAllowAlias(): void;
-    getAllowAlias(): boolean | undefined;
-    setAllowAlias(value: boolean): void;
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumOptions): EnumOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumOptions;
-    static deserializeBinaryFromReader(message: EnumOptions, reader: jspb.BinaryReader): EnumOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumOptions): EnumOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumOptions;
+  static deserializeBinaryFromReader(message: EnumOptions, reader: jspb.BinaryReader): EnumOptions;
 }
 
 export namespace EnumOptions {
-    export type AsObject = {
-        allowAlias?: boolean,
-        deprecated?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    allowAlias?: boolean,
+    deprecated?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class EnumValueOptions extends jspb.Message { 
+export class EnumValueOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumValueOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumValueOptions): EnumValueOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumValueOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumValueOptions;
-    static deserializeBinaryFromReader(message: EnumValueOptions, reader: jspb.BinaryReader): EnumValueOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumValueOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValueOptions): EnumValueOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValueOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValueOptions;
+  static deserializeBinaryFromReader(message: EnumValueOptions, reader: jspb.BinaryReader): EnumValueOptions;
 }
 
 export namespace EnumValueOptions {
-    export type AsObject = {
-        deprecated?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    deprecated?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class ServiceOptions extends jspb.Message { 
+export class ServiceOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ServiceOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: ServiceOptions): ServiceOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ServiceOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ServiceOptions;
-    static deserializeBinaryFromReader(message: ServiceOptions, reader: jspb.BinaryReader): ServiceOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ServiceOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: ServiceOptions): ServiceOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ServiceOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ServiceOptions;
+  static deserializeBinaryFromReader(message: ServiceOptions, reader: jspb.BinaryReader): ServiceOptions;
 }
 
 export namespace ServiceOptions {
-    export type AsObject = {
-        deprecated?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    deprecated?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class MethodOptions extends jspb.Message { 
+export class MethodOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
+  hasIdempotencyLevel(): boolean;
+  clearIdempotencyLevel(): void;
+  getIdempotencyLevel(): MethodOptions.IdempotencyLevel | undefined;
+  setIdempotencyLevel(value: MethodOptions.IdempotencyLevel): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasIdempotencyLevel(): boolean;
-    clearIdempotencyLevel(): void;
-    getIdempotencyLevel(): MethodOptions.IdempotencyLevel | undefined;
-    setIdempotencyLevel(value: MethodOptions.IdempotencyLevel): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): MethodOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: MethodOptions): MethodOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: MethodOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): MethodOptions;
-    static deserializeBinaryFromReader(message: MethodOptions, reader: jspb.BinaryReader): MethodOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MethodOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: MethodOptions): MethodOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MethodOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MethodOptions;
+  static deserializeBinaryFromReader(message: MethodOptions, reader: jspb.BinaryReader): MethodOptions;
 }
 
 export namespace MethodOptions {
-    export type AsObject = {
-        deprecated?: boolean,
-        idempotencyLevel?: MethodOptions.IdempotencyLevel,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    deprecated?: boolean,
+    idempotencyLevel?: MethodOptions.IdempotencyLevel,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 
-    export enum IdempotencyLevel {
+  export enum IdempotencyLevel {
     IDEMPOTENCY_UNKNOWN = 0,
     NO_SIDE_EFFECTS = 1,
     IDEMPOTENT = 2,
-    }
-
+  }
 }
 
-export class UninterpretedOption extends jspb.Message { 
-    clearNameList(): void;
-    getNameList(): Array<UninterpretedOption.NamePart>;
-    setNameList(value: Array<UninterpretedOption.NamePart>): void;
-    addName(value?: UninterpretedOption.NamePart, index?: number): UninterpretedOption.NamePart;
+export class UninterpretedOption extends jspb.Message {
+  clearNameList(): void;
+  getNameList(): Array<UninterpretedOption.NamePart>;
+  setNameList(value: Array<UninterpretedOption.NamePart>): void;
+  addName(value?: UninterpretedOption.NamePart, index?: number): UninterpretedOption.NamePart;
 
+  hasIdentifierValue(): boolean;
+  clearIdentifierValue(): void;
+  getIdentifierValue(): string | undefined;
+  setIdentifierValue(value: string): void;
 
-    hasIdentifierValue(): boolean;
-    clearIdentifierValue(): void;
-    getIdentifierValue(): string | undefined;
-    setIdentifierValue(value: string): void;
+  hasPositiveIntValue(): boolean;
+  clearPositiveIntValue(): void;
+  getPositiveIntValue(): number | undefined;
+  setPositiveIntValue(value: number): void;
 
+  hasNegativeIntValue(): boolean;
+  clearNegativeIntValue(): void;
+  getNegativeIntValue(): number | undefined;
+  setNegativeIntValue(value: number): void;
 
-    hasPositiveIntValue(): boolean;
-    clearPositiveIntValue(): void;
-    getPositiveIntValue(): number | undefined;
-    setPositiveIntValue(value: number): void;
+  hasDoubleValue(): boolean;
+  clearDoubleValue(): void;
+  getDoubleValue(): number | undefined;
+  setDoubleValue(value: number): void;
 
+  hasStringValue(): boolean;
+  clearStringValue(): void;
+  getStringValue(): Uint8Array | string;
+  getStringValue_asU8(): Uint8Array;
+  getStringValue_asB64(): string;
+  setStringValue(value: Uint8Array | string): void;
 
-    hasNegativeIntValue(): boolean;
-    clearNegativeIntValue(): void;
-    getNegativeIntValue(): number | undefined;
-    setNegativeIntValue(value: number): void;
+  hasAggregateValue(): boolean;
+  clearAggregateValue(): void;
+  getAggregateValue(): string | undefined;
+  setAggregateValue(value: string): void;
 
-
-    hasDoubleValue(): boolean;
-    clearDoubleValue(): void;
-    getDoubleValue(): number | undefined;
-    setDoubleValue(value: number): void;
-
-
-    hasStringValue(): boolean;
-    clearStringValue(): void;
-    getStringValue(): Uint8Array | string;
-    getStringValue_asU8(): Uint8Array;
-    getStringValue_asB64(): string;
-    setStringValue(value: Uint8Array | string): void;
-
-
-    hasAggregateValue(): boolean;
-    clearAggregateValue(): void;
-    getAggregateValue(): string | undefined;
-    setAggregateValue(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UninterpretedOption.AsObject;
-    static toObject(includeInstance: boolean, msg: UninterpretedOption): UninterpretedOption.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UninterpretedOption, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UninterpretedOption;
-    static deserializeBinaryFromReader(message: UninterpretedOption, reader: jspb.BinaryReader): UninterpretedOption;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UninterpretedOption.AsObject;
+  static toObject(includeInstance: boolean, msg: UninterpretedOption): UninterpretedOption.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UninterpretedOption, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UninterpretedOption;
+  static deserializeBinaryFromReader(message: UninterpretedOption, reader: jspb.BinaryReader): UninterpretedOption;
 }
 
 export namespace UninterpretedOption {
-    export type AsObject = {
-        nameList: Array<UninterpretedOption.NamePart.AsObject>,
-        identifierValue?: string,
-        positiveIntValue?: number,
-        negativeIntValue?: number,
-        doubleValue?: number,
-        stringValue: Uint8Array | string,
-        aggregateValue?: string,
-    }
+  export type AsObject = {
+    nameList: Array<UninterpretedOption.NamePart.AsObject>,
+    identifierValue?: string,
+    positiveIntValue?: number,
+    negativeIntValue?: number,
+    doubleValue?: number,
+    stringValue: Uint8Array | string,
+    aggregateValue?: string,
+  }
 
-
-    export class NamePart extends jspb.Message { 
-
+  export class NamePart extends jspb.Message {
     hasNamePart(): boolean;
     clearNamePart(): void;
     getNamePart(): string | undefined;
     setNamePart(value: string): void;
-
 
     hasIsExtension(): boolean;
     clearIsExtension(): void;
     getIsExtension(): boolean | undefined;
     setIsExtension(value: boolean): void;
 
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): NamePart.AsObject;
-        static toObject(includeInstance: boolean, msg: NamePart): NamePart.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: NamePart, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): NamePart;
-        static deserializeBinaryFromReader(message: NamePart, reader: jspb.BinaryReader): NamePart;
-    }
-
-    export namespace NamePart {
-        export type AsObject = {
-        namePart?: string,
-        isExtension?: boolean,
-        }
-    }
-
-}
-
-export class SourceCodeInfo extends jspb.Message { 
-    clearLocationList(): void;
-    getLocationList(): Array<SourceCodeInfo.Location>;
-    setLocationList(value: Array<SourceCodeInfo.Location>): void;
-    addLocation(value?: SourceCodeInfo.Location, index?: number): SourceCodeInfo.Location;
-
-
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SourceCodeInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: SourceCodeInfo): SourceCodeInfo.AsObject;
+    toObject(includeInstance?: boolean): NamePart.AsObject;
+    static toObject(includeInstance: boolean, msg: NamePart): NamePart.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SourceCodeInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SourceCodeInfo;
-    static deserializeBinaryFromReader(message: SourceCodeInfo, reader: jspb.BinaryReader): SourceCodeInfo;
+    static serializeBinaryToWriter(message: NamePart, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): NamePart;
+    static deserializeBinaryFromReader(message: NamePart, reader: jspb.BinaryReader): NamePart;
+  }
+
+  export namespace NamePart {
+    export type AsObject = {
+      namePart?: string,
+      isExtension?: boolean,
+    }
+  }
+}
+
+export class SourceCodeInfo extends jspb.Message {
+  clearLocationList(): void;
+  getLocationList(): Array<SourceCodeInfo.Location>;
+  setLocationList(value: Array<SourceCodeInfo.Location>): void;
+  addLocation(value?: SourceCodeInfo.Location, index?: number): SourceCodeInfo.Location;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SourceCodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: SourceCodeInfo): SourceCodeInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SourceCodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SourceCodeInfo;
+  static deserializeBinaryFromReader(message: SourceCodeInfo, reader: jspb.BinaryReader): SourceCodeInfo;
 }
 
 export namespace SourceCodeInfo {
-    export type AsObject = {
-        locationList: Array<SourceCodeInfo.Location.AsObject>,
-    }
+  export type AsObject = {
+    locationList: Array<SourceCodeInfo.Location.AsObject>,
+  }
 
-
-    export class Location extends jspb.Message { 
+  export class Location extends jspb.Message {
     clearPathList(): void;
     getPathList(): Array<number>;
     setPathList(value: Array<number>): void;
@@ -1165,12 +1054,10 @@ export namespace SourceCodeInfo {
     setSpanList(value: Array<number>): void;
     addSpan(value: number, index?: number): number;
 
-
     hasLeadingComments(): boolean;
     clearLeadingComments(): void;
     getLeadingComments(): string | undefined;
     setLeadingComments(value: string): void;
-
 
     hasTrailingComments(): boolean;
     clearTrailingComments(): void;
@@ -1182,94 +1069,86 @@ export namespace SourceCodeInfo {
     setLeadingDetachedCommentsList(value: Array<string>): void;
     addLeadingDetachedComments(value: string, index?: number): string;
 
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): Location.AsObject;
-        static toObject(includeInstance: boolean, msg: Location): Location.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: Location, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): Location;
-        static deserializeBinaryFromReader(message: Location, reader: jspb.BinaryReader): Location;
-    }
-
-    export namespace Location {
-        export type AsObject = {
-        pathList: Array<number>,
-        spanList: Array<number>,
-        leadingComments?: string,
-        trailingComments?: string,
-        leadingDetachedCommentsList: Array<string>,
-        }
-    }
-
-}
-
-export class GeneratedCodeInfo extends jspb.Message { 
-    clearAnnotationList(): void;
-    getAnnotationList(): Array<GeneratedCodeInfo.Annotation>;
-    setAnnotationList(value: Array<GeneratedCodeInfo.Annotation>): void;
-    addAnnotation(value?: GeneratedCodeInfo.Annotation, index?: number): GeneratedCodeInfo.Annotation;
-
-
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GeneratedCodeInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): GeneratedCodeInfo.AsObject;
+    toObject(includeInstance?: boolean): Location.AsObject;
+    static toObject(includeInstance: boolean, msg: Location): Location.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GeneratedCodeInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GeneratedCodeInfo;
-    static deserializeBinaryFromReader(message: GeneratedCodeInfo, reader: jspb.BinaryReader): GeneratedCodeInfo;
+    static serializeBinaryToWriter(message: Location, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Location;
+    static deserializeBinaryFromReader(message: Location, reader: jspb.BinaryReader): Location;
+  }
+
+  export namespace Location {
+    export type AsObject = {
+      pathList: Array<number>,
+      spanList: Array<number>,
+      leadingComments?: string,
+      trailingComments?: string,
+      leadingDetachedCommentsList: Array<string>,
+    }
+  }
+}
+
+export class GeneratedCodeInfo extends jspb.Message {
+  clearAnnotationList(): void;
+  getAnnotationList(): Array<GeneratedCodeInfo.Annotation>;
+  setAnnotationList(value: Array<GeneratedCodeInfo.Annotation>): void;
+  addAnnotation(value?: GeneratedCodeInfo.Annotation, index?: number): GeneratedCodeInfo.Annotation;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GeneratedCodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): GeneratedCodeInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GeneratedCodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GeneratedCodeInfo;
+  static deserializeBinaryFromReader(message: GeneratedCodeInfo, reader: jspb.BinaryReader): GeneratedCodeInfo;
 }
 
 export namespace GeneratedCodeInfo {
-    export type AsObject = {
-        annotationList: Array<GeneratedCodeInfo.Annotation.AsObject>,
-    }
+  export type AsObject = {
+    annotationList: Array<GeneratedCodeInfo.Annotation.AsObject>,
+  }
 
-
-    export class Annotation extends jspb.Message { 
+  export class Annotation extends jspb.Message {
     clearPathList(): void;
     getPathList(): Array<number>;
     setPathList(value: Array<number>): void;
     addPath(value: number, index?: number): number;
-
 
     hasSourceFile(): boolean;
     clearSourceFile(): void;
     getSourceFile(): string | undefined;
     setSourceFile(value: string): void;
 
-
     hasBegin(): boolean;
     clearBegin(): void;
     getBegin(): number | undefined;
     setBegin(value: number): void;
-
 
     hasEnd(): boolean;
     clearEnd(): void;
     getEnd(): number | undefined;
     setEnd(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Annotation.AsObject;
+    static toObject(includeInstance: boolean, msg: Annotation): Annotation.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Annotation, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Annotation;
+    static deserializeBinaryFromReader(message: Annotation, reader: jspb.BinaryReader): Annotation;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): Annotation.AsObject;
-        static toObject(includeInstance: boolean, msg: Annotation): Annotation.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: Annotation, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): Annotation;
-        static deserializeBinaryFromReader(message: Annotation, reader: jspb.BinaryReader): Annotation;
+  export namespace Annotation {
+    export type AsObject = {
+      pathList: Array<number>,
+      sourceFile?: string,
+      begin?: number,
+      end?: number,
     }
-
-    export namespace Annotation {
-        export type AsObject = {
-        pathList: Array<number>,
-        sourceFile?: string,
-        begin?: number,
-        end?: number,
-        }
-    }
-
+  }
 }
+

--- a/lib/proto/hash_resolver_pb.d.ts
+++ b/lib/proto/hash_resolver_pb.d.ts
@@ -1,60 +1,57 @@
 // package: hashresolver
 // file: hash_resolver.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 
-export class ResolveRequest extends jspb.Message { 
-    getHash(): string;
-    setHash(value: string): void;
+export class ResolveRequest extends jspb.Message {
+  getHash(): string;
+  setHash(value: string): void;
 
-    getTimeout(): number;
-    setTimeout(value: number): void;
+  getTimeout(): number;
+  setTimeout(value: number): void;
 
-    getHeightNow(): number;
-    setHeightNow(value: number): void;
+  getHeightNow(): number;
+  setHeightNow(value: number): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ResolveRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ResolveRequest): ResolveRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ResolveRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ResolveRequest;
-    static deserializeBinaryFromReader(message: ResolveRequest, reader: jspb.BinaryReader): ResolveRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ResolveRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ResolveRequest): ResolveRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ResolveRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ResolveRequest;
+  static deserializeBinaryFromReader(message: ResolveRequest, reader: jspb.BinaryReader): ResolveRequest;
 }
 
 export namespace ResolveRequest {
-    export type AsObject = {
-        hash: string,
-        timeout: number,
-        heightNow: number,
-        amount: number,
-    }
+  export type AsObject = {
+    hash: string,
+    timeout: number,
+    heightNow: number,
+    amount: number,
+  }
 }
 
-export class ResolveResponse extends jspb.Message { 
-    getPreimage(): string;
-    setPreimage(value: string): void;
+export class ResolveResponse extends jspb.Message {
+  getPreimage(): string;
+  setPreimage(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ResolveResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ResolveResponse): ResolveResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ResolveResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ResolveResponse;
-    static deserializeBinaryFromReader(message: ResolveResponse, reader: jspb.BinaryReader): ResolveResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ResolveResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ResolveResponse): ResolveResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ResolveResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ResolveResponse;
+  static deserializeBinaryFromReader(message: ResolveResponse, reader: jspb.BinaryReader): ResolveResponse;
 }
 
 export namespace ResolveResponse {
-    export type AsObject = {
-        preimage: string,
-    }
+  export type AsObject = {
+    preimage: string,
+  }
 }
+

--- a/lib/proto/lndrpc_pb.d.ts
+++ b/lib/proto/lndrpc_pb.d.ts
@@ -1,1791 +1,1691 @@
 // package: lnrpc
 // file: lndrpc.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 import * as annotations_pb from "./annotations_pb";
 
-export class GenSeedRequest extends jspb.Message { 
-    getAezeedPassphrase(): Uint8Array | string;
-    getAezeedPassphrase_asU8(): Uint8Array;
-    getAezeedPassphrase_asB64(): string;
-    setAezeedPassphrase(value: Uint8Array | string): void;
+export class GenSeedRequest extends jspb.Message {
+  getAezeedPassphrase(): Uint8Array | string;
+  getAezeedPassphrase_asU8(): Uint8Array;
+  getAezeedPassphrase_asB64(): string;
+  setAezeedPassphrase(value: Uint8Array | string): void;
 
-    getSeedEntropy(): Uint8Array | string;
-    getSeedEntropy_asU8(): Uint8Array;
-    getSeedEntropy_asB64(): string;
-    setSeedEntropy(value: Uint8Array | string): void;
+  getSeedEntropy(): Uint8Array | string;
+  getSeedEntropy_asU8(): Uint8Array;
+  getSeedEntropy_asB64(): string;
+  setSeedEntropy(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GenSeedRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GenSeedRequest): GenSeedRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GenSeedRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GenSeedRequest;
-    static deserializeBinaryFromReader(message: GenSeedRequest, reader: jspb.BinaryReader): GenSeedRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GenSeedRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GenSeedRequest): GenSeedRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GenSeedRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GenSeedRequest;
+  static deserializeBinaryFromReader(message: GenSeedRequest, reader: jspb.BinaryReader): GenSeedRequest;
 }
 
 export namespace GenSeedRequest {
-    export type AsObject = {
-        aezeedPassphrase: Uint8Array | string,
-        seedEntropy: Uint8Array | string,
-    }
+  export type AsObject = {
+    aezeedPassphrase: Uint8Array | string,
+    seedEntropy: Uint8Array | string,
+  }
 }
 
-export class GenSeedResponse extends jspb.Message { 
-    clearCipherSeedMnemonicList(): void;
-    getCipherSeedMnemonicList(): Array<string>;
-    setCipherSeedMnemonicList(value: Array<string>): void;
-    addCipherSeedMnemonic(value: string, index?: number): string;
+export class GenSeedResponse extends jspb.Message {
+  clearCipherSeedMnemonicList(): void;
+  getCipherSeedMnemonicList(): Array<string>;
+  setCipherSeedMnemonicList(value: Array<string>): void;
+  addCipherSeedMnemonic(value: string, index?: number): string;
 
-    getEncipheredSeed(): Uint8Array | string;
-    getEncipheredSeed_asU8(): Uint8Array;
-    getEncipheredSeed_asB64(): string;
-    setEncipheredSeed(value: Uint8Array | string): void;
+  getEncipheredSeed(): Uint8Array | string;
+  getEncipheredSeed_asU8(): Uint8Array;
+  getEncipheredSeed_asB64(): string;
+  setEncipheredSeed(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GenSeedResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GenSeedResponse): GenSeedResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GenSeedResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GenSeedResponse;
-    static deserializeBinaryFromReader(message: GenSeedResponse, reader: jspb.BinaryReader): GenSeedResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GenSeedResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GenSeedResponse): GenSeedResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GenSeedResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GenSeedResponse;
+  static deserializeBinaryFromReader(message: GenSeedResponse, reader: jspb.BinaryReader): GenSeedResponse;
 }
 
 export namespace GenSeedResponse {
-    export type AsObject = {
-        cipherSeedMnemonicList: Array<string>,
-        encipheredSeed: Uint8Array | string,
-    }
+  export type AsObject = {
+    cipherSeedMnemonicList: Array<string>,
+    encipheredSeed: Uint8Array | string,
+  }
 }
 
-export class InitWalletRequest extends jspb.Message { 
-    getWalletPassword(): Uint8Array | string;
-    getWalletPassword_asU8(): Uint8Array;
-    getWalletPassword_asB64(): string;
-    setWalletPassword(value: Uint8Array | string): void;
+export class InitWalletRequest extends jspb.Message {
+  getWalletPassword(): Uint8Array | string;
+  getWalletPassword_asU8(): Uint8Array;
+  getWalletPassword_asB64(): string;
+  setWalletPassword(value: Uint8Array | string): void;
 
-    clearCipherSeedMnemonicList(): void;
-    getCipherSeedMnemonicList(): Array<string>;
-    setCipherSeedMnemonicList(value: Array<string>): void;
-    addCipherSeedMnemonic(value: string, index?: number): string;
+  clearCipherSeedMnemonicList(): void;
+  getCipherSeedMnemonicList(): Array<string>;
+  setCipherSeedMnemonicList(value: Array<string>): void;
+  addCipherSeedMnemonic(value: string, index?: number): string;
 
-    getAezeedPassphrase(): Uint8Array | string;
-    getAezeedPassphrase_asU8(): Uint8Array;
-    getAezeedPassphrase_asB64(): string;
-    setAezeedPassphrase(value: Uint8Array | string): void;
+  getAezeedPassphrase(): Uint8Array | string;
+  getAezeedPassphrase_asU8(): Uint8Array;
+  getAezeedPassphrase_asB64(): string;
+  setAezeedPassphrase(value: Uint8Array | string): void;
 
-    getRecoveryWindow(): number;
-    setRecoveryWindow(value: number): void;
+  getRecoveryWindow(): number;
+  setRecoveryWindow(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): InitWalletRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: InitWalletRequest): InitWalletRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: InitWalletRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): InitWalletRequest;
-    static deserializeBinaryFromReader(message: InitWalletRequest, reader: jspb.BinaryReader): InitWalletRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): InitWalletRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: InitWalletRequest): InitWalletRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: InitWalletRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): InitWalletRequest;
+  static deserializeBinaryFromReader(message: InitWalletRequest, reader: jspb.BinaryReader): InitWalletRequest;
 }
 
 export namespace InitWalletRequest {
-    export type AsObject = {
-        walletPassword: Uint8Array | string,
-        cipherSeedMnemonicList: Array<string>,
-        aezeedPassphrase: Uint8Array | string,
-        recoveryWindow: number,
-    }
+  export type AsObject = {
+    walletPassword: Uint8Array | string,
+    cipherSeedMnemonicList: Array<string>,
+    aezeedPassphrase: Uint8Array | string,
+    recoveryWindow: number,
+  }
 }
 
-export class InitWalletResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): InitWalletResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: InitWalletResponse): InitWalletResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: InitWalletResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): InitWalletResponse;
-    static deserializeBinaryFromReader(message: InitWalletResponse, reader: jspb.BinaryReader): InitWalletResponse;
+export class InitWalletResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): InitWalletResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: InitWalletResponse): InitWalletResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: InitWalletResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): InitWalletResponse;
+  static deserializeBinaryFromReader(message: InitWalletResponse, reader: jspb.BinaryReader): InitWalletResponse;
 }
 
 export namespace InitWalletResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class UnlockWalletRequest extends jspb.Message { 
-    getWalletPassword(): Uint8Array | string;
-    getWalletPassword_asU8(): Uint8Array;
-    getWalletPassword_asB64(): string;
-    setWalletPassword(value: Uint8Array | string): void;
+export class UnlockWalletRequest extends jspb.Message {
+  getWalletPassword(): Uint8Array | string;
+  getWalletPassword_asU8(): Uint8Array;
+  getWalletPassword_asB64(): string;
+  setWalletPassword(value: Uint8Array | string): void;
 
-    getRecoveryWindow(): number;
-    setRecoveryWindow(value: number): void;
+  getRecoveryWindow(): number;
+  setRecoveryWindow(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UnlockWalletRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: UnlockWalletRequest): UnlockWalletRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UnlockWalletRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UnlockWalletRequest;
-    static deserializeBinaryFromReader(message: UnlockWalletRequest, reader: jspb.BinaryReader): UnlockWalletRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UnlockWalletRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: UnlockWalletRequest): UnlockWalletRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UnlockWalletRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UnlockWalletRequest;
+  static deserializeBinaryFromReader(message: UnlockWalletRequest, reader: jspb.BinaryReader): UnlockWalletRequest;
 }
 
 export namespace UnlockWalletRequest {
-    export type AsObject = {
-        walletPassword: Uint8Array | string,
-        recoveryWindow: number,
-    }
+  export type AsObject = {
+    walletPassword: Uint8Array | string,
+    recoveryWindow: number,
+  }
 }
 
-export class UnlockWalletResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UnlockWalletResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: UnlockWalletResponse): UnlockWalletResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UnlockWalletResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UnlockWalletResponse;
-    static deserializeBinaryFromReader(message: UnlockWalletResponse, reader: jspb.BinaryReader): UnlockWalletResponse;
+export class UnlockWalletResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UnlockWalletResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: UnlockWalletResponse): UnlockWalletResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UnlockWalletResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UnlockWalletResponse;
+  static deserializeBinaryFromReader(message: UnlockWalletResponse, reader: jspb.BinaryReader): UnlockWalletResponse;
 }
 
 export namespace UnlockWalletResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChangePasswordRequest extends jspb.Message { 
-    getCurrentPassword(): Uint8Array | string;
-    getCurrentPassword_asU8(): Uint8Array;
-    getCurrentPassword_asB64(): string;
-    setCurrentPassword(value: Uint8Array | string): void;
+export class ChangePasswordRequest extends jspb.Message {
+  getCurrentPassword(): Uint8Array | string;
+  getCurrentPassword_asU8(): Uint8Array;
+  getCurrentPassword_asB64(): string;
+  setCurrentPassword(value: Uint8Array | string): void;
 
-    getNewPassword(): Uint8Array | string;
-    getNewPassword_asU8(): Uint8Array;
-    getNewPassword_asB64(): string;
-    setNewPassword(value: Uint8Array | string): void;
+  getNewPassword(): Uint8Array | string;
+  getNewPassword_asU8(): Uint8Array;
+  getNewPassword_asB64(): string;
+  setNewPassword(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChangePasswordRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChangePasswordRequest): ChangePasswordRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChangePasswordRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChangePasswordRequest;
-    static deserializeBinaryFromReader(message: ChangePasswordRequest, reader: jspb.BinaryReader): ChangePasswordRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChangePasswordRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChangePasswordRequest): ChangePasswordRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChangePasswordRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChangePasswordRequest;
+  static deserializeBinaryFromReader(message: ChangePasswordRequest, reader: jspb.BinaryReader): ChangePasswordRequest;
 }
 
 export namespace ChangePasswordRequest {
-    export type AsObject = {
-        currentPassword: Uint8Array | string,
-        newPassword: Uint8Array | string,
-    }
+  export type AsObject = {
+    currentPassword: Uint8Array | string,
+    newPassword: Uint8Array | string,
+  }
 }
 
-export class ChangePasswordResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChangePasswordResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ChangePasswordResponse): ChangePasswordResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChangePasswordResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChangePasswordResponse;
-    static deserializeBinaryFromReader(message: ChangePasswordResponse, reader: jspb.BinaryReader): ChangePasswordResponse;
+export class ChangePasswordResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChangePasswordResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ChangePasswordResponse): ChangePasswordResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChangePasswordResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChangePasswordResponse;
+  static deserializeBinaryFromReader(message: ChangePasswordResponse, reader: jspb.BinaryReader): ChangePasswordResponse;
 }
 
 export namespace ChangePasswordResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class Transaction extends jspb.Message { 
-    getTxHash(): string;
-    setTxHash(value: string): void;
+export class Transaction extends jspb.Message {
+  getTxHash(): string;
+  setTxHash(value: string): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getNumConfirmations(): number;
-    setNumConfirmations(value: number): void;
+  getNumConfirmations(): number;
+  setNumConfirmations(value: number): void;
 
-    getBlockHash(): string;
-    setBlockHash(value: string): void;
+  getBlockHash(): string;
+  setBlockHash(value: string): void;
 
-    getBlockHeight(): number;
-    setBlockHeight(value: number): void;
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
 
-    getTimeStamp(): number;
-    setTimeStamp(value: number): void;
+  getTimeStamp(): number;
+  setTimeStamp(value: number): void;
 
-    getTotalFees(): number;
-    setTotalFees(value: number): void;
+  getTotalFees(): number;
+  setTotalFees(value: number): void;
 
-    clearDestAddressesList(): void;
-    getDestAddressesList(): Array<string>;
-    setDestAddressesList(value: Array<string>): void;
-    addDestAddresses(value: string, index?: number): string;
+  clearDestAddressesList(): void;
+  getDestAddressesList(): Array<string>;
+  setDestAddressesList(value: Array<string>): void;
+  addDestAddresses(value: string, index?: number): string;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Transaction.AsObject;
-    static toObject(includeInstance: boolean, msg: Transaction): Transaction.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Transaction, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Transaction;
-    static deserializeBinaryFromReader(message: Transaction, reader: jspb.BinaryReader): Transaction;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Transaction.AsObject;
+  static toObject(includeInstance: boolean, msg: Transaction): Transaction.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Transaction, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Transaction;
+  static deserializeBinaryFromReader(message: Transaction, reader: jspb.BinaryReader): Transaction;
 }
 
 export namespace Transaction {
-    export type AsObject = {
-        txHash: string,
-        amount: number,
-        numConfirmations: number,
-        blockHash: string,
-        blockHeight: number,
-        timeStamp: number,
-        totalFees: number,
-        destAddressesList: Array<string>,
-    }
+  export type AsObject = {
+    txHash: string,
+    amount: number,
+    numConfirmations: number,
+    blockHash: string,
+    blockHeight: number,
+    timeStamp: number,
+    totalFees: number,
+    destAddressesList: Array<string>,
+  }
 }
 
-export class GetTransactionsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetTransactionsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetTransactionsRequest): GetTransactionsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetTransactionsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetTransactionsRequest;
-    static deserializeBinaryFromReader(message: GetTransactionsRequest, reader: jspb.BinaryReader): GetTransactionsRequest;
+export class GetTransactionsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetTransactionsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetTransactionsRequest): GetTransactionsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetTransactionsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetTransactionsRequest;
+  static deserializeBinaryFromReader(message: GetTransactionsRequest, reader: jspb.BinaryReader): GetTransactionsRequest;
 }
 
 export namespace GetTransactionsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class TransactionDetails extends jspb.Message { 
-    clearTransactionsList(): void;
-    getTransactionsList(): Array<Transaction>;
-    setTransactionsList(value: Array<Transaction>): void;
-    addTransactions(value?: Transaction, index?: number): Transaction;
+export class TransactionDetails extends jspb.Message {
+  clearTransactionsList(): void;
+  getTransactionsList(): Array<Transaction>;
+  setTransactionsList(value: Array<Transaction>): void;
+  addTransactions(value?: Transaction, index?: number): Transaction;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TransactionDetails.AsObject;
-    static toObject(includeInstance: boolean, msg: TransactionDetails): TransactionDetails.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TransactionDetails, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TransactionDetails;
-    static deserializeBinaryFromReader(message: TransactionDetails, reader: jspb.BinaryReader): TransactionDetails;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): TransactionDetails.AsObject;
+  static toObject(includeInstance: boolean, msg: TransactionDetails): TransactionDetails.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: TransactionDetails, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): TransactionDetails;
+  static deserializeBinaryFromReader(message: TransactionDetails, reader: jspb.BinaryReader): TransactionDetails;
 }
 
 export namespace TransactionDetails {
-    export type AsObject = {
-        transactionsList: Array<Transaction.AsObject>,
-    }
+  export type AsObject = {
+    transactionsList: Array<Transaction.AsObject>,
+  }
 }
 
-export class FeeLimit extends jspb.Message { 
+export class FeeLimit extends jspb.Message {
+  hasFixed(): boolean;
+  clearFixed(): void;
+  getFixed(): number;
+  setFixed(value: number): void;
 
-    hasFixed(): boolean;
-    clearFixed(): void;
-    getFixed(): number;
-    setFixed(value: number): void;
+  hasPercent(): boolean;
+  clearPercent(): void;
+  getPercent(): number;
+  setPercent(value: number): void;
 
-
-    hasPercent(): boolean;
-    clearPercent(): void;
-    getPercent(): number;
-    setPercent(value: number): void;
-
-
-    getLimitCase(): FeeLimit.LimitCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FeeLimit.AsObject;
-    static toObject(includeInstance: boolean, msg: FeeLimit): FeeLimit.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FeeLimit, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FeeLimit;
-    static deserializeBinaryFromReader(message: FeeLimit, reader: jspb.BinaryReader): FeeLimit;
+  getLimitCase(): FeeLimit.LimitCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FeeLimit.AsObject;
+  static toObject(includeInstance: boolean, msg: FeeLimit): FeeLimit.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FeeLimit, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FeeLimit;
+  static deserializeBinaryFromReader(message: FeeLimit, reader: jspb.BinaryReader): FeeLimit;
 }
 
 export namespace FeeLimit {
-    export type AsObject = {
-        fixed: number,
-        percent: number,
-    }
+  export type AsObject = {
+    fixed: number,
+    percent: number,
+  }
 
-    export enum LimitCase {
-        LIMIT_NOT_SET = 0,
-    
+  export enum LimitCase {
+    LIMIT_NOT_SET = 0,
     FIXED = 1,
-
     PERCENT = 2,
-
-    }
-
+  }
 }
 
-export class SendRequest extends jspb.Message { 
-    getDest(): Uint8Array | string;
-    getDest_asU8(): Uint8Array;
-    getDest_asB64(): string;
-    setDest(value: Uint8Array | string): void;
+export class SendRequest extends jspb.Message {
+  getDest(): Uint8Array | string;
+  getDest_asU8(): Uint8Array;
+  getDest_asB64(): string;
+  setDest(value: Uint8Array | string): void;
 
-    getDestString(): string;
-    setDestString(value: string): void;
+  getDestString(): string;
+  setDestString(value: string): void;
 
-    getAmt(): number;
-    setAmt(value: number): void;
+  getAmt(): number;
+  setAmt(value: number): void;
 
-    getPaymentHash(): Uint8Array | string;
-    getPaymentHash_asU8(): Uint8Array;
-    getPaymentHash_asB64(): string;
-    setPaymentHash(value: Uint8Array | string): void;
+  getPaymentHash(): Uint8Array | string;
+  getPaymentHash_asU8(): Uint8Array;
+  getPaymentHash_asB64(): string;
+  setPaymentHash(value: Uint8Array | string): void;
 
-    getPaymentHashString(): string;
-    setPaymentHashString(value: string): void;
+  getPaymentHashString(): string;
+  setPaymentHashString(value: string): void;
 
-    getPaymentRequest(): string;
-    setPaymentRequest(value: string): void;
+  getPaymentRequest(): string;
+  setPaymentRequest(value: string): void;
 
-    getFinalCltvDelta(): number;
-    setFinalCltvDelta(value: number): void;
+  getFinalCltvDelta(): number;
+  setFinalCltvDelta(value: number): void;
 
+  hasFeeLimit(): boolean;
+  clearFeeLimit(): void;
+  getFeeLimit(): FeeLimit | undefined;
+  setFeeLimit(value?: FeeLimit): void;
 
-    hasFeeLimit(): boolean;
-    clearFeeLimit(): void;
-    getFeeLimit(): FeeLimit | undefined;
-    setFeeLimit(value?: FeeLimit): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendRequest): SendRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendRequest;
-    static deserializeBinaryFromReader(message: SendRequest, reader: jspb.BinaryReader): SendRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendRequest): SendRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendRequest;
+  static deserializeBinaryFromReader(message: SendRequest, reader: jspb.BinaryReader): SendRequest;
 }
 
 export namespace SendRequest {
-    export type AsObject = {
-        dest: Uint8Array | string,
-        destString: string,
-        amt: number,
-        paymentHash: Uint8Array | string,
-        paymentHashString: string,
-        paymentRequest: string,
-        finalCltvDelta: number,
-        feeLimit?: FeeLimit.AsObject,
-    }
+  export type AsObject = {
+    dest: Uint8Array | string,
+    destString: string,
+    amt: number,
+    paymentHash: Uint8Array | string,
+    paymentHashString: string,
+    paymentRequest: string,
+    finalCltvDelta: number,
+    feeLimit?: FeeLimit.AsObject,
+  }
 }
 
-export class SendResponse extends jspb.Message { 
-    getPaymentError(): string;
-    setPaymentError(value: string): void;
+export class SendResponse extends jspb.Message {
+  getPaymentError(): string;
+  setPaymentError(value: string): void;
 
-    getPaymentPreimage(): Uint8Array | string;
-    getPaymentPreimage_asU8(): Uint8Array;
-    getPaymentPreimage_asB64(): string;
-    setPaymentPreimage(value: Uint8Array | string): void;
+  getPaymentPreimage(): Uint8Array | string;
+  getPaymentPreimage_asU8(): Uint8Array;
+  getPaymentPreimage_asB64(): string;
+  setPaymentPreimage(value: Uint8Array | string): void;
 
+  hasPaymentRoute(): boolean;
+  clearPaymentRoute(): void;
+  getPaymentRoute(): Route | undefined;
+  setPaymentRoute(value?: Route): void;
 
-    hasPaymentRoute(): boolean;
-    clearPaymentRoute(): void;
-    getPaymentRoute(): Route | undefined;
-    setPaymentRoute(value?: Route): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SendResponse): SendResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendResponse;
-    static deserializeBinaryFromReader(message: SendResponse, reader: jspb.BinaryReader): SendResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SendResponse): SendResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendResponse;
+  static deserializeBinaryFromReader(message: SendResponse, reader: jspb.BinaryReader): SendResponse;
 }
 
 export namespace SendResponse {
-    export type AsObject = {
-        paymentError: string,
-        paymentPreimage: Uint8Array | string,
-        paymentRoute?: Route.AsObject,
-    }
+  export type AsObject = {
+    paymentError: string,
+    paymentPreimage: Uint8Array | string,
+    paymentRoute?: Route.AsObject,
+  }
 }
 
-export class SendToRouteRequest extends jspb.Message { 
-    getPaymentHash(): Uint8Array | string;
-    getPaymentHash_asU8(): Uint8Array;
-    getPaymentHash_asB64(): string;
-    setPaymentHash(value: Uint8Array | string): void;
+export class SendToRouteRequest extends jspb.Message {
+  getPaymentHash(): Uint8Array | string;
+  getPaymentHash_asU8(): Uint8Array;
+  getPaymentHash_asB64(): string;
+  setPaymentHash(value: Uint8Array | string): void;
 
-    getPaymentHashString(): string;
-    setPaymentHashString(value: string): void;
+  getPaymentHashString(): string;
+  setPaymentHashString(value: string): void;
 
-    clearRoutesList(): void;
-    getRoutesList(): Array<Route>;
-    setRoutesList(value: Array<Route>): void;
-    addRoutes(value?: Route, index?: number): Route;
+  clearRoutesList(): void;
+  getRoutesList(): Array<Route>;
+  setRoutesList(value: Array<Route>): void;
+  addRoutes(value?: Route, index?: number): Route;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendToRouteRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendToRouteRequest): SendToRouteRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendToRouteRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendToRouteRequest;
-    static deserializeBinaryFromReader(message: SendToRouteRequest, reader: jspb.BinaryReader): SendToRouteRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendToRouteRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendToRouteRequest): SendToRouteRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendToRouteRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendToRouteRequest;
+  static deserializeBinaryFromReader(message: SendToRouteRequest, reader: jspb.BinaryReader): SendToRouteRequest;
 }
 
 export namespace SendToRouteRequest {
-    export type AsObject = {
-        paymentHash: Uint8Array | string,
-        paymentHashString: string,
-        routesList: Array<Route.AsObject>,
-    }
+  export type AsObject = {
+    paymentHash: Uint8Array | string,
+    paymentHashString: string,
+    routesList: Array<Route.AsObject>,
+  }
 }
 
-export class ChannelPoint extends jspb.Message { 
+export class ChannelPoint extends jspb.Message {
+  hasFundingTxidBytes(): boolean;
+  clearFundingTxidBytes(): void;
+  getFundingTxidBytes(): Uint8Array | string;
+  getFundingTxidBytes_asU8(): Uint8Array;
+  getFundingTxidBytes_asB64(): string;
+  setFundingTxidBytes(value: Uint8Array | string): void;
 
-    hasFundingTxidBytes(): boolean;
-    clearFundingTxidBytes(): void;
-    getFundingTxidBytes(): Uint8Array | string;
-    getFundingTxidBytes_asU8(): Uint8Array;
-    getFundingTxidBytes_asB64(): string;
-    setFundingTxidBytes(value: Uint8Array | string): void;
+  hasFundingTxidStr(): boolean;
+  clearFundingTxidStr(): void;
+  getFundingTxidStr(): string;
+  setFundingTxidStr(value: string): void;
 
+  getOutputIndex(): number;
+  setOutputIndex(value: number): void;
 
-    hasFundingTxidStr(): boolean;
-    clearFundingTxidStr(): void;
-    getFundingTxidStr(): string;
-    setFundingTxidStr(value: string): void;
-
-    getOutputIndex(): number;
-    setOutputIndex(value: number): void;
-
-
-    getFundingTxidCase(): ChannelPoint.FundingTxidCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelPoint.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelPoint): ChannelPoint.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelPoint, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelPoint;
-    static deserializeBinaryFromReader(message: ChannelPoint, reader: jspb.BinaryReader): ChannelPoint;
+  getFundingTxidCase(): ChannelPoint.FundingTxidCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelPoint.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelPoint): ChannelPoint.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelPoint, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelPoint;
+  static deserializeBinaryFromReader(message: ChannelPoint, reader: jspb.BinaryReader): ChannelPoint;
 }
 
 export namespace ChannelPoint {
-    export type AsObject = {
-        fundingTxidBytes: Uint8Array | string,
-        fundingTxidStr: string,
-        outputIndex: number,
-    }
+  export type AsObject = {
+    fundingTxidBytes: Uint8Array | string,
+    fundingTxidStr: string,
+    outputIndex: number,
+  }
 
-    export enum FundingTxidCase {
-        FUNDINGTXID_NOT_SET = 0,
-    
+  export enum FundingTxidCase {
+    FUNDING_TXID_NOT_SET = 0,
     FUNDING_TXID_BYTES = 1,
-
     FUNDING_TXID_STR = 2,
-
-    }
-
+  }
 }
 
-export class LightningAddress extends jspb.Message { 
-    getPubkey(): string;
-    setPubkey(value: string): void;
+export class LightningAddress extends jspb.Message {
+  getPubkey(): string;
+  setPubkey(value: string): void;
 
-    getHost(): string;
-    setHost(value: string): void;
+  getHost(): string;
+  setHost(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LightningAddress.AsObject;
-    static toObject(includeInstance: boolean, msg: LightningAddress): LightningAddress.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LightningAddress, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LightningAddress;
-    static deserializeBinaryFromReader(message: LightningAddress, reader: jspb.BinaryReader): LightningAddress;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LightningAddress.AsObject;
+  static toObject(includeInstance: boolean, msg: LightningAddress): LightningAddress.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LightningAddress, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LightningAddress;
+  static deserializeBinaryFromReader(message: LightningAddress, reader: jspb.BinaryReader): LightningAddress;
 }
 
 export namespace LightningAddress {
-    export type AsObject = {
-        pubkey: string,
-        host: string,
-    }
+  export type AsObject = {
+    pubkey: string,
+    host: string,
+  }
 }
 
-export class SendManyRequest extends jspb.Message { 
+export class SendManyRequest extends jspb.Message {
+  getAddrtoamountMap(): jspb.Map<string, number>;
+  clearAddrtoamountMap(): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getAddrtoamountMap(): jspb.Map<string, number>;
-    clearAddrtoamountMap(): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
-
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendManyRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendManyRequest): SendManyRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendManyRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendManyRequest;
-    static deserializeBinaryFromReader(message: SendManyRequest, reader: jspb.BinaryReader): SendManyRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendManyRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendManyRequest): SendManyRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendManyRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendManyRequest;
+  static deserializeBinaryFromReader(message: SendManyRequest, reader: jspb.BinaryReader): SendManyRequest;
 }
 
 export namespace SendManyRequest {
-    export type AsObject = {
-
-        addrtoamountMap: Array<[string, number]>,
-        targetConf: number,
-        satPerByte: number,
-    }
+  export type AsObject = {
+    addrtoamountMap: Array<[string, number]>,
+    targetConf: number,
+    satPerByte: number,
+  }
 }
 
-export class SendManyResponse extends jspb.Message { 
-    getTxid(): string;
-    setTxid(value: string): void;
+export class SendManyResponse extends jspb.Message {
+  getTxid(): string;
+  setTxid(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendManyResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SendManyResponse): SendManyResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendManyResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendManyResponse;
-    static deserializeBinaryFromReader(message: SendManyResponse, reader: jspb.BinaryReader): SendManyResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendManyResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SendManyResponse): SendManyResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendManyResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendManyResponse;
+  static deserializeBinaryFromReader(message: SendManyResponse, reader: jspb.BinaryReader): SendManyResponse;
 }
 
 export namespace SendManyResponse {
-    export type AsObject = {
-        txid: string,
-    }
+  export type AsObject = {
+    txid: string,
+  }
 }
 
-export class SendCoinsRequest extends jspb.Message { 
-    getAddr(): string;
-    setAddr(value: string): void;
+export class SendCoinsRequest extends jspb.Message {
+  getAddr(): string;
+  setAddr(value: string): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendCoinsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendCoinsRequest): SendCoinsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendCoinsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendCoinsRequest;
-    static deserializeBinaryFromReader(message: SendCoinsRequest, reader: jspb.BinaryReader): SendCoinsRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendCoinsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendCoinsRequest): SendCoinsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendCoinsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendCoinsRequest;
+  static deserializeBinaryFromReader(message: SendCoinsRequest, reader: jspb.BinaryReader): SendCoinsRequest;
 }
 
 export namespace SendCoinsRequest {
-    export type AsObject = {
-        addr: string,
-        amount: number,
-        targetConf: number,
-        satPerByte: number,
-    }
+  export type AsObject = {
+    addr: string,
+    amount: number,
+    targetConf: number,
+    satPerByte: number,
+  }
 }
 
-export class SendCoinsResponse extends jspb.Message { 
-    getTxid(): string;
-    setTxid(value: string): void;
+export class SendCoinsResponse extends jspb.Message {
+  getTxid(): string;
+  setTxid(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendCoinsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SendCoinsResponse): SendCoinsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendCoinsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendCoinsResponse;
-    static deserializeBinaryFromReader(message: SendCoinsResponse, reader: jspb.BinaryReader): SendCoinsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendCoinsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SendCoinsResponse): SendCoinsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendCoinsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendCoinsResponse;
+  static deserializeBinaryFromReader(message: SendCoinsResponse, reader: jspb.BinaryReader): SendCoinsResponse;
 }
 
 export namespace SendCoinsResponse {
-    export type AsObject = {
-        txid: string,
-    }
+  export type AsObject = {
+    txid: string,
+  }
 }
 
-export class NewAddressRequest extends jspb.Message { 
-    getType(): NewAddressRequest.AddressType;
-    setType(value: NewAddressRequest.AddressType): void;
+export class NewAddressRequest extends jspb.Message {
+  getType(): NewAddressRequest.AddressType;
+  setType(value: NewAddressRequest.AddressType): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NewAddressRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NewAddressRequest): NewAddressRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NewAddressRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NewAddressRequest;
-    static deserializeBinaryFromReader(message: NewAddressRequest, reader: jspb.BinaryReader): NewAddressRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NewAddressRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NewAddressRequest): NewAddressRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NewAddressRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NewAddressRequest;
+  static deserializeBinaryFromReader(message: NewAddressRequest, reader: jspb.BinaryReader): NewAddressRequest;
 }
 
 export namespace NewAddressRequest {
-    export type AsObject = {
-        type: NewAddressRequest.AddressType,
-    }
+  export type AsObject = {
+    type: NewAddressRequest.AddressType,
+  }
 
-    export enum AddressType {
+  export enum AddressType {
     WITNESS_PUBKEY_HASH = 0,
     NESTED_PUBKEY_HASH = 1,
-    }
-
+  }
 }
 
-export class NewWitnessAddressRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NewWitnessAddressRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NewWitnessAddressRequest): NewWitnessAddressRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NewWitnessAddressRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NewWitnessAddressRequest;
-    static deserializeBinaryFromReader(message: NewWitnessAddressRequest, reader: jspb.BinaryReader): NewWitnessAddressRequest;
+export class NewWitnessAddressRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NewWitnessAddressRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NewWitnessAddressRequest): NewWitnessAddressRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NewWitnessAddressRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NewWitnessAddressRequest;
+  static deserializeBinaryFromReader(message: NewWitnessAddressRequest, reader: jspb.BinaryReader): NewWitnessAddressRequest;
 }
 
 export namespace NewWitnessAddressRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class NewAddressResponse extends jspb.Message { 
-    getAddress(): string;
-    setAddress(value: string): void;
+export class NewAddressResponse extends jspb.Message {
+  getAddress(): string;
+  setAddress(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NewAddressResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: NewAddressResponse): NewAddressResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NewAddressResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NewAddressResponse;
-    static deserializeBinaryFromReader(message: NewAddressResponse, reader: jspb.BinaryReader): NewAddressResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NewAddressResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: NewAddressResponse): NewAddressResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NewAddressResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NewAddressResponse;
+  static deserializeBinaryFromReader(message: NewAddressResponse, reader: jspb.BinaryReader): NewAddressResponse;
 }
 
 export namespace NewAddressResponse {
-    export type AsObject = {
-        address: string,
-    }
+  export type AsObject = {
+    address: string,
+  }
 }
 
-export class SignMessageRequest extends jspb.Message { 
-    getMsg(): Uint8Array | string;
-    getMsg_asU8(): Uint8Array;
-    getMsg_asB64(): string;
-    setMsg(value: Uint8Array | string): void;
+export class SignMessageRequest extends jspb.Message {
+  getMsg(): Uint8Array | string;
+  getMsg_asU8(): Uint8Array;
+  getMsg_asB64(): string;
+  setMsg(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SignMessageRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SignMessageRequest): SignMessageRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SignMessageRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SignMessageRequest;
-    static deserializeBinaryFromReader(message: SignMessageRequest, reader: jspb.BinaryReader): SignMessageRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SignMessageRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SignMessageRequest): SignMessageRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SignMessageRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SignMessageRequest;
+  static deserializeBinaryFromReader(message: SignMessageRequest, reader: jspb.BinaryReader): SignMessageRequest;
 }
 
 export namespace SignMessageRequest {
-    export type AsObject = {
-        msg: Uint8Array | string,
-    }
+  export type AsObject = {
+    msg: Uint8Array | string,
+  }
 }
 
-export class SignMessageResponse extends jspb.Message { 
-    getSignature(): string;
-    setSignature(value: string): void;
+export class SignMessageResponse extends jspb.Message {
+  getSignature(): string;
+  setSignature(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SignMessageResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SignMessageResponse): SignMessageResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SignMessageResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SignMessageResponse;
-    static deserializeBinaryFromReader(message: SignMessageResponse, reader: jspb.BinaryReader): SignMessageResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SignMessageResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SignMessageResponse): SignMessageResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SignMessageResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SignMessageResponse;
+  static deserializeBinaryFromReader(message: SignMessageResponse, reader: jspb.BinaryReader): SignMessageResponse;
 }
 
 export namespace SignMessageResponse {
-    export type AsObject = {
-        signature: string,
-    }
+  export type AsObject = {
+    signature: string,
+  }
 }
 
-export class VerifyMessageRequest extends jspb.Message { 
-    getMsg(): Uint8Array | string;
-    getMsg_asU8(): Uint8Array;
-    getMsg_asB64(): string;
-    setMsg(value: Uint8Array | string): void;
+export class VerifyMessageRequest extends jspb.Message {
+  getMsg(): Uint8Array | string;
+  getMsg_asU8(): Uint8Array;
+  getMsg_asB64(): string;
+  setMsg(value: Uint8Array | string): void;
 
-    getSignature(): string;
-    setSignature(value: string): void;
+  getSignature(): string;
+  setSignature(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): VerifyMessageRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: VerifyMessageRequest): VerifyMessageRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: VerifyMessageRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): VerifyMessageRequest;
-    static deserializeBinaryFromReader(message: VerifyMessageRequest, reader: jspb.BinaryReader): VerifyMessageRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): VerifyMessageRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: VerifyMessageRequest): VerifyMessageRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: VerifyMessageRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): VerifyMessageRequest;
+  static deserializeBinaryFromReader(message: VerifyMessageRequest, reader: jspb.BinaryReader): VerifyMessageRequest;
 }
 
 export namespace VerifyMessageRequest {
-    export type AsObject = {
-        msg: Uint8Array | string,
-        signature: string,
-    }
+  export type AsObject = {
+    msg: Uint8Array | string,
+    signature: string,
+  }
 }
 
-export class VerifyMessageResponse extends jspb.Message { 
-    getValid(): boolean;
-    setValid(value: boolean): void;
+export class VerifyMessageResponse extends jspb.Message {
+  getValid(): boolean;
+  setValid(value: boolean): void;
 
-    getPubkey(): string;
-    setPubkey(value: string): void;
+  getPubkey(): string;
+  setPubkey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): VerifyMessageResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: VerifyMessageResponse): VerifyMessageResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: VerifyMessageResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): VerifyMessageResponse;
-    static deserializeBinaryFromReader(message: VerifyMessageResponse, reader: jspb.BinaryReader): VerifyMessageResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): VerifyMessageResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: VerifyMessageResponse): VerifyMessageResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: VerifyMessageResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): VerifyMessageResponse;
+  static deserializeBinaryFromReader(message: VerifyMessageResponse, reader: jspb.BinaryReader): VerifyMessageResponse;
 }
 
 export namespace VerifyMessageResponse {
-    export type AsObject = {
-        valid: boolean,
-        pubkey: string,
-    }
+  export type AsObject = {
+    valid: boolean,
+    pubkey: string,
+  }
 }
 
-export class ConnectPeerRequest extends jspb.Message { 
+export class ConnectPeerRequest extends jspb.Message {
+  hasAddr(): boolean;
+  clearAddr(): void;
+  getAddr(): LightningAddress | undefined;
+  setAddr(value?: LightningAddress): void;
 
-    hasAddr(): boolean;
-    clearAddr(): void;
-    getAddr(): LightningAddress | undefined;
-    setAddr(value?: LightningAddress): void;
+  getPerm(): boolean;
+  setPerm(value: boolean): void;
 
-    getPerm(): boolean;
-    setPerm(value: boolean): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectPeerRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectPeerRequest): ConnectPeerRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectPeerRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectPeerRequest;
-    static deserializeBinaryFromReader(message: ConnectPeerRequest, reader: jspb.BinaryReader): ConnectPeerRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectPeerRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectPeerRequest): ConnectPeerRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectPeerRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectPeerRequest;
+  static deserializeBinaryFromReader(message: ConnectPeerRequest, reader: jspb.BinaryReader): ConnectPeerRequest;
 }
 
 export namespace ConnectPeerRequest {
-    export type AsObject = {
-        addr?: LightningAddress.AsObject,
-        perm: boolean,
-    }
+  export type AsObject = {
+    addr?: LightningAddress.AsObject,
+    perm: boolean,
+  }
 }
 
-export class ConnectPeerResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectPeerResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectPeerResponse): ConnectPeerResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectPeerResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectPeerResponse;
-    static deserializeBinaryFromReader(message: ConnectPeerResponse, reader: jspb.BinaryReader): ConnectPeerResponse;
+export class ConnectPeerResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectPeerResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectPeerResponse): ConnectPeerResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectPeerResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectPeerResponse;
+  static deserializeBinaryFromReader(message: ConnectPeerResponse, reader: jspb.BinaryReader): ConnectPeerResponse;
 }
 
 export namespace ConnectPeerResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class DisconnectPeerRequest extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class DisconnectPeerRequest extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DisconnectPeerRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DisconnectPeerRequest): DisconnectPeerRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DisconnectPeerRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DisconnectPeerRequest;
-    static deserializeBinaryFromReader(message: DisconnectPeerRequest, reader: jspb.BinaryReader): DisconnectPeerRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DisconnectPeerRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DisconnectPeerRequest): DisconnectPeerRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DisconnectPeerRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DisconnectPeerRequest;
+  static deserializeBinaryFromReader(message: DisconnectPeerRequest, reader: jspb.BinaryReader): DisconnectPeerRequest;
 }
 
 export namespace DisconnectPeerRequest {
-    export type AsObject = {
-        pubKey: string,
-    }
+  export type AsObject = {
+    pubKey: string,
+  }
 }
 
-export class DisconnectPeerResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DisconnectPeerResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DisconnectPeerResponse): DisconnectPeerResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DisconnectPeerResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DisconnectPeerResponse;
-    static deserializeBinaryFromReader(message: DisconnectPeerResponse, reader: jspb.BinaryReader): DisconnectPeerResponse;
+export class DisconnectPeerResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DisconnectPeerResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DisconnectPeerResponse): DisconnectPeerResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DisconnectPeerResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DisconnectPeerResponse;
+  static deserializeBinaryFromReader(message: DisconnectPeerResponse, reader: jspb.BinaryReader): DisconnectPeerResponse;
 }
 
 export namespace DisconnectPeerResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class HTLC extends jspb.Message { 
-    getIncoming(): boolean;
-    setIncoming(value: boolean): void;
+export class HTLC extends jspb.Message {
+  getIncoming(): boolean;
+  setIncoming(value: boolean): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getHashLock(): Uint8Array | string;
-    getHashLock_asU8(): Uint8Array;
-    getHashLock_asB64(): string;
-    setHashLock(value: Uint8Array | string): void;
+  getHashLock(): Uint8Array | string;
+  getHashLock_asU8(): Uint8Array;
+  getHashLock_asB64(): string;
+  setHashLock(value: Uint8Array | string): void;
 
-    getExpirationHeight(): number;
-    setExpirationHeight(value: number): void;
+  getExpirationHeight(): number;
+  setExpirationHeight(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): HTLC.AsObject;
-    static toObject(includeInstance: boolean, msg: HTLC): HTLC.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: HTLC, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): HTLC;
-    static deserializeBinaryFromReader(message: HTLC, reader: jspb.BinaryReader): HTLC;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): HTLC.AsObject;
+  static toObject(includeInstance: boolean, msg: HTLC): HTLC.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: HTLC, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): HTLC;
+  static deserializeBinaryFromReader(message: HTLC, reader: jspb.BinaryReader): HTLC;
 }
 
 export namespace HTLC {
-    export type AsObject = {
-        incoming: boolean,
-        amount: number,
-        hashLock: Uint8Array | string,
-        expirationHeight: number,
-    }
+  export type AsObject = {
+    incoming: boolean,
+    amount: number,
+    hashLock: Uint8Array | string,
+    expirationHeight: number,
+  }
 }
 
-export class Channel extends jspb.Message { 
-    getActive(): boolean;
-    setActive(value: boolean): void;
+export class Channel extends jspb.Message {
+  getActive(): boolean;
+  setActive(value: boolean): void;
 
-    getRemotePubkey(): string;
-    setRemotePubkey(value: string): void;
+  getRemotePubkey(): string;
+  setRemotePubkey(value: string): void;
 
-    getChannelPoint(): string;
-    setChannelPoint(value: string): void;
+  getChannelPoint(): string;
+  setChannelPoint(value: string): void;
 
-    getChanId(): number;
-    setChanId(value: number): void;
+  getChanId(): string;
+  setChanId(value: string): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getLocalBalance(): number;
-    setLocalBalance(value: number): void;
+  getLocalBalance(): number;
+  setLocalBalance(value: number): void;
 
-    getRemoteBalance(): number;
-    setRemoteBalance(value: number): void;
+  getRemoteBalance(): number;
+  setRemoteBalance(value: number): void;
 
-    getCommitFee(): number;
-    setCommitFee(value: number): void;
+  getCommitFee(): number;
+  setCommitFee(value: number): void;
 
-    getCommitWeight(): number;
-    setCommitWeight(value: number): void;
+  getCommitWeight(): number;
+  setCommitWeight(value: number): void;
 
-    getFeePerKw(): number;
-    setFeePerKw(value: number): void;
+  getFeePerKw(): number;
+  setFeePerKw(value: number): void;
 
-    getUnsettledBalance(): number;
-    setUnsettledBalance(value: number): void;
+  getUnsettledBalance(): number;
+  setUnsettledBalance(value: number): void;
 
-    getTotalSatoshisSent(): number;
-    setTotalSatoshisSent(value: number): void;
+  getTotalSatoshisSent(): number;
+  setTotalSatoshisSent(value: number): void;
 
-    getTotalSatoshisReceived(): number;
-    setTotalSatoshisReceived(value: number): void;
+  getTotalSatoshisReceived(): number;
+  setTotalSatoshisReceived(value: number): void;
 
-    getNumUpdates(): number;
-    setNumUpdates(value: number): void;
+  getNumUpdates(): number;
+  setNumUpdates(value: number): void;
 
-    clearPendingHtlcsList(): void;
-    getPendingHtlcsList(): Array<HTLC>;
-    setPendingHtlcsList(value: Array<HTLC>): void;
-    addPendingHtlcs(value?: HTLC, index?: number): HTLC;
+  clearPendingHtlcsList(): void;
+  getPendingHtlcsList(): Array<HTLC>;
+  setPendingHtlcsList(value: Array<HTLC>): void;
+  addPendingHtlcs(value?: HTLC, index?: number): HTLC;
 
-    getCsvDelay(): number;
-    setCsvDelay(value: number): void;
+  getCsvDelay(): number;
+  setCsvDelay(value: number): void;
 
-    getPrivate(): boolean;
-    setPrivate(value: boolean): void;
+  getPrivate(): boolean;
+  setPrivate(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Channel.AsObject;
-    static toObject(includeInstance: boolean, msg: Channel): Channel.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Channel, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Channel;
-    static deserializeBinaryFromReader(message: Channel, reader: jspb.BinaryReader): Channel;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Channel.AsObject;
+  static toObject(includeInstance: boolean, msg: Channel): Channel.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Channel, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Channel;
+  static deserializeBinaryFromReader(message: Channel, reader: jspb.BinaryReader): Channel;
 }
 
 export namespace Channel {
-    export type AsObject = {
-        active: boolean,
-        remotePubkey: string,
-        channelPoint: string,
-        chanId: number,
-        capacity: number,
-        localBalance: number,
-        remoteBalance: number,
-        commitFee: number,
-        commitWeight: number,
-        feePerKw: number,
-        unsettledBalance: number,
-        totalSatoshisSent: number,
-        totalSatoshisReceived: number,
-        numUpdates: number,
-        pendingHtlcsList: Array<HTLC.AsObject>,
-        csvDelay: number,
-        pb_private: boolean,
-    }
+  export type AsObject = {
+    active: boolean,
+    remotePubkey: string,
+    channelPoint: string,
+    chanId: string,
+    capacity: number,
+    localBalance: number,
+    remoteBalance: number,
+    commitFee: number,
+    commitWeight: number,
+    feePerKw: number,
+    unsettledBalance: number,
+    totalSatoshisSent: number,
+    totalSatoshisReceived: number,
+    numUpdates: number,
+    pendingHtlcsList: Array<HTLC.AsObject>,
+    csvDelay: number,
+    pb_private: boolean,
+  }
 }
 
-export class ListChannelsRequest extends jspb.Message { 
-    getActiveOnly(): boolean;
-    setActiveOnly(value: boolean): void;
+export class ListChannelsRequest extends jspb.Message {
+  getActiveOnly(): boolean;
+  setActiveOnly(value: boolean): void;
 
-    getInactiveOnly(): boolean;
-    setInactiveOnly(value: boolean): void;
+  getInactiveOnly(): boolean;
+  setInactiveOnly(value: boolean): void;
 
-    getPublicOnly(): boolean;
-    setPublicOnly(value: boolean): void;
+  getPublicOnly(): boolean;
+  setPublicOnly(value: boolean): void;
 
-    getPrivateOnly(): boolean;
-    setPrivateOnly(value: boolean): void;
+  getPrivateOnly(): boolean;
+  setPrivateOnly(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListChannelsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListChannelsRequest): ListChannelsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListChannelsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListChannelsRequest;
-    static deserializeBinaryFromReader(message: ListChannelsRequest, reader: jspb.BinaryReader): ListChannelsRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListChannelsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListChannelsRequest): ListChannelsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListChannelsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListChannelsRequest;
+  static deserializeBinaryFromReader(message: ListChannelsRequest, reader: jspb.BinaryReader): ListChannelsRequest;
 }
 
 export namespace ListChannelsRequest {
-    export type AsObject = {
-        activeOnly: boolean,
-        inactiveOnly: boolean,
-        publicOnly: boolean,
-        privateOnly: boolean,
-    }
+  export type AsObject = {
+    activeOnly: boolean,
+    inactiveOnly: boolean,
+    publicOnly: boolean,
+    privateOnly: boolean,
+  }
 }
 
-export class ListChannelsResponse extends jspb.Message { 
-    clearChannelsList(): void;
-    getChannelsList(): Array<Channel>;
-    setChannelsList(value: Array<Channel>): void;
-    addChannels(value?: Channel, index?: number): Channel;
+export class ListChannelsResponse extends jspb.Message {
+  clearChannelsList(): void;
+  getChannelsList(): Array<Channel>;
+  setChannelsList(value: Array<Channel>): void;
+  addChannels(value?: Channel, index?: number): Channel;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListChannelsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListChannelsResponse): ListChannelsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListChannelsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListChannelsResponse;
-    static deserializeBinaryFromReader(message: ListChannelsResponse, reader: jspb.BinaryReader): ListChannelsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListChannelsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListChannelsResponse): ListChannelsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListChannelsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListChannelsResponse;
+  static deserializeBinaryFromReader(message: ListChannelsResponse, reader: jspb.BinaryReader): ListChannelsResponse;
 }
 
 export namespace ListChannelsResponse {
-    export type AsObject = {
-        channelsList: Array<Channel.AsObject>,
-    }
+  export type AsObject = {
+    channelsList: Array<Channel.AsObject>,
+  }
 }
 
-export class ChannelCloseSummary extends jspb.Message { 
-    getChannelPoint(): string;
-    setChannelPoint(value: string): void;
+export class ChannelCloseSummary extends jspb.Message {
+  getChannelPoint(): string;
+  setChannelPoint(value: string): void;
 
-    getChanId(): number;
-    setChanId(value: number): void;
+  getChanId(): string;
+  setChanId(value: string): void;
 
-    getChainHash(): string;
-    setChainHash(value: string): void;
+  getChainHash(): string;
+  setChainHash(value: string): void;
 
-    getClosingTxHash(): string;
-    setClosingTxHash(value: string): void;
+  getClosingTxHash(): string;
+  setClosingTxHash(value: string): void;
 
-    getRemotePubkey(): string;
-    setRemotePubkey(value: string): void;
+  getRemotePubkey(): string;
+  setRemotePubkey(value: string): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getCloseHeight(): number;
-    setCloseHeight(value: number): void;
+  getCloseHeight(): number;
+  setCloseHeight(value: number): void;
 
-    getSettledBalance(): number;
-    setSettledBalance(value: number): void;
+  getSettledBalance(): number;
+  setSettledBalance(value: number): void;
 
-    getTimeLockedBalance(): number;
-    setTimeLockedBalance(value: number): void;
+  getTimeLockedBalance(): number;
+  setTimeLockedBalance(value: number): void;
 
-    getCloseType(): ChannelCloseSummary.ClosureType;
-    setCloseType(value: ChannelCloseSummary.ClosureType): void;
+  getCloseType(): ChannelCloseSummary.ClosureType;
+  setCloseType(value: ChannelCloseSummary.ClosureType): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelCloseSummary.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelCloseSummary): ChannelCloseSummary.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelCloseSummary, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelCloseSummary;
-    static deserializeBinaryFromReader(message: ChannelCloseSummary, reader: jspb.BinaryReader): ChannelCloseSummary;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelCloseSummary.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelCloseSummary): ChannelCloseSummary.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelCloseSummary, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelCloseSummary;
+  static deserializeBinaryFromReader(message: ChannelCloseSummary, reader: jspb.BinaryReader): ChannelCloseSummary;
 }
 
 export namespace ChannelCloseSummary {
-    export type AsObject = {
-        channelPoint: string,
-        chanId: number,
-        chainHash: string,
-        closingTxHash: string,
-        remotePubkey: string,
-        capacity: number,
-        closeHeight: number,
-        settledBalance: number,
-        timeLockedBalance: number,
-        closeType: ChannelCloseSummary.ClosureType,
-    }
+  export type AsObject = {
+    channelPoint: string,
+    chanId: string,
+    chainHash: string,
+    closingTxHash: string,
+    remotePubkey: string,
+    capacity: number,
+    closeHeight: number,
+    settledBalance: number,
+    timeLockedBalance: number,
+    closeType: ChannelCloseSummary.ClosureType,
+  }
 
-    export enum ClosureType {
+  export enum ClosureType {
     COOPERATIVE_CLOSE = 0,
     LOCAL_FORCE_CLOSE = 1,
     REMOTE_FORCE_CLOSE = 2,
     BREACH_CLOSE = 3,
     FUNDING_CANCELED = 4,
-    }
-
+  }
 }
 
-export class ClosedChannelsRequest extends jspb.Message { 
-    getCooperative(): boolean;
-    setCooperative(value: boolean): void;
+export class ClosedChannelsRequest extends jspb.Message {
+  getCooperative(): boolean;
+  setCooperative(value: boolean): void;
 
-    getLocalForce(): boolean;
-    setLocalForce(value: boolean): void;
+  getLocalForce(): boolean;
+  setLocalForce(value: boolean): void;
 
-    getRemoteForce(): boolean;
-    setRemoteForce(value: boolean): void;
+  getRemoteForce(): boolean;
+  setRemoteForce(value: boolean): void;
 
-    getBreach(): boolean;
-    setBreach(value: boolean): void;
+  getBreach(): boolean;
+  setBreach(value: boolean): void;
 
-    getFundingCanceled(): boolean;
-    setFundingCanceled(value: boolean): void;
+  getFundingCanceled(): boolean;
+  setFundingCanceled(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ClosedChannelsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ClosedChannelsRequest): ClosedChannelsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ClosedChannelsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ClosedChannelsRequest;
-    static deserializeBinaryFromReader(message: ClosedChannelsRequest, reader: jspb.BinaryReader): ClosedChannelsRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ClosedChannelsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ClosedChannelsRequest): ClosedChannelsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ClosedChannelsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ClosedChannelsRequest;
+  static deserializeBinaryFromReader(message: ClosedChannelsRequest, reader: jspb.BinaryReader): ClosedChannelsRequest;
 }
 
 export namespace ClosedChannelsRequest {
-    export type AsObject = {
-        cooperative: boolean,
-        localForce: boolean,
-        remoteForce: boolean,
-        breach: boolean,
-        fundingCanceled: boolean,
-    }
+  export type AsObject = {
+    cooperative: boolean,
+    localForce: boolean,
+    remoteForce: boolean,
+    breach: boolean,
+    fundingCanceled: boolean,
+  }
 }
 
-export class ClosedChannelsResponse extends jspb.Message { 
-    clearChannelsList(): void;
-    getChannelsList(): Array<ChannelCloseSummary>;
-    setChannelsList(value: Array<ChannelCloseSummary>): void;
-    addChannels(value?: ChannelCloseSummary, index?: number): ChannelCloseSummary;
+export class ClosedChannelsResponse extends jspb.Message {
+  clearChannelsList(): void;
+  getChannelsList(): Array<ChannelCloseSummary>;
+  setChannelsList(value: Array<ChannelCloseSummary>): void;
+  addChannels(value?: ChannelCloseSummary, index?: number): ChannelCloseSummary;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ClosedChannelsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ClosedChannelsResponse): ClosedChannelsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ClosedChannelsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ClosedChannelsResponse;
-    static deserializeBinaryFromReader(message: ClosedChannelsResponse, reader: jspb.BinaryReader): ClosedChannelsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ClosedChannelsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ClosedChannelsResponse): ClosedChannelsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ClosedChannelsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ClosedChannelsResponse;
+  static deserializeBinaryFromReader(message: ClosedChannelsResponse, reader: jspb.BinaryReader): ClosedChannelsResponse;
 }
 
 export namespace ClosedChannelsResponse {
-    export type AsObject = {
-        channelsList: Array<ChannelCloseSummary.AsObject>,
-    }
+  export type AsObject = {
+    channelsList: Array<ChannelCloseSummary.AsObject>,
+  }
 }
 
-export class Peer extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class Peer extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-    getAddress(): string;
-    setAddress(value: string): void;
+  getAddress(): string;
+  setAddress(value: string): void;
 
-    getBytesSent(): number;
-    setBytesSent(value: number): void;
+  getBytesSent(): number;
+  setBytesSent(value: number): void;
 
-    getBytesRecv(): number;
-    setBytesRecv(value: number): void;
+  getBytesRecv(): number;
+  setBytesRecv(value: number): void;
 
-    getSatSent(): number;
-    setSatSent(value: number): void;
+  getSatSent(): number;
+  setSatSent(value: number): void;
 
-    getSatRecv(): number;
-    setSatRecv(value: number): void;
+  getSatRecv(): number;
+  setSatRecv(value: number): void;
 
-    getInbound(): boolean;
-    setInbound(value: boolean): void;
+  getInbound(): boolean;
+  setInbound(value: boolean): void;
 
-    getPingTime(): number;
-    setPingTime(value: number): void;
+  getPingTime(): number;
+  setPingTime(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Peer.AsObject;
-    static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Peer, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Peer;
-    static deserializeBinaryFromReader(message: Peer, reader: jspb.BinaryReader): Peer;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Peer.AsObject;
+  static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Peer, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Peer;
+  static deserializeBinaryFromReader(message: Peer, reader: jspb.BinaryReader): Peer;
 }
 
 export namespace Peer {
-    export type AsObject = {
-        pubKey: string,
-        address: string,
-        bytesSent: number,
-        bytesRecv: number,
-        satSent: number,
-        satRecv: number,
-        inbound: boolean,
-        pingTime: number,
-    }
+  export type AsObject = {
+    pubKey: string,
+    address: string,
+    bytesSent: number,
+    bytesRecv: number,
+    satSent: number,
+    satRecv: number,
+    inbound: boolean,
+    pingTime: number,
+  }
 }
 
-export class ListPeersRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPeersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPeersRequest): ListPeersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPeersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPeersRequest;
-    static deserializeBinaryFromReader(message: ListPeersRequest, reader: jspb.BinaryReader): ListPeersRequest;
+export class ListPeersRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPeersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPeersRequest): ListPeersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPeersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPeersRequest;
+  static deserializeBinaryFromReader(message: ListPeersRequest, reader: jspb.BinaryReader): ListPeersRequest;
 }
 
 export namespace ListPeersRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListPeersResponse extends jspb.Message { 
-    clearPeersList(): void;
-    getPeersList(): Array<Peer>;
-    setPeersList(value: Array<Peer>): void;
-    addPeers(value?: Peer, index?: number): Peer;
+export class ListPeersResponse extends jspb.Message {
+  clearPeersList(): void;
+  getPeersList(): Array<Peer>;
+  setPeersList(value: Array<Peer>): void;
+  addPeers(value?: Peer, index?: number): Peer;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPeersResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPeersResponse): ListPeersResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPeersResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPeersResponse;
-    static deserializeBinaryFromReader(message: ListPeersResponse, reader: jspb.BinaryReader): ListPeersResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPeersResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPeersResponse): ListPeersResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPeersResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPeersResponse;
+  static deserializeBinaryFromReader(message: ListPeersResponse, reader: jspb.BinaryReader): ListPeersResponse;
 }
 
 export namespace ListPeersResponse {
-    export type AsObject = {
-        peersList: Array<Peer.AsObject>,
-    }
+  export type AsObject = {
+    peersList: Array<Peer.AsObject>,
+  }
 }
 
-export class GetInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
-    static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
+export class GetInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
+  static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
 }
 
 export namespace GetInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetInfoResponse extends jspb.Message { 
-    getIdentityPubkey(): string;
-    setIdentityPubkey(value: string): void;
+export class GetInfoResponse extends jspb.Message {
+  getIdentityPubkey(): string;
+  setIdentityPubkey(value: string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-    getNumPendingChannels(): number;
-    setNumPendingChannels(value: number): void;
+  getNumPendingChannels(): number;
+  setNumPendingChannels(value: number): void;
 
-    getNumActiveChannels(): number;
-    setNumActiveChannels(value: number): void;
+  getNumActiveChannels(): number;
+  setNumActiveChannels(value: number): void;
 
-    getNumPeers(): number;
-    setNumPeers(value: number): void;
+  getNumPeers(): number;
+  setNumPeers(value: number): void;
 
-    getBlockHeight(): number;
-    setBlockHeight(value: number): void;
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
 
-    getBlockHash(): string;
-    setBlockHash(value: string): void;
+  getBlockHash(): string;
+  setBlockHash(value: string): void;
 
-    getSyncedToChain(): boolean;
-    setSyncedToChain(value: boolean): void;
+  getSyncedToChain(): boolean;
+  setSyncedToChain(value: boolean): void;
 
-    getTestnet(): boolean;
-    setTestnet(value: boolean): void;
+  getTestnet(): boolean;
+  setTestnet(value: boolean): void;
 
-    clearChainsList(): void;
-    getChainsList(): Array<string>;
-    setChainsList(value: Array<string>): void;
-    addChains(value: string, index?: number): string;
+  clearChainsList(): void;
+  getChainsList(): Array<string>;
+  setChainsList(value: Array<string>): void;
+  addChains(value: string, index?: number): string;
 
-    clearUrisList(): void;
-    getUrisList(): Array<string>;
-    setUrisList(value: Array<string>): void;
-    addUris(value: string, index?: number): string;
+  clearUrisList(): void;
+  getUrisList(): Array<string>;
+  setUrisList(value: Array<string>): void;
+  addUris(value: string, index?: number): string;
 
-    getBestHeaderTimestamp(): number;
-    setBestHeaderTimestamp(value: number): void;
+  getBestHeaderTimestamp(): number;
+  setBestHeaderTimestamp(value: number): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
+  getVersion(): string;
+  setVersion(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
-    static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
+  static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
 }
 
 export namespace GetInfoResponse {
-    export type AsObject = {
-        identityPubkey: string,
-        alias: string,
-        numPendingChannels: number,
-        numActiveChannels: number,
-        numPeers: number,
-        blockHeight: number,
-        blockHash: string,
-        syncedToChain: boolean,
-        testnet: boolean,
-        chainsList: Array<string>,
-        urisList: Array<string>,
-        bestHeaderTimestamp: number,
-        version: string,
-    }
+  export type AsObject = {
+    identityPubkey: string,
+    alias: string,
+    numPendingChannels: number,
+    numActiveChannels: number,
+    numPeers: number,
+    blockHeight: number,
+    blockHash: string,
+    syncedToChain: boolean,
+    testnet: boolean,
+    chainsList: Array<string>,
+    urisList: Array<string>,
+    bestHeaderTimestamp: number,
+    version: string,
+  }
 }
 
-export class ConfirmationUpdate extends jspb.Message { 
-    getBlockSha(): Uint8Array | string;
-    getBlockSha_asU8(): Uint8Array;
-    getBlockSha_asB64(): string;
-    setBlockSha(value: Uint8Array | string): void;
+export class ConfirmationUpdate extends jspb.Message {
+  getBlockSha(): Uint8Array | string;
+  getBlockSha_asU8(): Uint8Array;
+  getBlockSha_asB64(): string;
+  setBlockSha(value: Uint8Array | string): void;
 
-    getBlockHeight(): number;
-    setBlockHeight(value: number): void;
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
 
-    getNumConfsLeft(): number;
-    setNumConfsLeft(value: number): void;
+  getNumConfsLeft(): number;
+  setNumConfsLeft(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConfirmationUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ConfirmationUpdate): ConfirmationUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConfirmationUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConfirmationUpdate;
-    static deserializeBinaryFromReader(message: ConfirmationUpdate, reader: jspb.BinaryReader): ConfirmationUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConfirmationUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ConfirmationUpdate): ConfirmationUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConfirmationUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConfirmationUpdate;
+  static deserializeBinaryFromReader(message: ConfirmationUpdate, reader: jspb.BinaryReader): ConfirmationUpdate;
 }
 
 export namespace ConfirmationUpdate {
-    export type AsObject = {
-        blockSha: Uint8Array | string,
-        blockHeight: number,
-        numConfsLeft: number,
-    }
+  export type AsObject = {
+    blockSha: Uint8Array | string,
+    blockHeight: number,
+    numConfsLeft: number,
+  }
 }
 
-export class ChannelOpenUpdate extends jspb.Message { 
+export class ChannelOpenUpdate extends jspb.Message {
+  hasChannelPoint(): boolean;
+  clearChannelPoint(): void;
+  getChannelPoint(): ChannelPoint | undefined;
+  setChannelPoint(value?: ChannelPoint): void;
 
-    hasChannelPoint(): boolean;
-    clearChannelPoint(): void;
-    getChannelPoint(): ChannelPoint | undefined;
-    setChannelPoint(value?: ChannelPoint): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelOpenUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelOpenUpdate): ChannelOpenUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelOpenUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelOpenUpdate;
-    static deserializeBinaryFromReader(message: ChannelOpenUpdate, reader: jspb.BinaryReader): ChannelOpenUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelOpenUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelOpenUpdate): ChannelOpenUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelOpenUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelOpenUpdate;
+  static deserializeBinaryFromReader(message: ChannelOpenUpdate, reader: jspb.BinaryReader): ChannelOpenUpdate;
 }
 
 export namespace ChannelOpenUpdate {
-    export type AsObject = {
-        channelPoint?: ChannelPoint.AsObject,
-    }
+  export type AsObject = {
+    channelPoint?: ChannelPoint.AsObject,
+  }
 }
 
-export class ChannelCloseUpdate extends jspb.Message { 
-    getClosingTxid(): Uint8Array | string;
-    getClosingTxid_asU8(): Uint8Array;
-    getClosingTxid_asB64(): string;
-    setClosingTxid(value: Uint8Array | string): void;
+export class ChannelCloseUpdate extends jspb.Message {
+  getClosingTxid(): Uint8Array | string;
+  getClosingTxid_asU8(): Uint8Array;
+  getClosingTxid_asB64(): string;
+  setClosingTxid(value: Uint8Array | string): void;
 
-    getSuccess(): boolean;
-    setSuccess(value: boolean): void;
+  getSuccess(): boolean;
+  setSuccess(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelCloseUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelCloseUpdate): ChannelCloseUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelCloseUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelCloseUpdate;
-    static deserializeBinaryFromReader(message: ChannelCloseUpdate, reader: jspb.BinaryReader): ChannelCloseUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelCloseUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelCloseUpdate): ChannelCloseUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelCloseUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelCloseUpdate;
+  static deserializeBinaryFromReader(message: ChannelCloseUpdate, reader: jspb.BinaryReader): ChannelCloseUpdate;
 }
 
 export namespace ChannelCloseUpdate {
-    export type AsObject = {
-        closingTxid: Uint8Array | string,
-        success: boolean,
-    }
+  export type AsObject = {
+    closingTxid: Uint8Array | string,
+    success: boolean,
+  }
 }
 
-export class CloseChannelRequest extends jspb.Message { 
+export class CloseChannelRequest extends jspb.Message {
+  hasChannelPoint(): boolean;
+  clearChannelPoint(): void;
+  getChannelPoint(): ChannelPoint | undefined;
+  setChannelPoint(value?: ChannelPoint): void;
 
-    hasChannelPoint(): boolean;
-    clearChannelPoint(): void;
-    getChannelPoint(): ChannelPoint | undefined;
-    setChannelPoint(value?: ChannelPoint): void;
+  getForce(): boolean;
+  setForce(value: boolean): void;
 
-    getForce(): boolean;
-    setForce(value: boolean): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CloseChannelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: CloseChannelRequest): CloseChannelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CloseChannelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CloseChannelRequest;
-    static deserializeBinaryFromReader(message: CloseChannelRequest, reader: jspb.BinaryReader): CloseChannelRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CloseChannelRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: CloseChannelRequest): CloseChannelRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CloseChannelRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CloseChannelRequest;
+  static deserializeBinaryFromReader(message: CloseChannelRequest, reader: jspb.BinaryReader): CloseChannelRequest;
 }
 
 export namespace CloseChannelRequest {
-    export type AsObject = {
-        channelPoint?: ChannelPoint.AsObject,
-        force: boolean,
-        targetConf: number,
-        satPerByte: number,
-    }
+  export type AsObject = {
+    channelPoint?: ChannelPoint.AsObject,
+    force: boolean,
+    targetConf: number,
+    satPerByte: number,
+  }
 }
 
-export class CloseStatusUpdate extends jspb.Message { 
+export class CloseStatusUpdate extends jspb.Message {
+  hasClosePending(): boolean;
+  clearClosePending(): void;
+  getClosePending(): PendingUpdate | undefined;
+  setClosePending(value?: PendingUpdate): void;
 
-    hasClosePending(): boolean;
-    clearClosePending(): void;
-    getClosePending(): PendingUpdate | undefined;
-    setClosePending(value?: PendingUpdate): void;
+  hasConfirmation(): boolean;
+  clearConfirmation(): void;
+  getConfirmation(): ConfirmationUpdate | undefined;
+  setConfirmation(value?: ConfirmationUpdate): void;
 
+  hasChanClose(): boolean;
+  clearChanClose(): void;
+  getChanClose(): ChannelCloseUpdate | undefined;
+  setChanClose(value?: ChannelCloseUpdate): void;
 
-    hasConfirmation(): boolean;
-    clearConfirmation(): void;
-    getConfirmation(): ConfirmationUpdate | undefined;
-    setConfirmation(value?: ConfirmationUpdate): void;
-
-
-    hasChanClose(): boolean;
-    clearChanClose(): void;
-    getChanClose(): ChannelCloseUpdate | undefined;
-    setChanClose(value?: ChannelCloseUpdate): void;
-
-
-    getUpdateCase(): CloseStatusUpdate.UpdateCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CloseStatusUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: CloseStatusUpdate): CloseStatusUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CloseStatusUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CloseStatusUpdate;
-    static deserializeBinaryFromReader(message: CloseStatusUpdate, reader: jspb.BinaryReader): CloseStatusUpdate;
+  getUpdateCase(): CloseStatusUpdate.UpdateCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CloseStatusUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: CloseStatusUpdate): CloseStatusUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CloseStatusUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CloseStatusUpdate;
+  static deserializeBinaryFromReader(message: CloseStatusUpdate, reader: jspb.BinaryReader): CloseStatusUpdate;
 }
 
 export namespace CloseStatusUpdate {
-    export type AsObject = {
-        closePending?: PendingUpdate.AsObject,
-        confirmation?: ConfirmationUpdate.AsObject,
-        chanClose?: ChannelCloseUpdate.AsObject,
-    }
+  export type AsObject = {
+    closePending?: PendingUpdate.AsObject,
+    confirmation?: ConfirmationUpdate.AsObject,
+    chanClose?: ChannelCloseUpdate.AsObject,
+  }
 
-    export enum UpdateCase {
-        UPDATE_NOT_SET = 0,
-    
+  export enum UpdateCase {
+    UPDATE_NOT_SET = 0,
     CLOSE_PENDING = 1,
-
     CONFIRMATION = 2,
-
     CHAN_CLOSE = 3,
-
-    }
-
+  }
 }
 
-export class PendingUpdate extends jspb.Message { 
-    getTxid(): Uint8Array | string;
-    getTxid_asU8(): Uint8Array;
-    getTxid_asB64(): string;
-    setTxid(value: Uint8Array | string): void;
+export class PendingUpdate extends jspb.Message {
+  getTxid(): Uint8Array | string;
+  getTxid_asU8(): Uint8Array;
+  getTxid_asB64(): string;
+  setTxid(value: Uint8Array | string): void;
 
-    getOutputIndex(): number;
-    setOutputIndex(value: number): void;
+  getOutputIndex(): number;
+  setOutputIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingUpdate): PendingUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingUpdate;
-    static deserializeBinaryFromReader(message: PendingUpdate, reader: jspb.BinaryReader): PendingUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingUpdate): PendingUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingUpdate;
+  static deserializeBinaryFromReader(message: PendingUpdate, reader: jspb.BinaryReader): PendingUpdate;
 }
 
 export namespace PendingUpdate {
-    export type AsObject = {
-        txid: Uint8Array | string,
-        outputIndex: number,
-    }
+  export type AsObject = {
+    txid: Uint8Array | string,
+    outputIndex: number,
+  }
 }
 
-export class OpenChannelRequest extends jspb.Message { 
-    getNodePubkey(): Uint8Array | string;
-    getNodePubkey_asU8(): Uint8Array;
-    getNodePubkey_asB64(): string;
-    setNodePubkey(value: Uint8Array | string): void;
+export class OpenChannelRequest extends jspb.Message {
+  getNodePubkey(): Uint8Array | string;
+  getNodePubkey_asU8(): Uint8Array;
+  getNodePubkey_asB64(): string;
+  setNodePubkey(value: Uint8Array | string): void;
 
-    getNodePubkeyString(): string;
-    setNodePubkeyString(value: string): void;
+  getNodePubkeyString(): string;
+  setNodePubkeyString(value: string): void;
 
-    getLocalFundingAmount(): number;
-    setLocalFundingAmount(value: number): void;
+  getLocalFundingAmount(): number;
+  setLocalFundingAmount(value: number): void;
 
-    getPushSat(): number;
-    setPushSat(value: number): void;
+  getPushSat(): number;
+  setPushSat(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-    getPrivate(): boolean;
-    setPrivate(value: boolean): void;
+  getPrivate(): boolean;
+  setPrivate(value: boolean): void;
 
-    getMinHtlcMsat(): number;
-    setMinHtlcMsat(value: number): void;
+  getMinHtlcMsat(): number;
+  setMinHtlcMsat(value: number): void;
 
-    getRemoteCsvDelay(): number;
-    setRemoteCsvDelay(value: number): void;
+  getRemoteCsvDelay(): number;
+  setRemoteCsvDelay(value: number): void;
 
-    getMinConfs(): number;
-    setMinConfs(value: number): void;
+  getMinConfs(): number;
+  setMinConfs(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OpenChannelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: OpenChannelRequest): OpenChannelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OpenChannelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OpenChannelRequest;
-    static deserializeBinaryFromReader(message: OpenChannelRequest, reader: jspb.BinaryReader): OpenChannelRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OpenChannelRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: OpenChannelRequest): OpenChannelRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OpenChannelRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OpenChannelRequest;
+  static deserializeBinaryFromReader(message: OpenChannelRequest, reader: jspb.BinaryReader): OpenChannelRequest;
 }
 
 export namespace OpenChannelRequest {
-    export type AsObject = {
-        nodePubkey: Uint8Array | string,
-        nodePubkeyString: string,
-        localFundingAmount: number,
-        pushSat: number,
-        targetConf: number,
-        satPerByte: number,
-        pb_private: boolean,
-        minHtlcMsat: number,
-        remoteCsvDelay: number,
-        minConfs: number,
-    }
+  export type AsObject = {
+    nodePubkey: Uint8Array | string,
+    nodePubkeyString: string,
+    localFundingAmount: number,
+    pushSat: number,
+    targetConf: number,
+    satPerByte: number,
+    pb_private: boolean,
+    minHtlcMsat: number,
+    remoteCsvDelay: number,
+    minConfs: number,
+  }
 }
 
-export class OpenStatusUpdate extends jspb.Message { 
+export class OpenStatusUpdate extends jspb.Message {
+  hasChanPending(): boolean;
+  clearChanPending(): void;
+  getChanPending(): PendingUpdate | undefined;
+  setChanPending(value?: PendingUpdate): void;
 
-    hasChanPending(): boolean;
-    clearChanPending(): void;
-    getChanPending(): PendingUpdate | undefined;
-    setChanPending(value?: PendingUpdate): void;
+  hasConfirmation(): boolean;
+  clearConfirmation(): void;
+  getConfirmation(): ConfirmationUpdate | undefined;
+  setConfirmation(value?: ConfirmationUpdate): void;
 
+  hasChanOpen(): boolean;
+  clearChanOpen(): void;
+  getChanOpen(): ChannelOpenUpdate | undefined;
+  setChanOpen(value?: ChannelOpenUpdate): void;
 
-    hasConfirmation(): boolean;
-    clearConfirmation(): void;
-    getConfirmation(): ConfirmationUpdate | undefined;
-    setConfirmation(value?: ConfirmationUpdate): void;
-
-
-    hasChanOpen(): boolean;
-    clearChanOpen(): void;
-    getChanOpen(): ChannelOpenUpdate | undefined;
-    setChanOpen(value?: ChannelOpenUpdate): void;
-
-
-    getUpdateCase(): OpenStatusUpdate.UpdateCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OpenStatusUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: OpenStatusUpdate): OpenStatusUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OpenStatusUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OpenStatusUpdate;
-    static deserializeBinaryFromReader(message: OpenStatusUpdate, reader: jspb.BinaryReader): OpenStatusUpdate;
+  getUpdateCase(): OpenStatusUpdate.UpdateCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OpenStatusUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: OpenStatusUpdate): OpenStatusUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OpenStatusUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OpenStatusUpdate;
+  static deserializeBinaryFromReader(message: OpenStatusUpdate, reader: jspb.BinaryReader): OpenStatusUpdate;
 }
 
 export namespace OpenStatusUpdate {
-    export type AsObject = {
-        chanPending?: PendingUpdate.AsObject,
-        confirmation?: ConfirmationUpdate.AsObject,
-        chanOpen?: ChannelOpenUpdate.AsObject,
-    }
+  export type AsObject = {
+    chanPending?: PendingUpdate.AsObject,
+    confirmation?: ConfirmationUpdate.AsObject,
+    chanOpen?: ChannelOpenUpdate.AsObject,
+  }
 
-    export enum UpdateCase {
-        UPDATE_NOT_SET = 0,
-    
+  export enum UpdateCase {
+    UPDATE_NOT_SET = 0,
     CHAN_PENDING = 1,
-
     CONFIRMATION = 2,
-
     CHAN_OPEN = 3,
-
-    }
-
+  }
 }
 
-export class PendingHTLC extends jspb.Message { 
-    getIncoming(): boolean;
-    setIncoming(value: boolean): void;
+export class PendingHTLC extends jspb.Message {
+  getIncoming(): boolean;
+  setIncoming(value: boolean): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getOutpoint(): string;
-    setOutpoint(value: string): void;
+  getOutpoint(): string;
+  setOutpoint(value: string): void;
 
-    getMaturityHeight(): number;
-    setMaturityHeight(value: number): void;
+  getMaturityHeight(): number;
+  setMaturityHeight(value: number): void;
 
-    getBlocksTilMaturity(): number;
-    setBlocksTilMaturity(value: number): void;
+  getBlocksTilMaturity(): number;
+  setBlocksTilMaturity(value: number): void;
 
-    getStage(): number;
-    setStage(value: number): void;
+  getStage(): number;
+  setStage(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingHTLC.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingHTLC): PendingHTLC.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingHTLC, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingHTLC;
-    static deserializeBinaryFromReader(message: PendingHTLC, reader: jspb.BinaryReader): PendingHTLC;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingHTLC.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingHTLC): PendingHTLC.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingHTLC, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingHTLC;
+  static deserializeBinaryFromReader(message: PendingHTLC, reader: jspb.BinaryReader): PendingHTLC;
 }
 
 export namespace PendingHTLC {
-    export type AsObject = {
-        incoming: boolean,
-        amount: number,
-        outpoint: string,
-        maturityHeight: number,
-        blocksTilMaturity: number,
-        stage: number,
-    }
+  export type AsObject = {
+    incoming: boolean,
+    amount: number,
+    outpoint: string,
+    maturityHeight: number,
+    blocksTilMaturity: number,
+    stage: number,
+  }
 }
 
-export class PendingChannelsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingChannelsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingChannelsRequest): PendingChannelsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingChannelsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingChannelsRequest;
-    static deserializeBinaryFromReader(message: PendingChannelsRequest, reader: jspb.BinaryReader): PendingChannelsRequest;
+export class PendingChannelsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingChannelsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingChannelsRequest): PendingChannelsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingChannelsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingChannelsRequest;
+  static deserializeBinaryFromReader(message: PendingChannelsRequest, reader: jspb.BinaryReader): PendingChannelsRequest;
 }
 
 export namespace PendingChannelsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class PendingChannelsResponse extends jspb.Message { 
-    getTotalLimboBalance(): number;
-    setTotalLimboBalance(value: number): void;
+export class PendingChannelsResponse extends jspb.Message {
+  getTotalLimboBalance(): number;
+  setTotalLimboBalance(value: number): void;
 
-    clearPendingOpenChannelsList(): void;
-    getPendingOpenChannelsList(): Array<PendingChannelsResponse.PendingOpenChannel>;
-    setPendingOpenChannelsList(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
-    addPendingOpenChannels(value?: PendingChannelsResponse.PendingOpenChannel, index?: number): PendingChannelsResponse.PendingOpenChannel;
+  clearPendingOpenChannelsList(): void;
+  getPendingOpenChannelsList(): Array<PendingChannelsResponse.PendingOpenChannel>;
+  setPendingOpenChannelsList(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
+  addPendingOpenChannels(value?: PendingChannelsResponse.PendingOpenChannel, index?: number): PendingChannelsResponse.PendingOpenChannel;
 
-    clearPendingClosingChannelsList(): void;
-    getPendingClosingChannelsList(): Array<PendingChannelsResponse.ClosedChannel>;
-    setPendingClosingChannelsList(value: Array<PendingChannelsResponse.ClosedChannel>): void;
-    addPendingClosingChannels(value?: PendingChannelsResponse.ClosedChannel, index?: number): PendingChannelsResponse.ClosedChannel;
+  clearPendingClosingChannelsList(): void;
+  getPendingClosingChannelsList(): Array<PendingChannelsResponse.ClosedChannel>;
+  setPendingClosingChannelsList(value: Array<PendingChannelsResponse.ClosedChannel>): void;
+  addPendingClosingChannels(value?: PendingChannelsResponse.ClosedChannel, index?: number): PendingChannelsResponse.ClosedChannel;
 
-    clearPendingForceClosingChannelsList(): void;
-    getPendingForceClosingChannelsList(): Array<PendingChannelsResponse.ForceClosedChannel>;
-    setPendingForceClosingChannelsList(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
-    addPendingForceClosingChannels(value?: PendingChannelsResponse.ForceClosedChannel, index?: number): PendingChannelsResponse.ForceClosedChannel;
+  clearPendingForceClosingChannelsList(): void;
+  getPendingForceClosingChannelsList(): Array<PendingChannelsResponse.ForceClosedChannel>;
+  setPendingForceClosingChannelsList(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
+  addPendingForceClosingChannels(value?: PendingChannelsResponse.ForceClosedChannel, index?: number): PendingChannelsResponse.ForceClosedChannel;
 
-    clearWaitingCloseChannelsList(): void;
-    getWaitingCloseChannelsList(): Array<PendingChannelsResponse.WaitingCloseChannel>;
-    setWaitingCloseChannelsList(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
-    addWaitingCloseChannels(value?: PendingChannelsResponse.WaitingCloseChannel, index?: number): PendingChannelsResponse.WaitingCloseChannel;
+  clearWaitingCloseChannelsList(): void;
+  getWaitingCloseChannelsList(): Array<PendingChannelsResponse.WaitingCloseChannel>;
+  setWaitingCloseChannelsList(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
+  addWaitingCloseChannels(value?: PendingChannelsResponse.WaitingCloseChannel, index?: number): PendingChannelsResponse.WaitingCloseChannel;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingChannelsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingChannelsResponse): PendingChannelsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingChannelsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingChannelsResponse;
-    static deserializeBinaryFromReader(message: PendingChannelsResponse, reader: jspb.BinaryReader): PendingChannelsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingChannelsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingChannelsResponse): PendingChannelsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingChannelsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingChannelsResponse;
+  static deserializeBinaryFromReader(message: PendingChannelsResponse, reader: jspb.BinaryReader): PendingChannelsResponse;
 }
 
 export namespace PendingChannelsResponse {
-    export type AsObject = {
-        totalLimboBalance: number,
-        pendingOpenChannelsList: Array<PendingChannelsResponse.PendingOpenChannel.AsObject>,
-        pendingClosingChannelsList: Array<PendingChannelsResponse.ClosedChannel.AsObject>,
-        pendingForceClosingChannelsList: Array<PendingChannelsResponse.ForceClosedChannel.AsObject>,
-        waitingCloseChannelsList: Array<PendingChannelsResponse.WaitingCloseChannel.AsObject>,
-    }
+  export type AsObject = {
+    totalLimboBalance: number,
+    pendingOpenChannelsList: Array<PendingChannelsResponse.PendingOpenChannel.AsObject>,
+    pendingClosingChannelsList: Array<PendingChannelsResponse.ClosedChannel.AsObject>,
+    pendingForceClosingChannelsList: Array<PendingChannelsResponse.ForceClosedChannel.AsObject>,
+    waitingCloseChannelsList: Array<PendingChannelsResponse.WaitingCloseChannel.AsObject>,
+  }
 
-
-    export class PendingChannel extends jspb.Message { 
+  export class PendingChannel extends jspb.Message {
     getRemoteNodePub(): string;
     setRemoteNodePub(value: string): void;
 
@@ -1801,29 +1701,27 @@ export namespace PendingChannelsResponse {
     getRemoteBalance(): number;
     setRemoteBalance(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PendingChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: PendingChannel): PendingChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PendingChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PendingChannel;
+    static deserializeBinaryFromReader(message: PendingChannel, reader: jspb.BinaryReader): PendingChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): PendingChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: PendingChannel): PendingChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: PendingChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): PendingChannel;
-        static deserializeBinaryFromReader(message: PendingChannel, reader: jspb.BinaryReader): PendingChannel;
+  export namespace PendingChannel {
+    export type AsObject = {
+      remoteNodePub: string,
+      channelPoint: string,
+      capacity: number,
+      localBalance: number,
+      remoteBalance: number,
     }
+  }
 
-    export namespace PendingChannel {
-        export type AsObject = {
-        remoteNodePub: string,
-        channelPoint: string,
-        capacity: number,
-        localBalance: number,
-        remoteBalance: number,
-        }
-    }
-
-    export class PendingOpenChannel extends jspb.Message { 
-
+  export class PendingOpenChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1841,29 +1739,27 @@ export namespace PendingChannelsResponse {
     getFeePerKw(): number;
     setFeePerKw(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PendingOpenChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: PendingOpenChannel): PendingOpenChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PendingOpenChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PendingOpenChannel;
+    static deserializeBinaryFromReader(message: PendingOpenChannel, reader: jspb.BinaryReader): PendingOpenChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): PendingOpenChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: PendingOpenChannel): PendingOpenChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: PendingOpenChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): PendingOpenChannel;
-        static deserializeBinaryFromReader(message: PendingOpenChannel, reader: jspb.BinaryReader): PendingOpenChannel;
+  export namespace PendingOpenChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      confirmationHeight: number,
+      commitFee: number,
+      commitWeight: number,
+      feePerKw: number,
     }
+  }
 
-    export namespace PendingOpenChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        confirmationHeight: number,
-        commitFee: number,
-        commitWeight: number,
-        feePerKw: number,
-        }
-    }
-
-    export class WaitingCloseChannel extends jspb.Message { 
-
+  export class WaitingCloseChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1872,26 +1768,24 @@ export namespace PendingChannelsResponse {
     getLimboBalance(): number;
     setLimboBalance(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): WaitingCloseChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: WaitingCloseChannel): WaitingCloseChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: WaitingCloseChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): WaitingCloseChannel;
+    static deserializeBinaryFromReader(message: WaitingCloseChannel, reader: jspb.BinaryReader): WaitingCloseChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): WaitingCloseChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: WaitingCloseChannel): WaitingCloseChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: WaitingCloseChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): WaitingCloseChannel;
-        static deserializeBinaryFromReader(message: WaitingCloseChannel, reader: jspb.BinaryReader): WaitingCloseChannel;
+  export namespace WaitingCloseChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      limboBalance: number,
     }
+  }
 
-    export namespace WaitingCloseChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        limboBalance: number,
-        }
-    }
-
-    export class ClosedChannel extends jspb.Message { 
-
+  export class ClosedChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1900,26 +1794,24 @@ export namespace PendingChannelsResponse {
     getClosingTxid(): string;
     setClosingTxid(value: string): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ClosedChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: ClosedChannel): ClosedChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ClosedChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ClosedChannel;
+    static deserializeBinaryFromReader(message: ClosedChannel, reader: jspb.BinaryReader): ClosedChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ClosedChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: ClosedChannel): ClosedChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ClosedChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ClosedChannel;
-        static deserializeBinaryFromReader(message: ClosedChannel, reader: jspb.BinaryReader): ClosedChannel;
+  export namespace ClosedChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      closingTxid: string,
     }
+  }
 
-    export namespace ClosedChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        closingTxid: string,
-        }
-    }
-
-    export class ForceClosedChannel extends jspb.Message { 
-
+  export class ForceClosedChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1945,1671 +1837,1603 @@ export namespace PendingChannelsResponse {
     setPendingHtlcsList(value: Array<PendingHTLC>): void;
     addPendingHtlcs(value?: PendingHTLC, index?: number): PendingHTLC;
 
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ForceClosedChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: ForceClosedChannel): ForceClosedChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ForceClosedChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ForceClosedChannel;
-        static deserializeBinaryFromReader(message: ForceClosedChannel, reader: jspb.BinaryReader): ForceClosedChannel;
-    }
-
-    export namespace ForceClosedChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        closingTxid: string,
-        limboBalance: number,
-        maturityHeight: number,
-        blocksTilMaturity: number,
-        recoveredBalance: number,
-        pendingHtlcsList: Array<PendingHTLC.AsObject>,
-        }
-    }
-
-}
-
-export class WalletBalanceRequest extends jspb.Message { 
-
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): WalletBalanceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: WalletBalanceRequest): WalletBalanceRequest.AsObject;
+    toObject(includeInstance?: boolean): ForceClosedChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: ForceClosedChannel): ForceClosedChannel.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: WalletBalanceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): WalletBalanceRequest;
-    static deserializeBinaryFromReader(message: WalletBalanceRequest, reader: jspb.BinaryReader): WalletBalanceRequest;
+    static serializeBinaryToWriter(message: ForceClosedChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ForceClosedChannel;
+    static deserializeBinaryFromReader(message: ForceClosedChannel, reader: jspb.BinaryReader): ForceClosedChannel;
+  }
+
+  export namespace ForceClosedChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      closingTxid: string,
+      limboBalance: number,
+      maturityHeight: number,
+      blocksTilMaturity: number,
+      recoveredBalance: number,
+      pendingHtlcsList: Array<PendingHTLC.AsObject>,
+    }
+  }
+}
+
+export class WalletBalanceRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): WalletBalanceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: WalletBalanceRequest): WalletBalanceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: WalletBalanceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): WalletBalanceRequest;
+  static deserializeBinaryFromReader(message: WalletBalanceRequest, reader: jspb.BinaryReader): WalletBalanceRequest;
 }
 
 export namespace WalletBalanceRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class WalletBalanceResponse extends jspb.Message { 
-    getTotalBalance(): number;
-    setTotalBalance(value: number): void;
+export class WalletBalanceResponse extends jspb.Message {
+  getTotalBalance(): number;
+  setTotalBalance(value: number): void;
 
-    getConfirmedBalance(): number;
-    setConfirmedBalance(value: number): void;
+  getConfirmedBalance(): number;
+  setConfirmedBalance(value: number): void;
 
-    getUnconfirmedBalance(): number;
-    setUnconfirmedBalance(value: number): void;
+  getUnconfirmedBalance(): number;
+  setUnconfirmedBalance(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): WalletBalanceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: WalletBalanceResponse): WalletBalanceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: WalletBalanceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): WalletBalanceResponse;
-    static deserializeBinaryFromReader(message: WalletBalanceResponse, reader: jspb.BinaryReader): WalletBalanceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): WalletBalanceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: WalletBalanceResponse): WalletBalanceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: WalletBalanceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): WalletBalanceResponse;
+  static deserializeBinaryFromReader(message: WalletBalanceResponse, reader: jspb.BinaryReader): WalletBalanceResponse;
 }
 
 export namespace WalletBalanceResponse {
-    export type AsObject = {
-        totalBalance: number,
-        confirmedBalance: number,
-        unconfirmedBalance: number,
-    }
+  export type AsObject = {
+    totalBalance: number,
+    confirmedBalance: number,
+    unconfirmedBalance: number,
+  }
 }
 
-export class ChannelBalanceRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalanceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalanceRequest): ChannelBalanceRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalanceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalanceRequest;
-    static deserializeBinaryFromReader(message: ChannelBalanceRequest, reader: jspb.BinaryReader): ChannelBalanceRequest;
+export class ChannelBalanceRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalanceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalanceRequest): ChannelBalanceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalanceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalanceRequest;
+  static deserializeBinaryFromReader(message: ChannelBalanceRequest, reader: jspb.BinaryReader): ChannelBalanceRequest;
 }
 
 export namespace ChannelBalanceRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChannelBalanceResponse extends jspb.Message { 
-    getBalance(): number;
-    setBalance(value: number): void;
+export class ChannelBalanceResponse extends jspb.Message {
+  getBalance(): number;
+  setBalance(value: number): void;
 
-    getPendingOpenBalance(): number;
-    setPendingOpenBalance(value: number): void;
+  getPendingOpenBalance(): number;
+  setPendingOpenBalance(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalanceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalanceResponse): ChannelBalanceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalanceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalanceResponse;
-    static deserializeBinaryFromReader(message: ChannelBalanceResponse, reader: jspb.BinaryReader): ChannelBalanceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalanceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalanceResponse): ChannelBalanceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalanceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalanceResponse;
+  static deserializeBinaryFromReader(message: ChannelBalanceResponse, reader: jspb.BinaryReader): ChannelBalanceResponse;
 }
 
 export namespace ChannelBalanceResponse {
-    export type AsObject = {
-        balance: number,
-        pendingOpenBalance: number,
-    }
+  export type AsObject = {
+    balance: number,
+    pendingOpenBalance: number,
+  }
 }
 
-export class QueryRoutesRequest extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class QueryRoutesRequest extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-    getAmt(): number;
-    setAmt(value: number): void;
+  getAmt(): number;
+  setAmt(value: number): void;
 
-    getNumRoutes(): number;
-    setNumRoutes(value: number): void;
+  getNumRoutes(): number;
+  setNumRoutes(value: number): void;
 
-    getFinalCltvDelta(): number;
-    setFinalCltvDelta(value: number): void;
+  getFinalCltvDelta(): number;
+  setFinalCltvDelta(value: number): void;
 
+  hasFeeLimit(): boolean;
+  clearFeeLimit(): void;
+  getFeeLimit(): FeeLimit | undefined;
+  setFeeLimit(value?: FeeLimit): void;
 
-    hasFeeLimit(): boolean;
-    clearFeeLimit(): void;
-    getFeeLimit(): FeeLimit | undefined;
-    setFeeLimit(value?: FeeLimit): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): QueryRoutesRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: QueryRoutesRequest): QueryRoutesRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: QueryRoutesRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): QueryRoutesRequest;
-    static deserializeBinaryFromReader(message: QueryRoutesRequest, reader: jspb.BinaryReader): QueryRoutesRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): QueryRoutesRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: QueryRoutesRequest): QueryRoutesRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: QueryRoutesRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): QueryRoutesRequest;
+  static deserializeBinaryFromReader(message: QueryRoutesRequest, reader: jspb.BinaryReader): QueryRoutesRequest;
 }
 
 export namespace QueryRoutesRequest {
-    export type AsObject = {
-        pubKey: string,
-        amt: number,
-        numRoutes: number,
-        finalCltvDelta: number,
-        feeLimit?: FeeLimit.AsObject,
-    }
+  export type AsObject = {
+    pubKey: string,
+    amt: number,
+    numRoutes: number,
+    finalCltvDelta: number,
+    feeLimit?: FeeLimit.AsObject,
+  }
 }
 
-export class QueryRoutesResponse extends jspb.Message { 
-    clearRoutesList(): void;
-    getRoutesList(): Array<Route>;
-    setRoutesList(value: Array<Route>): void;
-    addRoutes(value?: Route, index?: number): Route;
+export class QueryRoutesResponse extends jspb.Message {
+  clearRoutesList(): void;
+  getRoutesList(): Array<Route>;
+  setRoutesList(value: Array<Route>): void;
+  addRoutes(value?: Route, index?: number): Route;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): QueryRoutesResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: QueryRoutesResponse): QueryRoutesResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: QueryRoutesResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): QueryRoutesResponse;
-    static deserializeBinaryFromReader(message: QueryRoutesResponse, reader: jspb.BinaryReader): QueryRoutesResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): QueryRoutesResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: QueryRoutesResponse): QueryRoutesResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: QueryRoutesResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): QueryRoutesResponse;
+  static deserializeBinaryFromReader(message: QueryRoutesResponse, reader: jspb.BinaryReader): QueryRoutesResponse;
 }
 
 export namespace QueryRoutesResponse {
-    export type AsObject = {
-        routesList: Array<Route.AsObject>,
-    }
+  export type AsObject = {
+    routesList: Array<Route.AsObject>,
+  }
 }
 
-export class Hop extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class Hop extends jspb.Message {
+  getChanId(): string;
+  setChanId(value: string): void;
 
-    getChanCapacity(): number;
-    setChanCapacity(value: number): void;
+  getChanCapacity(): number;
+  setChanCapacity(value: number): void;
 
-    getAmtToForward(): number;
-    setAmtToForward(value: number): void;
+  getAmtToForward(): number;
+  setAmtToForward(value: number): void;
 
-    getFee(): number;
-    setFee(value: number): void;
+  getFee(): number;
+  setFee(value: number): void;
 
-    getExpiry(): number;
-    setExpiry(value: number): void;
+  getExpiry(): number;
+  setExpiry(value: number): void;
 
-    getAmtToForwardMsat(): number;
-    setAmtToForwardMsat(value: number): void;
+  getAmtToForwardMsat(): number;
+  setAmtToForwardMsat(value: number): void;
 
-    getFeeMsat(): number;
-    setFeeMsat(value: number): void;
+  getFeeMsat(): number;
+  setFeeMsat(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Hop.AsObject;
-    static toObject(includeInstance: boolean, msg: Hop): Hop.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Hop, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Hop;
-    static deserializeBinaryFromReader(message: Hop, reader: jspb.BinaryReader): Hop;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Hop.AsObject;
+  static toObject(includeInstance: boolean, msg: Hop): Hop.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Hop, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Hop;
+  static deserializeBinaryFromReader(message: Hop, reader: jspb.BinaryReader): Hop;
 }
 
 export namespace Hop {
-    export type AsObject = {
-        chanId: number,
-        chanCapacity: number,
-        amtToForward: number,
-        fee: number,
-        expiry: number,
-        amtToForwardMsat: number,
-        feeMsat: number,
-    }
+  export type AsObject = {
+    chanId: string,
+    chanCapacity: number,
+    amtToForward: number,
+    fee: number,
+    expiry: number,
+    amtToForwardMsat: number,
+    feeMsat: number,
+  }
 }
 
-export class Route extends jspb.Message { 
-    getTotalTimeLock(): number;
-    setTotalTimeLock(value: number): void;
+export class Route extends jspb.Message {
+  getTotalTimeLock(): number;
+  setTotalTimeLock(value: number): void;
 
-    getTotalFees(): number;
-    setTotalFees(value: number): void;
+  getTotalFees(): number;
+  setTotalFees(value: number): void;
 
-    getTotalAmt(): number;
-    setTotalAmt(value: number): void;
+  getTotalAmt(): number;
+  setTotalAmt(value: number): void;
 
-    clearHopsList(): void;
-    getHopsList(): Array<Hop>;
-    setHopsList(value: Array<Hop>): void;
-    addHops(value?: Hop, index?: number): Hop;
+  clearHopsList(): void;
+  getHopsList(): Array<Hop>;
+  setHopsList(value: Array<Hop>): void;
+  addHops(value?: Hop, index?: number): Hop;
 
-    getTotalFeesMsat(): number;
-    setTotalFeesMsat(value: number): void;
+  getTotalFeesMsat(): number;
+  setTotalFeesMsat(value: number): void;
 
-    getTotalAmtMsat(): number;
-    setTotalAmtMsat(value: number): void;
+  getTotalAmtMsat(): number;
+  setTotalAmtMsat(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Route.AsObject;
-    static toObject(includeInstance: boolean, msg: Route): Route.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Route, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Route;
-    static deserializeBinaryFromReader(message: Route, reader: jspb.BinaryReader): Route;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Route.AsObject;
+  static toObject(includeInstance: boolean, msg: Route): Route.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Route, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Route;
+  static deserializeBinaryFromReader(message: Route, reader: jspb.BinaryReader): Route;
 }
 
 export namespace Route {
-    export type AsObject = {
-        totalTimeLock: number,
-        totalFees: number,
-        totalAmt: number,
-        hopsList: Array<Hop.AsObject>,
-        totalFeesMsat: number,
-        totalAmtMsat: number,
-    }
+  export type AsObject = {
+    totalTimeLock: number,
+    totalFees: number,
+    totalAmt: number,
+    hopsList: Array<Hop.AsObject>,
+    totalFeesMsat: number,
+    totalAmtMsat: number,
+  }
 }
 
-export class NodeInfoRequest extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class NodeInfoRequest extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeInfoRequest): NodeInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeInfoRequest;
-    static deserializeBinaryFromReader(message: NodeInfoRequest, reader: jspb.BinaryReader): NodeInfoRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeInfoRequest): NodeInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeInfoRequest;
+  static deserializeBinaryFromReader(message: NodeInfoRequest, reader: jspb.BinaryReader): NodeInfoRequest;
 }
 
 export namespace NodeInfoRequest {
-    export type AsObject = {
-        pubKey: string,
-    }
+  export type AsObject = {
+    pubKey: string,
+  }
 }
 
-export class NodeInfo extends jspb.Message { 
+export class NodeInfo extends jspb.Message {
+  hasNode(): boolean;
+  clearNode(): void;
+  getNode(): LightningNode | undefined;
+  setNode(value?: LightningNode): void;
 
-    hasNode(): boolean;
-    clearNode(): void;
-    getNode(): LightningNode | undefined;
-    setNode(value?: LightningNode): void;
+  getNumChannels(): number;
+  setNumChannels(value: number): void;
 
-    getNumChannels(): number;
-    setNumChannels(value: number): void;
+  getTotalCapacity(): number;
+  setTotalCapacity(value: number): void;
 
-    getTotalCapacity(): number;
-    setTotalCapacity(value: number): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeInfo): NodeInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeInfo;
-    static deserializeBinaryFromReader(message: NodeInfo, reader: jspb.BinaryReader): NodeInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeInfo): NodeInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeInfo;
+  static deserializeBinaryFromReader(message: NodeInfo, reader: jspb.BinaryReader): NodeInfo;
 }
 
 export namespace NodeInfo {
-    export type AsObject = {
-        node?: LightningNode.AsObject,
-        numChannels: number,
-        totalCapacity: number,
-    }
+  export type AsObject = {
+    node?: LightningNode.AsObject,
+    numChannels: number,
+    totalCapacity: number,
+  }
 }
 
-export class LightningNode extends jspb.Message { 
-    getLastUpdate(): number;
-    setLastUpdate(value: number): void;
+export class LightningNode extends jspb.Message {
+  getLastUpdate(): number;
+  setLastUpdate(value: number): void;
 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-    clearAddressesList(): void;
-    getAddressesList(): Array<NodeAddress>;
-    setAddressesList(value: Array<NodeAddress>): void;
-    addAddresses(value?: NodeAddress, index?: number): NodeAddress;
+  clearAddressesList(): void;
+  getAddressesList(): Array<NodeAddress>;
+  setAddressesList(value: Array<NodeAddress>): void;
+  addAddresses(value?: NodeAddress, index?: number): NodeAddress;
 
-    getColor(): string;
-    setColor(value: string): void;
+  getColor(): string;
+  setColor(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LightningNode.AsObject;
-    static toObject(includeInstance: boolean, msg: LightningNode): LightningNode.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LightningNode, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LightningNode;
-    static deserializeBinaryFromReader(message: LightningNode, reader: jspb.BinaryReader): LightningNode;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LightningNode.AsObject;
+  static toObject(includeInstance: boolean, msg: LightningNode): LightningNode.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LightningNode, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LightningNode;
+  static deserializeBinaryFromReader(message: LightningNode, reader: jspb.BinaryReader): LightningNode;
 }
 
 export namespace LightningNode {
-    export type AsObject = {
-        lastUpdate: number,
-        pubKey: string,
-        alias: string,
-        addressesList: Array<NodeAddress.AsObject>,
-        color: string,
-    }
+  export type AsObject = {
+    lastUpdate: number,
+    pubKey: string,
+    alias: string,
+    addressesList: Array<NodeAddress.AsObject>,
+    color: string,
+  }
 }
 
-export class NodeAddress extends jspb.Message { 
-    getNetwork(): string;
-    setNetwork(value: string): void;
+export class NodeAddress extends jspb.Message {
+  getNetwork(): string;
+  setNetwork(value: string): void;
 
-    getAddr(): string;
-    setAddr(value: string): void;
+  getAddr(): string;
+  setAddr(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeAddress.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeAddress): NodeAddress.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeAddress, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeAddress;
-    static deserializeBinaryFromReader(message: NodeAddress, reader: jspb.BinaryReader): NodeAddress;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeAddress.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeAddress): NodeAddress.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeAddress, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeAddress;
+  static deserializeBinaryFromReader(message: NodeAddress, reader: jspb.BinaryReader): NodeAddress;
 }
 
 export namespace NodeAddress {
-    export type AsObject = {
-        network: string,
-        addr: string,
-    }
+  export type AsObject = {
+    network: string,
+    addr: string,
+  }
 }
 
-export class RoutingPolicy extends jspb.Message { 
-    getTimeLockDelta(): number;
-    setTimeLockDelta(value: number): void;
+export class RoutingPolicy extends jspb.Message {
+  getTimeLockDelta(): number;
+  setTimeLockDelta(value: number): void;
 
-    getMinHtlc(): number;
-    setMinHtlc(value: number): void;
+  getMinHtlc(): number;
+  setMinHtlc(value: number): void;
 
-    getFeeBaseMsat(): number;
-    setFeeBaseMsat(value: number): void;
+  getFeeBaseMsat(): number;
+  setFeeBaseMsat(value: number): void;
 
-    getFeeRateMilliMsat(): number;
-    setFeeRateMilliMsat(value: number): void;
+  getFeeRateMilliMsat(): number;
+  setFeeRateMilliMsat(value: number): void;
 
-    getDisabled(): boolean;
-    setDisabled(value: boolean): void;
+  getDisabled(): boolean;
+  setDisabled(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RoutingPolicy.AsObject;
-    static toObject(includeInstance: boolean, msg: RoutingPolicy): RoutingPolicy.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RoutingPolicy, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RoutingPolicy;
-    static deserializeBinaryFromReader(message: RoutingPolicy, reader: jspb.BinaryReader): RoutingPolicy;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RoutingPolicy.AsObject;
+  static toObject(includeInstance: boolean, msg: RoutingPolicy): RoutingPolicy.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RoutingPolicy, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RoutingPolicy;
+  static deserializeBinaryFromReader(message: RoutingPolicy, reader: jspb.BinaryReader): RoutingPolicy;
 }
 
 export namespace RoutingPolicy {
-    export type AsObject = {
-        timeLockDelta: number,
-        minHtlc: number,
-        feeBaseMsat: number,
-        feeRateMilliMsat: number,
-        disabled: boolean,
-    }
+  export type AsObject = {
+    timeLockDelta: number,
+    minHtlc: number,
+    feeBaseMsat: number,
+    feeRateMilliMsat: number,
+    disabled: boolean,
+  }
 }
 
-export class ChannelEdge extends jspb.Message { 
-    getChannelId(): number;
-    setChannelId(value: number): void;
+export class ChannelEdge extends jspb.Message {
+  getChannelId(): number;
+  setChannelId(value: number): void;
 
-    getChanPoint(): string;
-    setChanPoint(value: string): void;
+  getChanPoint(): string;
+  setChanPoint(value: string): void;
 
-    getLastUpdate(): number;
-    setLastUpdate(value: number): void;
+  getLastUpdate(): number;
+  setLastUpdate(value: number): void;
 
-    getNode1Pub(): string;
-    setNode1Pub(value: string): void;
+  getNode1Pub(): string;
+  setNode1Pub(value: string): void;
 
-    getNode2Pub(): string;
-    setNode2Pub(value: string): void;
+  getNode2Pub(): string;
+  setNode2Pub(value: string): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
+  hasNode1Policy(): boolean;
+  clearNode1Policy(): void;
+  getNode1Policy(): RoutingPolicy | undefined;
+  setNode1Policy(value?: RoutingPolicy): void;
 
-    hasNode1Policy(): boolean;
-    clearNode1Policy(): void;
-    getNode1Policy(): RoutingPolicy | undefined;
-    setNode1Policy(value?: RoutingPolicy): void;
+  hasNode2Policy(): boolean;
+  clearNode2Policy(): void;
+  getNode2Policy(): RoutingPolicy | undefined;
+  setNode2Policy(value?: RoutingPolicy): void;
 
-
-    hasNode2Policy(): boolean;
-    clearNode2Policy(): void;
-    getNode2Policy(): RoutingPolicy | undefined;
-    setNode2Policy(value?: RoutingPolicy): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelEdge.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelEdge): ChannelEdge.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelEdge, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelEdge;
-    static deserializeBinaryFromReader(message: ChannelEdge, reader: jspb.BinaryReader): ChannelEdge;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelEdge.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelEdge): ChannelEdge.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelEdge, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelEdge;
+  static deserializeBinaryFromReader(message: ChannelEdge, reader: jspb.BinaryReader): ChannelEdge;
 }
 
 export namespace ChannelEdge {
-    export type AsObject = {
-        channelId: number,
-        chanPoint: string,
-        lastUpdate: number,
-        node1Pub: string,
-        node2Pub: string,
-        capacity: number,
-        node1Policy?: RoutingPolicy.AsObject,
-        node2Policy?: RoutingPolicy.AsObject,
-    }
+  export type AsObject = {
+    channelId: number,
+    chanPoint: string,
+    lastUpdate: number,
+    node1Pub: string,
+    node2Pub: string,
+    capacity: number,
+    node1Policy?: RoutingPolicy.AsObject,
+    node2Policy?: RoutingPolicy.AsObject,
+  }
 }
 
-export class ChannelGraphRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelGraphRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelGraphRequest): ChannelGraphRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelGraphRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelGraphRequest;
-    static deserializeBinaryFromReader(message: ChannelGraphRequest, reader: jspb.BinaryReader): ChannelGraphRequest;
+export class ChannelGraphRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelGraphRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelGraphRequest): ChannelGraphRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelGraphRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelGraphRequest;
+  static deserializeBinaryFromReader(message: ChannelGraphRequest, reader: jspb.BinaryReader): ChannelGraphRequest;
 }
 
 export namespace ChannelGraphRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChannelGraph extends jspb.Message { 
-    clearNodesList(): void;
-    getNodesList(): Array<LightningNode>;
-    setNodesList(value: Array<LightningNode>): void;
-    addNodes(value?: LightningNode, index?: number): LightningNode;
+export class ChannelGraph extends jspb.Message {
+  clearNodesList(): void;
+  getNodesList(): Array<LightningNode>;
+  setNodesList(value: Array<LightningNode>): void;
+  addNodes(value?: LightningNode, index?: number): LightningNode;
 
-    clearEdgesList(): void;
-    getEdgesList(): Array<ChannelEdge>;
-    setEdgesList(value: Array<ChannelEdge>): void;
-    addEdges(value?: ChannelEdge, index?: number): ChannelEdge;
+  clearEdgesList(): void;
+  getEdgesList(): Array<ChannelEdge>;
+  setEdgesList(value: Array<ChannelEdge>): void;
+  addEdges(value?: ChannelEdge, index?: number): ChannelEdge;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelGraph.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelGraph): ChannelGraph.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelGraph, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelGraph;
-    static deserializeBinaryFromReader(message: ChannelGraph, reader: jspb.BinaryReader): ChannelGraph;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelGraph.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelGraph): ChannelGraph.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelGraph, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelGraph;
+  static deserializeBinaryFromReader(message: ChannelGraph, reader: jspb.BinaryReader): ChannelGraph;
 }
 
 export namespace ChannelGraph {
-    export type AsObject = {
-        nodesList: Array<LightningNode.AsObject>,
-        edgesList: Array<ChannelEdge.AsObject>,
-    }
+  export type AsObject = {
+    nodesList: Array<LightningNode.AsObject>,
+    edgesList: Array<ChannelEdge.AsObject>,
+  }
 }
 
-export class ChanInfoRequest extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class ChanInfoRequest extends jspb.Message {
+  getChanId(): number;
+  setChanId(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChanInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChanInfoRequest): ChanInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChanInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChanInfoRequest;
-    static deserializeBinaryFromReader(message: ChanInfoRequest, reader: jspb.BinaryReader): ChanInfoRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChanInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChanInfoRequest): ChanInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChanInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChanInfoRequest;
+  static deserializeBinaryFromReader(message: ChanInfoRequest, reader: jspb.BinaryReader): ChanInfoRequest;
 }
 
 export namespace ChanInfoRequest {
-    export type AsObject = {
-        chanId: number,
-    }
+  export type AsObject = {
+    chanId: number,
+  }
 }
 
-export class NetworkInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NetworkInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NetworkInfoRequest): NetworkInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NetworkInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NetworkInfoRequest;
-    static deserializeBinaryFromReader(message: NetworkInfoRequest, reader: jspb.BinaryReader): NetworkInfoRequest;
+export class NetworkInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NetworkInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NetworkInfoRequest): NetworkInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NetworkInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NetworkInfoRequest;
+  static deserializeBinaryFromReader(message: NetworkInfoRequest, reader: jspb.BinaryReader): NetworkInfoRequest;
 }
 
 export namespace NetworkInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class NetworkInfo extends jspb.Message { 
-    getGraphDiameter(): number;
-    setGraphDiameter(value: number): void;
+export class NetworkInfo extends jspb.Message {
+  getGraphDiameter(): number;
+  setGraphDiameter(value: number): void;
 
-    getAvgOutDegree(): number;
-    setAvgOutDegree(value: number): void;
+  getAvgOutDegree(): number;
+  setAvgOutDegree(value: number): void;
 
-    getMaxOutDegree(): number;
-    setMaxOutDegree(value: number): void;
+  getMaxOutDegree(): number;
+  setMaxOutDegree(value: number): void;
 
-    getNumNodes(): number;
-    setNumNodes(value: number): void;
+  getNumNodes(): number;
+  setNumNodes(value: number): void;
 
-    getNumChannels(): number;
-    setNumChannels(value: number): void;
+  getNumChannels(): number;
+  setNumChannels(value: number): void;
 
-    getTotalNetworkCapacity(): number;
-    setTotalNetworkCapacity(value: number): void;
+  getTotalNetworkCapacity(): number;
+  setTotalNetworkCapacity(value: number): void;
 
-    getAvgChannelSize(): number;
-    setAvgChannelSize(value: number): void;
+  getAvgChannelSize(): number;
+  setAvgChannelSize(value: number): void;
 
-    getMinChannelSize(): number;
-    setMinChannelSize(value: number): void;
+  getMinChannelSize(): number;
+  setMinChannelSize(value: number): void;
 
-    getMaxChannelSize(): number;
-    setMaxChannelSize(value: number): void;
+  getMaxChannelSize(): number;
+  setMaxChannelSize(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NetworkInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: NetworkInfo): NetworkInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NetworkInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NetworkInfo;
-    static deserializeBinaryFromReader(message: NetworkInfo, reader: jspb.BinaryReader): NetworkInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NetworkInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: NetworkInfo): NetworkInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NetworkInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NetworkInfo;
+  static deserializeBinaryFromReader(message: NetworkInfo, reader: jspb.BinaryReader): NetworkInfo;
 }
 
 export namespace NetworkInfo {
-    export type AsObject = {
-        graphDiameter: number,
-        avgOutDegree: number,
-        maxOutDegree: number,
-        numNodes: number,
-        numChannels: number,
-        totalNetworkCapacity: number,
-        avgChannelSize: number,
-        minChannelSize: number,
-        maxChannelSize: number,
-    }
+  export type AsObject = {
+    graphDiameter: number,
+    avgOutDegree: number,
+    maxOutDegree: number,
+    numNodes: number,
+    numChannels: number,
+    totalNetworkCapacity: number,
+    avgChannelSize: number,
+    minChannelSize: number,
+    maxChannelSize: number,
+  }
 }
 
-export class StopRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): StopRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: StopRequest): StopRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: StopRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): StopRequest;
-    static deserializeBinaryFromReader(message: StopRequest, reader: jspb.BinaryReader): StopRequest;
+export class StopRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): StopRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: StopRequest): StopRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: StopRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): StopRequest;
+  static deserializeBinaryFromReader(message: StopRequest, reader: jspb.BinaryReader): StopRequest;
 }
 
 export namespace StopRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class StopResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): StopResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: StopResponse): StopResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: StopResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): StopResponse;
-    static deserializeBinaryFromReader(message: StopResponse, reader: jspb.BinaryReader): StopResponse;
+export class StopResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): StopResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: StopResponse): StopResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: StopResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): StopResponse;
+  static deserializeBinaryFromReader(message: StopResponse, reader: jspb.BinaryReader): StopResponse;
 }
 
 export namespace StopResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GraphTopologySubscription extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GraphTopologySubscription.AsObject;
-    static toObject(includeInstance: boolean, msg: GraphTopologySubscription): GraphTopologySubscription.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GraphTopologySubscription, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GraphTopologySubscription;
-    static deserializeBinaryFromReader(message: GraphTopologySubscription, reader: jspb.BinaryReader): GraphTopologySubscription;
+export class GraphTopologySubscription extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GraphTopologySubscription.AsObject;
+  static toObject(includeInstance: boolean, msg: GraphTopologySubscription): GraphTopologySubscription.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GraphTopologySubscription, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GraphTopologySubscription;
+  static deserializeBinaryFromReader(message: GraphTopologySubscription, reader: jspb.BinaryReader): GraphTopologySubscription;
 }
 
 export namespace GraphTopologySubscription {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GraphTopologyUpdate extends jspb.Message { 
-    clearNodeUpdatesList(): void;
-    getNodeUpdatesList(): Array<NodeUpdate>;
-    setNodeUpdatesList(value: Array<NodeUpdate>): void;
-    addNodeUpdates(value?: NodeUpdate, index?: number): NodeUpdate;
+export class GraphTopologyUpdate extends jspb.Message {
+  clearNodeUpdatesList(): void;
+  getNodeUpdatesList(): Array<NodeUpdate>;
+  setNodeUpdatesList(value: Array<NodeUpdate>): void;
+  addNodeUpdates(value?: NodeUpdate, index?: number): NodeUpdate;
 
-    clearChannelUpdatesList(): void;
-    getChannelUpdatesList(): Array<ChannelEdgeUpdate>;
-    setChannelUpdatesList(value: Array<ChannelEdgeUpdate>): void;
-    addChannelUpdates(value?: ChannelEdgeUpdate, index?: number): ChannelEdgeUpdate;
+  clearChannelUpdatesList(): void;
+  getChannelUpdatesList(): Array<ChannelEdgeUpdate>;
+  setChannelUpdatesList(value: Array<ChannelEdgeUpdate>): void;
+  addChannelUpdates(value?: ChannelEdgeUpdate, index?: number): ChannelEdgeUpdate;
 
-    clearClosedChansList(): void;
-    getClosedChansList(): Array<ClosedChannelUpdate>;
-    setClosedChansList(value: Array<ClosedChannelUpdate>): void;
-    addClosedChans(value?: ClosedChannelUpdate, index?: number): ClosedChannelUpdate;
+  clearClosedChansList(): void;
+  getClosedChansList(): Array<ClosedChannelUpdate>;
+  setClosedChansList(value: Array<ClosedChannelUpdate>): void;
+  addClosedChans(value?: ClosedChannelUpdate, index?: number): ClosedChannelUpdate;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GraphTopologyUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: GraphTopologyUpdate): GraphTopologyUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GraphTopologyUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GraphTopologyUpdate;
-    static deserializeBinaryFromReader(message: GraphTopologyUpdate, reader: jspb.BinaryReader): GraphTopologyUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GraphTopologyUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: GraphTopologyUpdate): GraphTopologyUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GraphTopologyUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GraphTopologyUpdate;
+  static deserializeBinaryFromReader(message: GraphTopologyUpdate, reader: jspb.BinaryReader): GraphTopologyUpdate;
 }
 
 export namespace GraphTopologyUpdate {
-    export type AsObject = {
-        nodeUpdatesList: Array<NodeUpdate.AsObject>,
-        channelUpdatesList: Array<ChannelEdgeUpdate.AsObject>,
-        closedChansList: Array<ClosedChannelUpdate.AsObject>,
-    }
+  export type AsObject = {
+    nodeUpdatesList: Array<NodeUpdate.AsObject>,
+    channelUpdatesList: Array<ChannelEdgeUpdate.AsObject>,
+    closedChansList: Array<ClosedChannelUpdate.AsObject>,
+  }
 }
 
-export class NodeUpdate extends jspb.Message { 
-    clearAddressesList(): void;
-    getAddressesList(): Array<string>;
-    setAddressesList(value: Array<string>): void;
-    addAddresses(value: string, index?: number): string;
+export class NodeUpdate extends jspb.Message {
+  clearAddressesList(): void;
+  getAddressesList(): Array<string>;
+  setAddressesList(value: Array<string>): void;
+  addAddresses(value: string, index?: number): string;
 
-    getIdentityKey(): string;
-    setIdentityKey(value: string): void;
+  getIdentityKey(): string;
+  setIdentityKey(value: string): void;
 
-    getGlobalFeatures(): Uint8Array | string;
-    getGlobalFeatures_asU8(): Uint8Array;
-    getGlobalFeatures_asB64(): string;
-    setGlobalFeatures(value: Uint8Array | string): void;
+  getGlobalFeatures(): Uint8Array | string;
+  getGlobalFeatures_asU8(): Uint8Array;
+  getGlobalFeatures_asB64(): string;
+  setGlobalFeatures(value: Uint8Array | string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeUpdate): NodeUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeUpdate;
-    static deserializeBinaryFromReader(message: NodeUpdate, reader: jspb.BinaryReader): NodeUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeUpdate): NodeUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeUpdate;
+  static deserializeBinaryFromReader(message: NodeUpdate, reader: jspb.BinaryReader): NodeUpdate;
 }
 
 export namespace NodeUpdate {
-    export type AsObject = {
-        addressesList: Array<string>,
-        identityKey: string,
-        globalFeatures: Uint8Array | string,
-        alias: string,
-    }
+  export type AsObject = {
+    addressesList: Array<string>,
+    identityKey: string,
+    globalFeatures: Uint8Array | string,
+    alias: string,
+  }
 }
 
-export class ChannelEdgeUpdate extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class ChannelEdgeUpdate extends jspb.Message {
+  getChanId(): number;
+  setChanId(value: number): void;
 
+  hasChanPoint(): boolean;
+  clearChanPoint(): void;
+  getChanPoint(): ChannelPoint | undefined;
+  setChanPoint(value?: ChannelPoint): void;
 
-    hasChanPoint(): boolean;
-    clearChanPoint(): void;
-    getChanPoint(): ChannelPoint | undefined;
-    setChanPoint(value?: ChannelPoint): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  hasRoutingPolicy(): boolean;
+  clearRoutingPolicy(): void;
+  getRoutingPolicy(): RoutingPolicy | undefined;
+  setRoutingPolicy(value?: RoutingPolicy): void;
 
+  getAdvertisingNode(): string;
+  setAdvertisingNode(value: string): void;
 
-    hasRoutingPolicy(): boolean;
-    clearRoutingPolicy(): void;
-    getRoutingPolicy(): RoutingPolicy | undefined;
-    setRoutingPolicy(value?: RoutingPolicy): void;
+  getConnectingNode(): string;
+  setConnectingNode(value: string): void;
 
-    getAdvertisingNode(): string;
-    setAdvertisingNode(value: string): void;
-
-    getConnectingNode(): string;
-    setConnectingNode(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelEdgeUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelEdgeUpdate): ChannelEdgeUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelEdgeUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelEdgeUpdate;
-    static deserializeBinaryFromReader(message: ChannelEdgeUpdate, reader: jspb.BinaryReader): ChannelEdgeUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelEdgeUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelEdgeUpdate): ChannelEdgeUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelEdgeUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelEdgeUpdate;
+  static deserializeBinaryFromReader(message: ChannelEdgeUpdate, reader: jspb.BinaryReader): ChannelEdgeUpdate;
 }
 
 export namespace ChannelEdgeUpdate {
-    export type AsObject = {
-        chanId: number,
-        chanPoint?: ChannelPoint.AsObject,
-        capacity: number,
-        routingPolicy?: RoutingPolicy.AsObject,
-        advertisingNode: string,
-        connectingNode: string,
-    }
+  export type AsObject = {
+    chanId: number,
+    chanPoint?: ChannelPoint.AsObject,
+    capacity: number,
+    routingPolicy?: RoutingPolicy.AsObject,
+    advertisingNode: string,
+    connectingNode: string,
+  }
 }
 
-export class ClosedChannelUpdate extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class ClosedChannelUpdate extends jspb.Message {
+  getChanId(): string;
+  setChanId(value: string): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getClosedHeight(): number;
-    setClosedHeight(value: number): void;
+  getClosedHeight(): number;
+  setClosedHeight(value: number): void;
 
+  hasChanPoint(): boolean;
+  clearChanPoint(): void;
+  getChanPoint(): ChannelPoint | undefined;
+  setChanPoint(value?: ChannelPoint): void;
 
-    hasChanPoint(): boolean;
-    clearChanPoint(): void;
-    getChanPoint(): ChannelPoint | undefined;
-    setChanPoint(value?: ChannelPoint): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ClosedChannelUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ClosedChannelUpdate): ClosedChannelUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ClosedChannelUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ClosedChannelUpdate;
-    static deserializeBinaryFromReader(message: ClosedChannelUpdate, reader: jspb.BinaryReader): ClosedChannelUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ClosedChannelUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ClosedChannelUpdate): ClosedChannelUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ClosedChannelUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ClosedChannelUpdate;
+  static deserializeBinaryFromReader(message: ClosedChannelUpdate, reader: jspb.BinaryReader): ClosedChannelUpdate;
 }
 
 export namespace ClosedChannelUpdate {
-    export type AsObject = {
-        chanId: number,
-        capacity: number,
-        closedHeight: number,
-        chanPoint?: ChannelPoint.AsObject,
-    }
+  export type AsObject = {
+    chanId: string,
+    capacity: number,
+    closedHeight: number,
+    chanPoint?: ChannelPoint.AsObject,
+  }
 }
 
-export class HopHint extends jspb.Message { 
-    getNodeId(): string;
-    setNodeId(value: string): void;
+export class HopHint extends jspb.Message {
+  getNodeId(): string;
+  setNodeId(value: string): void;
 
-    getChanId(): number;
-    setChanId(value: number): void;
+  getChanId(): string;
+  setChanId(value: string): void;
 
-    getFeeBaseMsat(): number;
-    setFeeBaseMsat(value: number): void;
+  getFeeBaseMsat(): number;
+  setFeeBaseMsat(value: number): void;
 
-    getFeeProportionalMillionths(): number;
-    setFeeProportionalMillionths(value: number): void;
+  getFeeProportionalMillionths(): number;
+  setFeeProportionalMillionths(value: number): void;
 
-    getCltvExpiryDelta(): number;
-    setCltvExpiryDelta(value: number): void;
+  getCltvExpiryDelta(): number;
+  setCltvExpiryDelta(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): HopHint.AsObject;
-    static toObject(includeInstance: boolean, msg: HopHint): HopHint.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: HopHint, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): HopHint;
-    static deserializeBinaryFromReader(message: HopHint, reader: jspb.BinaryReader): HopHint;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): HopHint.AsObject;
+  static toObject(includeInstance: boolean, msg: HopHint): HopHint.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: HopHint, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): HopHint;
+  static deserializeBinaryFromReader(message: HopHint, reader: jspb.BinaryReader): HopHint;
 }
 
 export namespace HopHint {
-    export type AsObject = {
-        nodeId: string,
-        chanId: number,
-        feeBaseMsat: number,
-        feeProportionalMillionths: number,
-        cltvExpiryDelta: number,
-    }
+  export type AsObject = {
+    nodeId: string,
+    chanId: string,
+    feeBaseMsat: number,
+    feeProportionalMillionths: number,
+    cltvExpiryDelta: number,
+  }
 }
 
-export class RouteHint extends jspb.Message { 
-    clearHopHintsList(): void;
-    getHopHintsList(): Array<HopHint>;
-    setHopHintsList(value: Array<HopHint>): void;
-    addHopHints(value?: HopHint, index?: number): HopHint;
+export class RouteHint extends jspb.Message {
+  clearHopHintsList(): void;
+  getHopHintsList(): Array<HopHint>;
+  setHopHintsList(value: Array<HopHint>): void;
+  addHopHints(value?: HopHint, index?: number): HopHint;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RouteHint.AsObject;
-    static toObject(includeInstance: boolean, msg: RouteHint): RouteHint.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RouteHint, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RouteHint;
-    static deserializeBinaryFromReader(message: RouteHint, reader: jspb.BinaryReader): RouteHint;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RouteHint.AsObject;
+  static toObject(includeInstance: boolean, msg: RouteHint): RouteHint.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RouteHint, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RouteHint;
+  static deserializeBinaryFromReader(message: RouteHint, reader: jspb.BinaryReader): RouteHint;
 }
 
 export namespace RouteHint {
-    export type AsObject = {
-        hopHintsList: Array<HopHint.AsObject>,
-    }
+  export type AsObject = {
+    hopHintsList: Array<HopHint.AsObject>,
+  }
 }
 
-export class Invoice extends jspb.Message { 
-    getMemo(): string;
-    setMemo(value: string): void;
+export class Invoice extends jspb.Message {
+  getMemo(): string;
+  setMemo(value: string): void;
 
-    getReceipt(): Uint8Array | string;
-    getReceipt_asU8(): Uint8Array;
-    getReceipt_asB64(): string;
-    setReceipt(value: Uint8Array | string): void;
+  getReceipt(): Uint8Array | string;
+  getReceipt_asU8(): Uint8Array;
+  getReceipt_asB64(): string;
+  setReceipt(value: Uint8Array | string): void;
 
-    getRPreimage(): Uint8Array | string;
-    getRPreimage_asU8(): Uint8Array;
-    getRPreimage_asB64(): string;
-    setRPreimage(value: Uint8Array | string): void;
+  getRPreimage(): Uint8Array | string;
+  getRPreimage_asU8(): Uint8Array;
+  getRPreimage_asB64(): string;
+  setRPreimage(value: Uint8Array | string): void;
 
-    getRHash(): Uint8Array | string;
-    getRHash_asU8(): Uint8Array;
-    getRHash_asB64(): string;
-    setRHash(value: Uint8Array | string): void;
+  getRHash(): Uint8Array | string;
+  getRHash_asU8(): Uint8Array;
+  getRHash_asB64(): string;
+  setRHash(value: Uint8Array | string): void;
 
-    getValue(): number;
-    setValue(value: number): void;
+  getValue(): number;
+  setValue(value: number): void;
 
-    getSettled(): boolean;
-    setSettled(value: boolean): void;
+  getSettled(): boolean;
+  setSettled(value: boolean): void;
 
-    getCreationDate(): number;
-    setCreationDate(value: number): void;
+  getCreationDate(): number;
+  setCreationDate(value: number): void;
 
-    getSettleDate(): number;
-    setSettleDate(value: number): void;
+  getSettleDate(): number;
+  setSettleDate(value: number): void;
 
-    getPaymentRequest(): string;
-    setPaymentRequest(value: string): void;
+  getPaymentRequest(): string;
+  setPaymentRequest(value: string): void;
 
-    getDescriptionHash(): Uint8Array | string;
-    getDescriptionHash_asU8(): Uint8Array;
-    getDescriptionHash_asB64(): string;
-    setDescriptionHash(value: Uint8Array | string): void;
+  getDescriptionHash(): Uint8Array | string;
+  getDescriptionHash_asU8(): Uint8Array;
+  getDescriptionHash_asB64(): string;
+  setDescriptionHash(value: Uint8Array | string): void;
 
-    getExpiry(): number;
-    setExpiry(value: number): void;
+  getExpiry(): number;
+  setExpiry(value: number): void;
 
-    getFallbackAddr(): string;
-    setFallbackAddr(value: string): void;
+  getFallbackAddr(): string;
+  setFallbackAddr(value: string): void;
 
-    getCltvExpiry(): number;
-    setCltvExpiry(value: number): void;
+  getCltvExpiry(): number;
+  setCltvExpiry(value: number): void;
 
-    clearRouteHintsList(): void;
-    getRouteHintsList(): Array<RouteHint>;
-    setRouteHintsList(value: Array<RouteHint>): void;
-    addRouteHints(value?: RouteHint, index?: number): RouteHint;
+  clearRouteHintsList(): void;
+  getRouteHintsList(): Array<RouteHint>;
+  setRouteHintsList(value: Array<RouteHint>): void;
+  addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
-    getPrivate(): boolean;
-    setPrivate(value: boolean): void;
+  getPrivate(): boolean;
+  setPrivate(value: boolean): void;
 
-    getAddIndex(): number;
-    setAddIndex(value: number): void;
+  getAddIndex(): number;
+  setAddIndex(value: number): void;
 
-    getSettleIndex(): number;
-    setSettleIndex(value: number): void;
+  getSettleIndex(): number;
+  setSettleIndex(value: number): void;
 
-    getAmtPaid(): number;
-    setAmtPaid(value: number): void;
+  getAmtPaid(): number;
+  setAmtPaid(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Invoice.AsObject;
-    static toObject(includeInstance: boolean, msg: Invoice): Invoice.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Invoice, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Invoice;
-    static deserializeBinaryFromReader(message: Invoice, reader: jspb.BinaryReader): Invoice;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Invoice.AsObject;
+  static toObject(includeInstance: boolean, msg: Invoice): Invoice.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Invoice, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Invoice;
+  static deserializeBinaryFromReader(message: Invoice, reader: jspb.BinaryReader): Invoice;
 }
 
 export namespace Invoice {
-    export type AsObject = {
-        memo: string,
-        receipt: Uint8Array | string,
-        rPreimage: Uint8Array | string,
-        rHash: Uint8Array | string,
-        value: number,
-        settled: boolean,
-        creationDate: number,
-        settleDate: number,
-        paymentRequest: string,
-        descriptionHash: Uint8Array | string,
-        expiry: number,
-        fallbackAddr: string,
-        cltvExpiry: number,
-        routeHintsList: Array<RouteHint.AsObject>,
-        pb_private: boolean,
-        addIndex: number,
-        settleIndex: number,
-        amtPaid: number,
-    }
+  export type AsObject = {
+    memo: string,
+    receipt: Uint8Array | string,
+    rPreimage: Uint8Array | string,
+    rHash: Uint8Array | string,
+    value: number,
+    settled: boolean,
+    creationDate: number,
+    settleDate: number,
+    paymentRequest: string,
+    descriptionHash: Uint8Array | string,
+    expiry: number,
+    fallbackAddr: string,
+    cltvExpiry: number,
+    routeHintsList: Array<RouteHint.AsObject>,
+    pb_private: boolean,
+    addIndex: number,
+    settleIndex: number,
+    amtPaid: number,
+  }
 }
 
-export class AddInvoiceResponse extends jspb.Message { 
-    getRHash(): Uint8Array | string;
-    getRHash_asU8(): Uint8Array;
-    getRHash_asB64(): string;
-    setRHash(value: Uint8Array | string): void;
+export class AddInvoiceResponse extends jspb.Message {
+  getRHash(): Uint8Array | string;
+  getRHash_asU8(): Uint8Array;
+  getRHash_asB64(): string;
+  setRHash(value: Uint8Array | string): void;
 
-    getPaymentRequest(): string;
-    setPaymentRequest(value: string): void;
+  getPaymentRequest(): string;
+  setPaymentRequest(value: string): void;
 
-    getAddIndex(): number;
-    setAddIndex(value: number): void;
+  getAddIndex(): number;
+  setAddIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): AddInvoiceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: AddInvoiceResponse): AddInvoiceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: AddInvoiceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): AddInvoiceResponse;
-    static deserializeBinaryFromReader(message: AddInvoiceResponse, reader: jspb.BinaryReader): AddInvoiceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): AddInvoiceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: AddInvoiceResponse): AddInvoiceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: AddInvoiceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AddInvoiceResponse;
+  static deserializeBinaryFromReader(message: AddInvoiceResponse, reader: jspb.BinaryReader): AddInvoiceResponse;
 }
 
 export namespace AddInvoiceResponse {
-    export type AsObject = {
-        rHash: Uint8Array | string,
-        paymentRequest: string,
-        addIndex: number,
-    }
+  export type AsObject = {
+    rHash: Uint8Array | string,
+    paymentRequest: string,
+    addIndex: number,
+  }
 }
 
-export class PaymentHash extends jspb.Message { 
-    getRHashStr(): string;
-    setRHashStr(value: string): void;
+export class PaymentHash extends jspb.Message {
+  getRHashStr(): string;
+  setRHashStr(value: string): void;
 
-    getRHash(): Uint8Array | string;
-    getRHash_asU8(): Uint8Array;
-    getRHash_asB64(): string;
-    setRHash(value: Uint8Array | string): void;
+  getRHash(): Uint8Array | string;
+  getRHash_asU8(): Uint8Array;
+  getRHash_asB64(): string;
+  setRHash(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PaymentHash.AsObject;
-    static toObject(includeInstance: boolean, msg: PaymentHash): PaymentHash.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PaymentHash, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PaymentHash;
-    static deserializeBinaryFromReader(message: PaymentHash, reader: jspb.BinaryReader): PaymentHash;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PaymentHash.AsObject;
+  static toObject(includeInstance: boolean, msg: PaymentHash): PaymentHash.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PaymentHash, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PaymentHash;
+  static deserializeBinaryFromReader(message: PaymentHash, reader: jspb.BinaryReader): PaymentHash;
 }
 
 export namespace PaymentHash {
-    export type AsObject = {
-        rHashStr: string,
-        rHash: Uint8Array | string,
-    }
+  export type AsObject = {
+    rHashStr: string,
+    rHash: Uint8Array | string,
+  }
 }
 
-export class ListInvoiceRequest extends jspb.Message { 
-    getPendingOnly(): boolean;
-    setPendingOnly(value: boolean): void;
+export class ListInvoiceRequest extends jspb.Message {
+  getPendingOnly(): boolean;
+  setPendingOnly(value: boolean): void;
 
-    getIndexOffset(): number;
-    setIndexOffset(value: number): void;
+  getIndexOffset(): number;
+  setIndexOffset(value: number): void;
 
-    getNumMaxInvoices(): number;
-    setNumMaxInvoices(value: number): void;
+  getNumMaxInvoices(): number;
+  setNumMaxInvoices(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListInvoiceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListInvoiceRequest): ListInvoiceRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListInvoiceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListInvoiceRequest;
-    static deserializeBinaryFromReader(message: ListInvoiceRequest, reader: jspb.BinaryReader): ListInvoiceRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListInvoiceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListInvoiceRequest): ListInvoiceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListInvoiceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListInvoiceRequest;
+  static deserializeBinaryFromReader(message: ListInvoiceRequest, reader: jspb.BinaryReader): ListInvoiceRequest;
 }
 
 export namespace ListInvoiceRequest {
-    export type AsObject = {
-        pendingOnly: boolean,
-        indexOffset: number,
-        numMaxInvoices: number,
-    }
+  export type AsObject = {
+    pendingOnly: boolean,
+    indexOffset: number,
+    numMaxInvoices: number,
+  }
 }
 
-export class ListInvoiceResponse extends jspb.Message { 
-    clearInvoicesList(): void;
-    getInvoicesList(): Array<Invoice>;
-    setInvoicesList(value: Array<Invoice>): void;
-    addInvoices(value?: Invoice, index?: number): Invoice;
+export class ListInvoiceResponse extends jspb.Message {
+  clearInvoicesList(): void;
+  getInvoicesList(): Array<Invoice>;
+  setInvoicesList(value: Array<Invoice>): void;
+  addInvoices(value?: Invoice, index?: number): Invoice;
 
-    getLastIndexOffset(): number;
-    setLastIndexOffset(value: number): void;
+  getLastIndexOffset(): number;
+  setLastIndexOffset(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListInvoiceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListInvoiceResponse): ListInvoiceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListInvoiceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListInvoiceResponse;
-    static deserializeBinaryFromReader(message: ListInvoiceResponse, reader: jspb.BinaryReader): ListInvoiceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListInvoiceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListInvoiceResponse): ListInvoiceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListInvoiceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListInvoiceResponse;
+  static deserializeBinaryFromReader(message: ListInvoiceResponse, reader: jspb.BinaryReader): ListInvoiceResponse;
 }
 
 export namespace ListInvoiceResponse {
-    export type AsObject = {
-        invoicesList: Array<Invoice.AsObject>,
-        lastIndexOffset: number,
-    }
+  export type AsObject = {
+    invoicesList: Array<Invoice.AsObject>,
+    lastIndexOffset: number,
+  }
 }
 
-export class InvoiceSubscription extends jspb.Message { 
-    getAddIndex(): number;
-    setAddIndex(value: number): void;
+export class InvoiceSubscription extends jspb.Message {
+  getAddIndex(): number;
+  setAddIndex(value: number): void;
 
-    getSettleIndex(): number;
-    setSettleIndex(value: number): void;
+  getSettleIndex(): number;
+  setSettleIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): InvoiceSubscription.AsObject;
-    static toObject(includeInstance: boolean, msg: InvoiceSubscription): InvoiceSubscription.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: InvoiceSubscription, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): InvoiceSubscription;
-    static deserializeBinaryFromReader(message: InvoiceSubscription, reader: jspb.BinaryReader): InvoiceSubscription;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): InvoiceSubscription.AsObject;
+  static toObject(includeInstance: boolean, msg: InvoiceSubscription): InvoiceSubscription.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: InvoiceSubscription, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): InvoiceSubscription;
+  static deserializeBinaryFromReader(message: InvoiceSubscription, reader: jspb.BinaryReader): InvoiceSubscription;
 }
 
 export namespace InvoiceSubscription {
-    export type AsObject = {
-        addIndex: number,
-        settleIndex: number,
-    }
+  export type AsObject = {
+    addIndex: number,
+    settleIndex: number,
+  }
 }
 
-export class Payment extends jspb.Message { 
-    getPaymentHash(): string;
-    setPaymentHash(value: string): void;
+export class Payment extends jspb.Message {
+  getPaymentHash(): string;
+  setPaymentHash(value: string): void;
 
-    getValue(): number;
-    setValue(value: number): void;
+  getValue(): number;
+  setValue(value: number): void;
 
-    getCreationDate(): number;
-    setCreationDate(value: number): void;
+  getCreationDate(): number;
+  setCreationDate(value: number): void;
 
-    clearPathList(): void;
-    getPathList(): Array<string>;
-    setPathList(value: Array<string>): void;
-    addPath(value: string, index?: number): string;
+  clearPathList(): void;
+  getPathList(): Array<string>;
+  setPathList(value: Array<string>): void;
+  addPath(value: string, index?: number): string;
 
-    getFee(): number;
-    setFee(value: number): void;
+  getFee(): number;
+  setFee(value: number): void;
 
-    getPaymentPreimage(): string;
-    setPaymentPreimage(value: string): void;
+  getPaymentPreimage(): string;
+  setPaymentPreimage(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Payment.AsObject;
-    static toObject(includeInstance: boolean, msg: Payment): Payment.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Payment, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Payment;
-    static deserializeBinaryFromReader(message: Payment, reader: jspb.BinaryReader): Payment;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Payment.AsObject;
+  static toObject(includeInstance: boolean, msg: Payment): Payment.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Payment, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Payment;
+  static deserializeBinaryFromReader(message: Payment, reader: jspb.BinaryReader): Payment;
 }
 
 export namespace Payment {
-    export type AsObject = {
-        paymentHash: string,
-        value: number,
-        creationDate: number,
-        pathList: Array<string>,
-        fee: number,
-        paymentPreimage: string,
-    }
+  export type AsObject = {
+    paymentHash: string,
+    value: number,
+    creationDate: number,
+    pathList: Array<string>,
+    fee: number,
+    paymentPreimage: string,
+  }
 }
 
-export class ListPaymentsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPaymentsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPaymentsRequest): ListPaymentsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPaymentsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPaymentsRequest;
-    static deserializeBinaryFromReader(message: ListPaymentsRequest, reader: jspb.BinaryReader): ListPaymentsRequest;
+export class ListPaymentsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPaymentsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPaymentsRequest): ListPaymentsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPaymentsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPaymentsRequest;
+  static deserializeBinaryFromReader(message: ListPaymentsRequest, reader: jspb.BinaryReader): ListPaymentsRequest;
 }
 
 export namespace ListPaymentsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListPaymentsResponse extends jspb.Message { 
-    clearPaymentsList(): void;
-    getPaymentsList(): Array<Payment>;
-    setPaymentsList(value: Array<Payment>): void;
-    addPayments(value?: Payment, index?: number): Payment;
+export class ListPaymentsResponse extends jspb.Message {
+  clearPaymentsList(): void;
+  getPaymentsList(): Array<Payment>;
+  setPaymentsList(value: Array<Payment>): void;
+  addPayments(value?: Payment, index?: number): Payment;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPaymentsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPaymentsResponse): ListPaymentsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPaymentsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPaymentsResponse;
-    static deserializeBinaryFromReader(message: ListPaymentsResponse, reader: jspb.BinaryReader): ListPaymentsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPaymentsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPaymentsResponse): ListPaymentsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPaymentsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPaymentsResponse;
+  static deserializeBinaryFromReader(message: ListPaymentsResponse, reader: jspb.BinaryReader): ListPaymentsResponse;
 }
 
 export namespace ListPaymentsResponse {
-    export type AsObject = {
-        paymentsList: Array<Payment.AsObject>,
-    }
+  export type AsObject = {
+    paymentsList: Array<Payment.AsObject>,
+  }
 }
 
-export class DeleteAllPaymentsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DeleteAllPaymentsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DeleteAllPaymentsRequest): DeleteAllPaymentsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DeleteAllPaymentsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsRequest;
-    static deserializeBinaryFromReader(message: DeleteAllPaymentsRequest, reader: jspb.BinaryReader): DeleteAllPaymentsRequest;
+export class DeleteAllPaymentsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DeleteAllPaymentsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DeleteAllPaymentsRequest): DeleteAllPaymentsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DeleteAllPaymentsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsRequest;
+  static deserializeBinaryFromReader(message: DeleteAllPaymentsRequest, reader: jspb.BinaryReader): DeleteAllPaymentsRequest;
 }
 
 export namespace DeleteAllPaymentsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class DeleteAllPaymentsResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DeleteAllPaymentsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DeleteAllPaymentsResponse): DeleteAllPaymentsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DeleteAllPaymentsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsResponse;
-    static deserializeBinaryFromReader(message: DeleteAllPaymentsResponse, reader: jspb.BinaryReader): DeleteAllPaymentsResponse;
+export class DeleteAllPaymentsResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DeleteAllPaymentsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DeleteAllPaymentsResponse): DeleteAllPaymentsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DeleteAllPaymentsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsResponse;
+  static deserializeBinaryFromReader(message: DeleteAllPaymentsResponse, reader: jspb.BinaryReader): DeleteAllPaymentsResponse;
 }
 
 export namespace DeleteAllPaymentsResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class DebugLevelRequest extends jspb.Message { 
-    getShow(): boolean;
-    setShow(value: boolean): void;
+export class DebugLevelRequest extends jspb.Message {
+  getShow(): boolean;
+  setShow(value: boolean): void;
 
-    getLevelSpec(): string;
-    setLevelSpec(value: string): void;
+  getLevelSpec(): string;
+  setLevelSpec(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DebugLevelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DebugLevelRequest): DebugLevelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DebugLevelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DebugLevelRequest;
-    static deserializeBinaryFromReader(message: DebugLevelRequest, reader: jspb.BinaryReader): DebugLevelRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DebugLevelRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DebugLevelRequest): DebugLevelRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DebugLevelRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DebugLevelRequest;
+  static deserializeBinaryFromReader(message: DebugLevelRequest, reader: jspb.BinaryReader): DebugLevelRequest;
 }
 
 export namespace DebugLevelRequest {
-    export type AsObject = {
-        show: boolean,
-        levelSpec: string,
-    }
+  export type AsObject = {
+    show: boolean,
+    levelSpec: string,
+  }
 }
 
-export class DebugLevelResponse extends jspb.Message { 
-    getSubSystems(): string;
-    setSubSystems(value: string): void;
+export class DebugLevelResponse extends jspb.Message {
+  getSubSystems(): string;
+  setSubSystems(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DebugLevelResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DebugLevelResponse): DebugLevelResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DebugLevelResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DebugLevelResponse;
-    static deserializeBinaryFromReader(message: DebugLevelResponse, reader: jspb.BinaryReader): DebugLevelResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DebugLevelResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DebugLevelResponse): DebugLevelResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DebugLevelResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DebugLevelResponse;
+  static deserializeBinaryFromReader(message: DebugLevelResponse, reader: jspb.BinaryReader): DebugLevelResponse;
 }
 
 export namespace DebugLevelResponse {
-    export type AsObject = {
-        subSystems: string,
-    }
+  export type AsObject = {
+    subSystems: string,
+  }
 }
 
-export class PayReqString extends jspb.Message { 
-    getPayReq(): string;
-    setPayReq(value: string): void;
+export class PayReqString extends jspb.Message {
+  getPayReq(): string;
+  setPayReq(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PayReqString.AsObject;
-    static toObject(includeInstance: boolean, msg: PayReqString): PayReqString.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PayReqString, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PayReqString;
-    static deserializeBinaryFromReader(message: PayReqString, reader: jspb.BinaryReader): PayReqString;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PayReqString.AsObject;
+  static toObject(includeInstance: boolean, msg: PayReqString): PayReqString.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PayReqString, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PayReqString;
+  static deserializeBinaryFromReader(message: PayReqString, reader: jspb.BinaryReader): PayReqString;
 }
 
 export namespace PayReqString {
-    export type AsObject = {
-        payReq: string,
-    }
+  export type AsObject = {
+    payReq: string,
+  }
 }
 
-export class PayReq extends jspb.Message { 
-    getDestination(): string;
-    setDestination(value: string): void;
+export class PayReq extends jspb.Message {
+  getDestination(): string;
+  setDestination(value: string): void;
 
-    getPaymentHash(): string;
-    setPaymentHash(value: string): void;
+  getPaymentHash(): string;
+  setPaymentHash(value: string): void;
 
-    getNumSatoshis(): number;
-    setNumSatoshis(value: number): void;
+  getNumSatoshis(): number;
+  setNumSatoshis(value: number): void;
 
-    getTimestamp(): number;
-    setTimestamp(value: number): void;
+  getTimestamp(): number;
+  setTimestamp(value: number): void;
 
-    getExpiry(): number;
-    setExpiry(value: number): void;
+  getExpiry(): number;
+  setExpiry(value: number): void;
 
-    getDescription(): string;
-    setDescription(value: string): void;
+  getDescription(): string;
+  setDescription(value: string): void;
 
-    getDescriptionHash(): string;
-    setDescriptionHash(value: string): void;
+  getDescriptionHash(): string;
+  setDescriptionHash(value: string): void;
 
-    getFallbackAddr(): string;
-    setFallbackAddr(value: string): void;
+  getFallbackAddr(): string;
+  setFallbackAddr(value: string): void;
 
-    getCltvExpiry(): number;
-    setCltvExpiry(value: number): void;
+  getCltvExpiry(): number;
+  setCltvExpiry(value: number): void;
 
-    clearRouteHintsList(): void;
-    getRouteHintsList(): Array<RouteHint>;
-    setRouteHintsList(value: Array<RouteHint>): void;
-    addRouteHints(value?: RouteHint, index?: number): RouteHint;
+  clearRouteHintsList(): void;
+  getRouteHintsList(): Array<RouteHint>;
+  setRouteHintsList(value: Array<RouteHint>): void;
+  addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PayReq.AsObject;
-    static toObject(includeInstance: boolean, msg: PayReq): PayReq.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PayReq, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PayReq;
-    static deserializeBinaryFromReader(message: PayReq, reader: jspb.BinaryReader): PayReq;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PayReq.AsObject;
+  static toObject(includeInstance: boolean, msg: PayReq): PayReq.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PayReq, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PayReq;
+  static deserializeBinaryFromReader(message: PayReq, reader: jspb.BinaryReader): PayReq;
 }
 
 export namespace PayReq {
-    export type AsObject = {
-        destination: string,
-        paymentHash: string,
-        numSatoshis: number,
-        timestamp: number,
-        expiry: number,
-        description: string,
-        descriptionHash: string,
-        fallbackAddr: string,
-        cltvExpiry: number,
-        routeHintsList: Array<RouteHint.AsObject>,
-    }
+  export type AsObject = {
+    destination: string,
+    paymentHash: string,
+    numSatoshis: number,
+    timestamp: number,
+    expiry: number,
+    description: string,
+    descriptionHash: string,
+    fallbackAddr: string,
+    cltvExpiry: number,
+    routeHintsList: Array<RouteHint.AsObject>,
+  }
 }
 
-export class FeeReportRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FeeReportRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: FeeReportRequest): FeeReportRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FeeReportRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FeeReportRequest;
-    static deserializeBinaryFromReader(message: FeeReportRequest, reader: jspb.BinaryReader): FeeReportRequest;
+export class FeeReportRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FeeReportRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: FeeReportRequest): FeeReportRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FeeReportRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FeeReportRequest;
+  static deserializeBinaryFromReader(message: FeeReportRequest, reader: jspb.BinaryReader): FeeReportRequest;
 }
 
 export namespace FeeReportRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChannelFeeReport extends jspb.Message { 
-    getChanPoint(): string;
-    setChanPoint(value: string): void;
+export class ChannelFeeReport extends jspb.Message {
+  getChanPoint(): string;
+  setChanPoint(value: string): void;
 
-    getBaseFeeMsat(): number;
-    setBaseFeeMsat(value: number): void;
+  getBaseFeeMsat(): number;
+  setBaseFeeMsat(value: number): void;
 
-    getFeePerMil(): number;
-    setFeePerMil(value: number): void;
+  getFeePerMil(): number;
+  setFeePerMil(value: number): void;
 
-    getFeeRate(): number;
-    setFeeRate(value: number): void;
+  getFeeRate(): number;
+  setFeeRate(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelFeeReport.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelFeeReport): ChannelFeeReport.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelFeeReport, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelFeeReport;
-    static deserializeBinaryFromReader(message: ChannelFeeReport, reader: jspb.BinaryReader): ChannelFeeReport;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelFeeReport.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelFeeReport): ChannelFeeReport.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelFeeReport, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelFeeReport;
+  static deserializeBinaryFromReader(message: ChannelFeeReport, reader: jspb.BinaryReader): ChannelFeeReport;
 }
 
 export namespace ChannelFeeReport {
-    export type AsObject = {
-        chanPoint: string,
-        baseFeeMsat: number,
-        feePerMil: number,
-        feeRate: number,
-    }
+  export type AsObject = {
+    chanPoint: string,
+    baseFeeMsat: number,
+    feePerMil: number,
+    feeRate: number,
+  }
 }
 
-export class FeeReportResponse extends jspb.Message { 
-    clearChannelFeesList(): void;
-    getChannelFeesList(): Array<ChannelFeeReport>;
-    setChannelFeesList(value: Array<ChannelFeeReport>): void;
-    addChannelFees(value?: ChannelFeeReport, index?: number): ChannelFeeReport;
+export class FeeReportResponse extends jspb.Message {
+  clearChannelFeesList(): void;
+  getChannelFeesList(): Array<ChannelFeeReport>;
+  setChannelFeesList(value: Array<ChannelFeeReport>): void;
+  addChannelFees(value?: ChannelFeeReport, index?: number): ChannelFeeReport;
 
-    getDayFeeSum(): number;
-    setDayFeeSum(value: number): void;
+  getDayFeeSum(): number;
+  setDayFeeSum(value: number): void;
 
-    getWeekFeeSum(): number;
-    setWeekFeeSum(value: number): void;
+  getWeekFeeSum(): number;
+  setWeekFeeSum(value: number): void;
 
-    getMonthFeeSum(): number;
-    setMonthFeeSum(value: number): void;
+  getMonthFeeSum(): number;
+  setMonthFeeSum(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FeeReportResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: FeeReportResponse): FeeReportResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FeeReportResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FeeReportResponse;
-    static deserializeBinaryFromReader(message: FeeReportResponse, reader: jspb.BinaryReader): FeeReportResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FeeReportResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: FeeReportResponse): FeeReportResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FeeReportResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FeeReportResponse;
+  static deserializeBinaryFromReader(message: FeeReportResponse, reader: jspb.BinaryReader): FeeReportResponse;
 }
 
 export namespace FeeReportResponse {
-    export type AsObject = {
-        channelFeesList: Array<ChannelFeeReport.AsObject>,
-        dayFeeSum: number,
-        weekFeeSum: number,
-        monthFeeSum: number,
-    }
+  export type AsObject = {
+    channelFeesList: Array<ChannelFeeReport.AsObject>,
+    dayFeeSum: number,
+    weekFeeSum: number,
+    monthFeeSum: number,
+  }
 }
 
-export class PolicyUpdateRequest extends jspb.Message { 
+export class PolicyUpdateRequest extends jspb.Message {
+  hasGlobal(): boolean;
+  clearGlobal(): void;
+  getGlobal(): boolean;
+  setGlobal(value: boolean): void;
 
-    hasGlobal(): boolean;
-    clearGlobal(): void;
-    getGlobal(): boolean;
-    setGlobal(value: boolean): void;
+  hasChanPoint(): boolean;
+  clearChanPoint(): void;
+  getChanPoint(): ChannelPoint | undefined;
+  setChanPoint(value?: ChannelPoint): void;
 
+  getBaseFeeMsat(): number;
+  setBaseFeeMsat(value: number): void;
 
-    hasChanPoint(): boolean;
-    clearChanPoint(): void;
-    getChanPoint(): ChannelPoint | undefined;
-    setChanPoint(value?: ChannelPoint): void;
+  getFeeRate(): number;
+  setFeeRate(value: number): void;
 
-    getBaseFeeMsat(): number;
-    setBaseFeeMsat(value: number): void;
+  getTimeLockDelta(): number;
+  setTimeLockDelta(value: number): void;
 
-    getFeeRate(): number;
-    setFeeRate(value: number): void;
-
-    getTimeLockDelta(): number;
-    setTimeLockDelta(value: number): void;
-
-
-    getScopeCase(): PolicyUpdateRequest.ScopeCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PolicyUpdateRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PolicyUpdateRequest): PolicyUpdateRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PolicyUpdateRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PolicyUpdateRequest;
-    static deserializeBinaryFromReader(message: PolicyUpdateRequest, reader: jspb.BinaryReader): PolicyUpdateRequest;
+  getScopeCase(): PolicyUpdateRequest.ScopeCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PolicyUpdateRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: PolicyUpdateRequest): PolicyUpdateRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PolicyUpdateRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PolicyUpdateRequest;
+  static deserializeBinaryFromReader(message: PolicyUpdateRequest, reader: jspb.BinaryReader): PolicyUpdateRequest;
 }
 
 export namespace PolicyUpdateRequest {
-    export type AsObject = {
-        global: boolean,
-        chanPoint?: ChannelPoint.AsObject,
-        baseFeeMsat: number,
-        feeRate: number,
-        timeLockDelta: number,
-    }
+  export type AsObject = {
+    global: boolean,
+    chanPoint?: ChannelPoint.AsObject,
+    baseFeeMsat: number,
+    feeRate: number,
+    timeLockDelta: number,
+  }
 
-    export enum ScopeCase {
-        SCOPE_NOT_SET = 0,
-    
+  export enum ScopeCase {
+    SCOPE_NOT_SET = 0,
     GLOBAL = 1,
-
     CHAN_POINT = 2,
-
-    }
-
+  }
 }
 
-export class PolicyUpdateResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PolicyUpdateResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PolicyUpdateResponse): PolicyUpdateResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PolicyUpdateResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PolicyUpdateResponse;
-    static deserializeBinaryFromReader(message: PolicyUpdateResponse, reader: jspb.BinaryReader): PolicyUpdateResponse;
+export class PolicyUpdateResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PolicyUpdateResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: PolicyUpdateResponse): PolicyUpdateResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PolicyUpdateResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PolicyUpdateResponse;
+  static deserializeBinaryFromReader(message: PolicyUpdateResponse, reader: jspb.BinaryReader): PolicyUpdateResponse;
 }
 
 export namespace PolicyUpdateResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ForwardingHistoryRequest extends jspb.Message { 
-    getStartTime(): number;
-    setStartTime(value: number): void;
+export class ForwardingHistoryRequest extends jspb.Message {
+  getStartTime(): number;
+  setStartTime(value: number): void;
 
-    getEndTime(): number;
-    setEndTime(value: number): void;
+  getEndTime(): number;
+  setEndTime(value: number): void;
 
-    getIndexOffset(): number;
-    setIndexOffset(value: number): void;
+  getIndexOffset(): number;
+  setIndexOffset(value: number): void;
 
-    getNumMaxEvents(): number;
-    setNumMaxEvents(value: number): void;
+  getNumMaxEvents(): number;
+  setNumMaxEvents(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ForwardingHistoryRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ForwardingHistoryRequest): ForwardingHistoryRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ForwardingHistoryRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ForwardingHistoryRequest;
-    static deserializeBinaryFromReader(message: ForwardingHistoryRequest, reader: jspb.BinaryReader): ForwardingHistoryRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ForwardingHistoryRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ForwardingHistoryRequest): ForwardingHistoryRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ForwardingHistoryRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ForwardingHistoryRequest;
+  static deserializeBinaryFromReader(message: ForwardingHistoryRequest, reader: jspb.BinaryReader): ForwardingHistoryRequest;
 }
 
 export namespace ForwardingHistoryRequest {
-    export type AsObject = {
-        startTime: number,
-        endTime: number,
-        indexOffset: number,
-        numMaxEvents: number,
-    }
+  export type AsObject = {
+    startTime: number,
+    endTime: number,
+    indexOffset: number,
+    numMaxEvents: number,
+  }
 }
 
-export class ForwardingEvent extends jspb.Message { 
-    getTimestamp(): number;
-    setTimestamp(value: number): void;
+export class ForwardingEvent extends jspb.Message {
+  getTimestamp(): number;
+  setTimestamp(value: number): void;
 
-    getChanIdIn(): number;
-    setChanIdIn(value: number): void;
+  getChanIdIn(): number;
+  setChanIdIn(value: number): void;
 
-    getChanIdOut(): number;
-    setChanIdOut(value: number): void;
+  getChanIdOut(): number;
+  setChanIdOut(value: number): void;
 
-    getAmtIn(): number;
-    setAmtIn(value: number): void;
+  getAmtIn(): number;
+  setAmtIn(value: number): void;
 
-    getAmtOut(): number;
-    setAmtOut(value: number): void;
+  getAmtOut(): number;
+  setAmtOut(value: number): void;
 
-    getFee(): number;
-    setFee(value: number): void;
+  getFee(): number;
+  setFee(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ForwardingEvent.AsObject;
-    static toObject(includeInstance: boolean, msg: ForwardingEvent): ForwardingEvent.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ForwardingEvent, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ForwardingEvent;
-    static deserializeBinaryFromReader(message: ForwardingEvent, reader: jspb.BinaryReader): ForwardingEvent;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ForwardingEvent.AsObject;
+  static toObject(includeInstance: boolean, msg: ForwardingEvent): ForwardingEvent.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ForwardingEvent, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ForwardingEvent;
+  static deserializeBinaryFromReader(message: ForwardingEvent, reader: jspb.BinaryReader): ForwardingEvent;
 }
 
 export namespace ForwardingEvent {
-    export type AsObject = {
-        timestamp: number,
-        chanIdIn: number,
-        chanIdOut: number,
-        amtIn: number,
-        amtOut: number,
-        fee: number,
-    }
+  export type AsObject = {
+    timestamp: number,
+    chanIdIn: number,
+    chanIdOut: number,
+    amtIn: number,
+    amtOut: number,
+    fee: number,
+  }
 }
 
-export class ForwardingHistoryResponse extends jspb.Message { 
-    clearForwardingEventsList(): void;
-    getForwardingEventsList(): Array<ForwardingEvent>;
-    setForwardingEventsList(value: Array<ForwardingEvent>): void;
-    addForwardingEvents(value?: ForwardingEvent, index?: number): ForwardingEvent;
+export class ForwardingHistoryResponse extends jspb.Message {
+  clearForwardingEventsList(): void;
+  getForwardingEventsList(): Array<ForwardingEvent>;
+  setForwardingEventsList(value: Array<ForwardingEvent>): void;
+  addForwardingEvents(value?: ForwardingEvent, index?: number): ForwardingEvent;
 
-    getLastOffsetIndex(): number;
-    setLastOffsetIndex(value: number): void;
+  getLastOffsetIndex(): number;
+  setLastOffsetIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ForwardingHistoryResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ForwardingHistoryResponse): ForwardingHistoryResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ForwardingHistoryResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ForwardingHistoryResponse;
-    static deserializeBinaryFromReader(message: ForwardingHistoryResponse, reader: jspb.BinaryReader): ForwardingHistoryResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ForwardingHistoryResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ForwardingHistoryResponse): ForwardingHistoryResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ForwardingHistoryResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ForwardingHistoryResponse;
+  static deserializeBinaryFromReader(message: ForwardingHistoryResponse, reader: jspb.BinaryReader): ForwardingHistoryResponse;
 }
 
 export namespace ForwardingHistoryResponse {
-    export type AsObject = {
-        forwardingEventsList: Array<ForwardingEvent.AsObject>,
-        lastOffsetIndex: number,
-    }
+  export type AsObject = {
+    forwardingEventsList: Array<ForwardingEvent.AsObject>,
+    lastOffsetIndex: number,
+  }
 }
 
-export class ResolveRequest extends jspb.Message { 
-    getHash(): string;
-    setHash(value: string): void;
+export class ResolveRequest extends jspb.Message {
+  getHash(): string;
+  setHash(value: string): void;
 
-    getTimeout(): number;
-    setTimeout(value: number): void;
+  getTimeout(): number;
+  setTimeout(value: number): void;
 
-    getHeightNow(): number;
-    setHeightNow(value: number): void;
+  getHeightNow(): number;
+  setHeightNow(value: number): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ResolveRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ResolveRequest): ResolveRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ResolveRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ResolveRequest;
-    static deserializeBinaryFromReader(message: ResolveRequest, reader: jspb.BinaryReader): ResolveRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ResolveRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ResolveRequest): ResolveRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ResolveRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ResolveRequest;
+  static deserializeBinaryFromReader(message: ResolveRequest, reader: jspb.BinaryReader): ResolveRequest;
 }
 
 export namespace ResolveRequest {
-    export type AsObject = {
-        hash: string,
-        timeout: number,
-        heightNow: number,
-        amount: number,
-    }
+  export type AsObject = {
+    hash: string,
+    timeout: number,
+    heightNow: number,
+    amount: number,
+  }
 }
 
-export class ResolveResponse extends jspb.Message { 
-    getPreimage(): string;
-    setPreimage(value: string): void;
+export class ResolveResponse extends jspb.Message {
+  getPreimage(): string;
+  setPreimage(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ResolveResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ResolveResponse): ResolveResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ResolveResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ResolveResponse;
-    static deserializeBinaryFromReader(message: ResolveResponse, reader: jspb.BinaryReader): ResolveResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ResolveResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ResolveResponse): ResolveResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ResolveResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ResolveResponse;
+  static deserializeBinaryFromReader(message: ResolveResponse, reader: jspb.BinaryReader): ResolveResponse;
 }
 
 export namespace ResolveResponse {
-    export type AsObject = {
-        preimage: string,
-    }
+  export type AsObject = {
+    preimage: string,
+  }
 }
+

--- a/lib/proto/lndrpc_pb.js
+++ b/lib/proto/lndrpc_pb.js
@@ -6442,7 +6442,7 @@ proto.lnrpc.Channel.toObject = function(includeInstance, msg) {
     active: jspb.Message.getFieldWithDefault(msg, 1, false),
     remotePubkey: jspb.Message.getFieldWithDefault(msg, 2, ""),
     channelPoint: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    chanId: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    chanId: jspb.Message.getFieldWithDefault(msg, 4, "0"),
     capacity: jspb.Message.getFieldWithDefault(msg, 5, 0),
     localBalance: jspb.Message.getFieldWithDefault(msg, 6, 0),
     remoteBalance: jspb.Message.getFieldWithDefault(msg, 7, 0),
@@ -6506,7 +6506,7 @@ proto.lnrpc.Channel.deserializeBinaryFromReader = function(msg, reader) {
       msg.setChannelPoint(value);
       break;
     case 4:
-      var value = /** @type {number} */ (reader.readUint64());
+      var value = /** @type {string} */ (reader.readUint64String());
       msg.setChanId(value);
       break;
     case 5:
@@ -6613,8 +6613,8 @@ proto.lnrpc.Channel.serializeBinaryToWriter = function(message, writer) {
     );
   }
   f = message.getChanId();
-  if (f !== 0) {
-    writer.writeUint64(
+  if (parseInt(f, 10) !== 0) {
+    writer.writeUint64String(
       4,
       f
     );
@@ -6763,14 +6763,14 @@ proto.lnrpc.Channel.prototype.setChannelPoint = function(value) {
 
 /**
  * optional uint64 chan_id = 4;
- * @return {number}
+ * @return {string}
  */
 proto.lnrpc.Channel.prototype.getChanId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, "0"));
 };
 
 
-/** @param {number} value */
+/** @param {string} value */
 proto.lnrpc.Channel.prototype.setChanId = function(value) {
   jspb.Message.setField(this, 4, value);
 };
@@ -7436,7 +7436,7 @@ proto.lnrpc.ChannelCloseSummary.prototype.toObject = function(opt_includeInstanc
 proto.lnrpc.ChannelCloseSummary.toObject = function(includeInstance, msg) {
   var f, obj = {
     channelPoint: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    chanId: jspb.Message.getFieldWithDefault(msg, 2, 0),
+    chanId: jspb.Message.getFieldWithDefault(msg, 2, "0"),
     chainHash: jspb.Message.getFieldWithDefault(msg, 3, ""),
     closingTxHash: jspb.Message.getFieldWithDefault(msg, 4, ""),
     remotePubkey: jspb.Message.getFieldWithDefault(msg, 5, ""),
@@ -7486,7 +7486,7 @@ proto.lnrpc.ChannelCloseSummary.deserializeBinaryFromReader = function(msg, read
       msg.setChannelPoint(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readUint64());
+      var value = /** @type {string} */ (reader.readUint64String());
       msg.setChanId(value);
       break;
     case 3:
@@ -7558,8 +7558,8 @@ proto.lnrpc.ChannelCloseSummary.serializeBinaryToWriter = function(message, writ
     );
   }
   f = message.getChanId();
-  if (f !== 0) {
-    writer.writeUint64(
+  if (parseInt(f, 10) !== 0) {
+    writer.writeUint64String(
       2,
       f
     );
@@ -7651,14 +7651,14 @@ proto.lnrpc.ChannelCloseSummary.prototype.setChannelPoint = function(value) {
 
 /**
  * optional uint64 chan_id = 2;
- * @return {number}
+ * @return {string}
  */
 proto.lnrpc.ChannelCloseSummary.prototype.getChanId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, "0"));
 };
 
 
-/** @param {number} value */
+/** @param {string} value */
 proto.lnrpc.ChannelCloseSummary.prototype.setChanId = function(value) {
   jspb.Message.setField(this, 2, value);
 };
@@ -14461,7 +14461,7 @@ proto.lnrpc.Hop.prototype.toObject = function(opt_includeInstance) {
  */
 proto.lnrpc.Hop.toObject = function(includeInstance, msg) {
   var f, obj = {
-    chanId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    chanId: jspb.Message.getFieldWithDefault(msg, 1, "0"),
     chanCapacity: jspb.Message.getFieldWithDefault(msg, 2, 0),
     amtToForward: jspb.Message.getFieldWithDefault(msg, 3, 0),
     fee: jspb.Message.getFieldWithDefault(msg, 4, 0),
@@ -14505,7 +14505,7 @@ proto.lnrpc.Hop.deserializeBinaryFromReader = function(msg, reader) {
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readUint64());
+      var value = /** @type {string} */ (reader.readUint64String());
       msg.setChanId(value);
       break;
     case 2:
@@ -14562,8 +14562,8 @@ proto.lnrpc.Hop.prototype.serializeBinary = function() {
 proto.lnrpc.Hop.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getChanId();
-  if (f !== 0) {
-    writer.writeUint64(
+  if (parseInt(f, 10) !== 0) {
+    writer.writeUint64String(
       1,
       f
     );
@@ -14615,14 +14615,14 @@ proto.lnrpc.Hop.serializeBinaryToWriter = function(message, writer) {
 
 /**
  * optional uint64 chan_id = 1;
- * @return {number}
+ * @return {string}
  */
 proto.lnrpc.Hop.prototype.getChanId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, "0"));
 };
 
 
-/** @param {number} value */
+/** @param {string} value */
 proto.lnrpc.Hop.prototype.setChanId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
@@ -18618,7 +18618,7 @@ proto.lnrpc.ClosedChannelUpdate.prototype.toObject = function(opt_includeInstanc
  */
 proto.lnrpc.ClosedChannelUpdate.toObject = function(includeInstance, msg) {
   var f, obj = {
-    chanId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    chanId: jspb.Message.getFieldWithDefault(msg, 1, "0"),
     capacity: jspb.Message.getFieldWithDefault(msg, 2, 0),
     closedHeight: jspb.Message.getFieldWithDefault(msg, 3, 0),
     chanPoint: (f = msg.getChanPoint()) && proto.lnrpc.ChannelPoint.toObject(includeInstance, f)
@@ -18659,7 +18659,7 @@ proto.lnrpc.ClosedChannelUpdate.deserializeBinaryFromReader = function(msg, read
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readUint64());
+      var value = /** @type {string} */ (reader.readUint64String());
       msg.setChanId(value);
       break;
     case 2:
@@ -18705,8 +18705,8 @@ proto.lnrpc.ClosedChannelUpdate.prototype.serializeBinary = function() {
 proto.lnrpc.ClosedChannelUpdate.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getChanId();
-  if (f !== 0) {
-    writer.writeUint64(
+  if (parseInt(f, 10) !== 0) {
+    writer.writeUint64String(
       1,
       f
     );
@@ -18738,14 +18738,14 @@ proto.lnrpc.ClosedChannelUpdate.serializeBinaryToWriter = function(message, writ
 
 /**
  * optional uint64 chan_id = 1;
- * @return {number}
+ * @return {string}
  */
 proto.lnrpc.ClosedChannelUpdate.prototype.getChanId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, "0"));
 };
 
 
-/** @param {number} value */
+/** @param {string} value */
 proto.lnrpc.ClosedChannelUpdate.prototype.setChanId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
@@ -18859,7 +18859,7 @@ proto.lnrpc.HopHint.prototype.toObject = function(opt_includeInstance) {
 proto.lnrpc.HopHint.toObject = function(includeInstance, msg) {
   var f, obj = {
     nodeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    chanId: jspb.Message.getFieldWithDefault(msg, 2, 0),
+    chanId: jspb.Message.getFieldWithDefault(msg, 2, "0"),
     feeBaseMsat: jspb.Message.getFieldWithDefault(msg, 3, 0),
     feeProportionalMillionths: jspb.Message.getFieldWithDefault(msg, 4, 0),
     cltvExpiryDelta: jspb.Message.getFieldWithDefault(msg, 5, 0)
@@ -18904,7 +18904,7 @@ proto.lnrpc.HopHint.deserializeBinaryFromReader = function(msg, reader) {
       msg.setNodeId(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readUint64());
+      var value = /** @type {string} */ (reader.readUint64String());
       msg.setChanId(value);
       break;
     case 3:
@@ -18956,8 +18956,8 @@ proto.lnrpc.HopHint.serializeBinaryToWriter = function(message, writer) {
     );
   }
   f = message.getChanId();
-  if (f !== 0) {
-    writer.writeUint64(
+  if (parseInt(f, 10) !== 0) {
+    writer.writeUint64String(
       2,
       f
     );
@@ -19003,14 +19003,14 @@ proto.lnrpc.HopHint.prototype.setNodeId = function(value) {
 
 /**
  * optional uint64 chan_id = 2;
- * @return {number}
+ * @return {string}
  */
 proto.lnrpc.HopHint.prototype.getChanId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, "0"));
 };
 
 
-/** @param {number} value */
+/** @param {string} value */
 proto.lnrpc.HopHint.prototype.setChanId = function(value) {
   jspb.Message.setField(this, 2, value);
 };

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -21,7 +21,7 @@
         "operationId": "AddCurrency",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcAddCurrencyResponse"
             }
@@ -48,7 +48,7 @@
         "operationId": "AddPair",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcAddPairResponse"
             }
@@ -75,7 +75,7 @@
         "operationId": "Ban",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcBanResponse"
             }
@@ -102,7 +102,7 @@
         "operationId": "ChannelBalance",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcChannelBalanceResponse"
             }
@@ -128,7 +128,7 @@
         "operationId": "Connect",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcConnectResponse"
             }
@@ -155,7 +155,7 @@
         "operationId": "ListCurrencies",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListCurrenciesResponse"
             }
@@ -172,7 +172,7 @@
         "operationId": "ExecuteSwap",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcSwapResult"
             }
@@ -199,7 +199,7 @@
         "operationId": "GetInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetInfoResponse"
             }
@@ -216,7 +216,7 @@
         "operationId": "GetNodeInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetNodeInfoResponse"
             }
@@ -242,7 +242,7 @@
         "operationId": "GetOrders",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetOrdersResponse"
             }
@@ -276,7 +276,7 @@
         "operationId": "ListPairs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListPairsResponse"
             }
@@ -293,7 +293,7 @@
         "operationId": "ListPeers",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListPeersResponse"
             }
@@ -310,7 +310,7 @@
         "operationId": "PlaceOrder",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcPlaceOrderEvent"
             }
@@ -337,7 +337,7 @@
         "operationId": "PlaceOrderSync",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcPlaceOrderResponse"
             }
@@ -364,7 +364,7 @@
         "operationId": "RemoveCurrency",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemoveCurrencyResponse"
             }
@@ -391,7 +391,7 @@
         "operationId": "RemoveOrder",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemoveOrderResponse"
             }
@@ -418,7 +418,7 @@
         "operationId": "RemovePair",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemovePairResponse"
             }
@@ -445,7 +445,7 @@
         "operationId": "Shutdown",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcShutdownResponse"
             }
@@ -472,7 +472,7 @@
         "operationId": "SubscribeRemovedOrders",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcOrderRemoval"
             }
@@ -489,7 +489,7 @@
         "operationId": "SubscribeSwaps",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcSwapResult"
             }
@@ -506,7 +506,7 @@
         "operationId": "Unban",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcUnbanResponse"
             }

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -1,1358 +1,1278 @@
 // package: xudrpc
 // file: xudrpc.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 import * as annotations_pb from "./annotations_pb";
 
-export class AddCurrencyRequest extends jspb.Message { 
-    getCurrency(): string;
-    setCurrency(value: string): void;
+export class AddCurrencyRequest extends jspb.Message {
+  getCurrency(): string;
+  setCurrency(value: string): void;
 
-    getSwapClient(): AddCurrencyRequest.SwapClient;
-    setSwapClient(value: AddCurrencyRequest.SwapClient): void;
+  getSwapClient(): AddCurrencyRequest.SwapClient;
+  setSwapClient(value: AddCurrencyRequest.SwapClient): void;
 
-    getTokenAddress(): string;
-    setTokenAddress(value: string): void;
+  getTokenAddress(): string;
+  setTokenAddress(value: string): void;
 
-    getDecimalPlaces(): number;
-    setDecimalPlaces(value: number): void;
+  getDecimalPlaces(): number;
+  setDecimalPlaces(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): AddCurrencyRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: AddCurrencyRequest): AddCurrencyRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: AddCurrencyRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): AddCurrencyRequest;
-    static deserializeBinaryFromReader(message: AddCurrencyRequest, reader: jspb.BinaryReader): AddCurrencyRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): AddCurrencyRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: AddCurrencyRequest): AddCurrencyRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: AddCurrencyRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AddCurrencyRequest;
+  static deserializeBinaryFromReader(message: AddCurrencyRequest, reader: jspb.BinaryReader): AddCurrencyRequest;
 }
 
 export namespace AddCurrencyRequest {
-    export type AsObject = {
-        currency: string,
-        swapClient: AddCurrencyRequest.SwapClient,
-        tokenAddress: string,
-        decimalPlaces: number,
-    }
+  export type AsObject = {
+    currency: string,
+    swapClient: AddCurrencyRequest.SwapClient,
+    tokenAddress: string,
+    decimalPlaces: number,
+  }
 
-    export enum SwapClient {
+  export enum SwapClient {
     LND = 0,
     RAIDEN = 1,
-    }
-
+  }
 }
 
-export class AddCurrencyResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): AddCurrencyResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: AddCurrencyResponse): AddCurrencyResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: AddCurrencyResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): AddCurrencyResponse;
-    static deserializeBinaryFromReader(message: AddCurrencyResponse, reader: jspb.BinaryReader): AddCurrencyResponse;
+export class AddCurrencyResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): AddCurrencyResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: AddCurrencyResponse): AddCurrencyResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: AddCurrencyResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AddCurrencyResponse;
+  static deserializeBinaryFromReader(message: AddCurrencyResponse, reader: jspb.BinaryReader): AddCurrencyResponse;
 }
 
 export namespace AddCurrencyResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class AddPairRequest extends jspb.Message { 
-    getBaseCurrency(): string;
-    setBaseCurrency(value: string): void;
+export class AddPairRequest extends jspb.Message {
+  getBaseCurrency(): string;
+  setBaseCurrency(value: string): void;
 
-    getQuoteCurrency(): string;
-    setQuoteCurrency(value: string): void;
+  getQuoteCurrency(): string;
+  setQuoteCurrency(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): AddPairRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: AddPairRequest): AddPairRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: AddPairRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): AddPairRequest;
-    static deserializeBinaryFromReader(message: AddPairRequest, reader: jspb.BinaryReader): AddPairRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): AddPairRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: AddPairRequest): AddPairRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: AddPairRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AddPairRequest;
+  static deserializeBinaryFromReader(message: AddPairRequest, reader: jspb.BinaryReader): AddPairRequest;
 }
 
 export namespace AddPairRequest {
-    export type AsObject = {
-        baseCurrency: string,
-        quoteCurrency: string,
-    }
+  export type AsObject = {
+    baseCurrency: string,
+    quoteCurrency: string,
+  }
 }
 
-export class AddPairResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): AddPairResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: AddPairResponse): AddPairResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: AddPairResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): AddPairResponse;
-    static deserializeBinaryFromReader(message: AddPairResponse, reader: jspb.BinaryReader): AddPairResponse;
+export class AddPairResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): AddPairResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: AddPairResponse): AddPairResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: AddPairResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AddPairResponse;
+  static deserializeBinaryFromReader(message: AddPairResponse, reader: jspb.BinaryReader): AddPairResponse;
 }
 
 export namespace AddPairResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class RemoveOrderRequest extends jspb.Message { 
-    getOrderId(): string;
-    setOrderId(value: string): void;
+export class RemoveOrderRequest extends jspb.Message {
+  getOrderId(): string;
+  setOrderId(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RemoveOrderRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: RemoveOrderRequest): RemoveOrderRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RemoveOrderRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RemoveOrderRequest;
-    static deserializeBinaryFromReader(message: RemoveOrderRequest, reader: jspb.BinaryReader): RemoveOrderRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemoveOrderRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: RemoveOrderRequest): RemoveOrderRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemoveOrderRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemoveOrderRequest;
+  static deserializeBinaryFromReader(message: RemoveOrderRequest, reader: jspb.BinaryReader): RemoveOrderRequest;
 }
 
 export namespace RemoveOrderRequest {
-    export type AsObject = {
-        orderId: string,
-    }
+  export type AsObject = {
+    orderId: string,
+  }
 }
 
-export class RemoveOrderResponse extends jspb.Message { 
-    getQuantityOnHold(): number;
-    setQuantityOnHold(value: number): void;
+export class RemoveOrderResponse extends jspb.Message {
+  getQuantityOnHold(): number;
+  setQuantityOnHold(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RemoveOrderResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: RemoveOrderResponse): RemoveOrderResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RemoveOrderResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RemoveOrderResponse;
-    static deserializeBinaryFromReader(message: RemoveOrderResponse, reader: jspb.BinaryReader): RemoveOrderResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemoveOrderResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: RemoveOrderResponse): RemoveOrderResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemoveOrderResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemoveOrderResponse;
+  static deserializeBinaryFromReader(message: RemoveOrderResponse, reader: jspb.BinaryReader): RemoveOrderResponse;
 }
 
 export namespace RemoveOrderResponse {
-    export type AsObject = {
-        quantityOnHold: number,
-    }
+  export type AsObject = {
+    quantityOnHold: number,
+  }
 }
 
-export class ChannelBalance extends jspb.Message { 
-    getBalance(): number;
-    setBalance(value: number): void;
+export class ChannelBalance extends jspb.Message {
+  getBalance(): number;
+  setBalance(value: number): void;
 
-    getPendingOpenBalance(): number;
-    setPendingOpenBalance(value: number): void;
+  getPendingOpenBalance(): number;
+  setPendingOpenBalance(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalance.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalance): ChannelBalance.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalance, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalance;
-    static deserializeBinaryFromReader(message: ChannelBalance, reader: jspb.BinaryReader): ChannelBalance;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalance.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalance): ChannelBalance.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalance, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalance;
+  static deserializeBinaryFromReader(message: ChannelBalance, reader: jspb.BinaryReader): ChannelBalance;
 }
 
 export namespace ChannelBalance {
-    export type AsObject = {
-        balance: number,
-        pendingOpenBalance: number,
-    }
+  export type AsObject = {
+    balance: number,
+    pendingOpenBalance: number,
+  }
 }
 
-export class ChannelBalanceRequest extends jspb.Message { 
-    getCurrency(): string;
-    setCurrency(value: string): void;
+export class ChannelBalanceRequest extends jspb.Message {
+  getCurrency(): string;
+  setCurrency(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalanceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalanceRequest): ChannelBalanceRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalanceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalanceRequest;
-    static deserializeBinaryFromReader(message: ChannelBalanceRequest, reader: jspb.BinaryReader): ChannelBalanceRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalanceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalanceRequest): ChannelBalanceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalanceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalanceRequest;
+  static deserializeBinaryFromReader(message: ChannelBalanceRequest, reader: jspb.BinaryReader): ChannelBalanceRequest;
 }
 
 export namespace ChannelBalanceRequest {
-    export type AsObject = {
-        currency: string,
-    }
+  export type AsObject = {
+    currency: string,
+  }
 }
 
-export class ChannelBalanceResponse extends jspb.Message { 
-
-    getBalancesMap(): jspb.Map<string, ChannelBalance>;
-    clearBalancesMap(): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalanceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalanceResponse): ChannelBalanceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalanceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalanceResponse;
-    static deserializeBinaryFromReader(message: ChannelBalanceResponse, reader: jspb.BinaryReader): ChannelBalanceResponse;
+export class ChannelBalanceResponse extends jspb.Message {
+  getBalancesMap(): jspb.Map<string, ChannelBalance>;
+  clearBalancesMap(): void;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalanceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalanceResponse): ChannelBalanceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalanceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalanceResponse;
+  static deserializeBinaryFromReader(message: ChannelBalanceResponse, reader: jspb.BinaryReader): ChannelBalanceResponse;
 }
 
 export namespace ChannelBalanceResponse {
-    export type AsObject = {
-
-        balancesMap: Array<[string, ChannelBalance.AsObject]>,
-    }
+  export type AsObject = {
+    balancesMap: Array<[string, ChannelBalance.AsObject]>,
+  }
 }
 
-export class ConnectRequest extends jspb.Message { 
-    getNodeUri(): string;
-    setNodeUri(value: string): void;
+export class ConnectRequest extends jspb.Message {
+  getNodeUri(): string;
+  setNodeUri(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectRequest): ConnectRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectRequest;
-    static deserializeBinaryFromReader(message: ConnectRequest, reader: jspb.BinaryReader): ConnectRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectRequest): ConnectRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectRequest;
+  static deserializeBinaryFromReader(message: ConnectRequest, reader: jspb.BinaryReader): ConnectRequest;
 }
 
 export namespace ConnectRequest {
-    export type AsObject = {
-        nodeUri: string,
-    }
+  export type AsObject = {
+    nodeUri: string,
+  }
 }
 
-export class ConnectResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectResponse): ConnectResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectResponse;
-    static deserializeBinaryFromReader(message: ConnectResponse, reader: jspb.BinaryReader): ConnectResponse;
+export class ConnectResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectResponse): ConnectResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectResponse;
+  static deserializeBinaryFromReader(message: ConnectResponse, reader: jspb.BinaryReader): ConnectResponse;
 }
 
 export namespace ConnectResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class BanRequest extends jspb.Message { 
-    getNodePubKey(): string;
-    setNodePubKey(value: string): void;
+export class BanRequest extends jspb.Message {
+  getNodePubKey(): string;
+  setNodePubKey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): BanRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: BanRequest): BanRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: BanRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): BanRequest;
-    static deserializeBinaryFromReader(message: BanRequest, reader: jspb.BinaryReader): BanRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): BanRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: BanRequest): BanRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: BanRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): BanRequest;
+  static deserializeBinaryFromReader(message: BanRequest, reader: jspb.BinaryReader): BanRequest;
 }
 
 export namespace BanRequest {
-    export type AsObject = {
-        nodePubKey: string,
-    }
+  export type AsObject = {
+    nodePubKey: string,
+  }
 }
 
-export class BanResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): BanResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: BanResponse): BanResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: BanResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): BanResponse;
-    static deserializeBinaryFromReader(message: BanResponse, reader: jspb.BinaryReader): BanResponse;
+export class BanResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): BanResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: BanResponse): BanResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: BanResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): BanResponse;
+  static deserializeBinaryFromReader(message: BanResponse, reader: jspb.BinaryReader): BanResponse;
 }
 
 export namespace BanResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
-    static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
+export class GetInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
+  static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
 }
 
 export namespace GetInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetInfoResponse extends jspb.Message { 
-    getVersion(): string;
-    setVersion(value: string): void;
+export class GetInfoResponse extends jspb.Message {
+  getVersion(): string;
+  setVersion(value: string): void;
 
-    getNodePubKey(): string;
-    setNodePubKey(value: string): void;
+  getNodePubKey(): string;
+  setNodePubKey(value: string): void;
 
-    clearUrisList(): void;
-    getUrisList(): Array<string>;
-    setUrisList(value: Array<string>): void;
-    addUris(value: string, index?: number): string;
+  clearUrisList(): void;
+  getUrisList(): Array<string>;
+  setUrisList(value: Array<string>): void;
+  addUris(value: string, index?: number): string;
 
-    getNumPeers(): number;
-    setNumPeers(value: number): void;
+  getNumPeers(): number;
+  setNumPeers(value: number): void;
 
-    getNumPairs(): number;
-    setNumPairs(value: number): void;
+  getNumPairs(): number;
+  setNumPairs(value: number): void;
 
+  hasOrders(): boolean;
+  clearOrders(): void;
+  getOrders(): OrdersCount | undefined;
+  setOrders(value?: OrdersCount): void;
 
-    hasOrders(): boolean;
-    clearOrders(): void;
-    getOrders(): OrdersCount | undefined;
-    setOrders(value?: OrdersCount): void;
+  hasLndbtc(): boolean;
+  clearLndbtc(): void;
+  getLndbtc(): LndInfo | undefined;
+  setLndbtc(value?: LndInfo): void;
 
+  hasLndltc(): boolean;
+  clearLndltc(): void;
+  getLndltc(): LndInfo | undefined;
+  setLndltc(value?: LndInfo): void;
 
-    hasLndbtc(): boolean;
-    clearLndbtc(): void;
-    getLndbtc(): LndInfo | undefined;
-    setLndbtc(value?: LndInfo): void;
+  hasRaiden(): boolean;
+  clearRaiden(): void;
+  getRaiden(): RaidenInfo | undefined;
+  setRaiden(value?: RaidenInfo): void;
 
-
-    hasLndltc(): boolean;
-    clearLndltc(): void;
-    getLndltc(): LndInfo | undefined;
-    setLndltc(value?: LndInfo): void;
-
-
-    hasRaiden(): boolean;
-    clearRaiden(): void;
-    getRaiden(): RaidenInfo | undefined;
-    setRaiden(value?: RaidenInfo): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
-    static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
+  static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
 }
 
 export namespace GetInfoResponse {
-    export type AsObject = {
-        version: string,
-        nodePubKey: string,
-        urisList: Array<string>,
-        numPeers: number,
-        numPairs: number,
-        orders?: OrdersCount.AsObject,
-        lndbtc?: LndInfo.AsObject,
-        lndltc?: LndInfo.AsObject,
-        raiden?: RaidenInfo.AsObject,
-    }
+  export type AsObject = {
+    version: string,
+    nodePubKey: string,
+    urisList: Array<string>,
+    numPeers: number,
+    numPairs: number,
+    orders?: OrdersCount.AsObject,
+    lndbtc?: LndInfo.AsObject,
+    lndltc?: LndInfo.AsObject,
+    raiden?: RaidenInfo.AsObject,
+  }
 }
 
-export class GetNodeInfoRequest extends jspb.Message { 
-    getNodePubKey(): string;
-    setNodePubKey(value: string): void;
+export class GetNodeInfoRequest extends jspb.Message {
+  getNodePubKey(): string;
+  setNodePubKey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetNodeInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetNodeInfoRequest): GetNodeInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetNodeInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetNodeInfoRequest;
-    static deserializeBinaryFromReader(message: GetNodeInfoRequest, reader: jspb.BinaryReader): GetNodeInfoRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetNodeInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetNodeInfoRequest): GetNodeInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetNodeInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetNodeInfoRequest;
+  static deserializeBinaryFromReader(message: GetNodeInfoRequest, reader: jspb.BinaryReader): GetNodeInfoRequest;
 }
 
 export namespace GetNodeInfoRequest {
-    export type AsObject = {
-        nodePubKey: string,
-    }
+  export type AsObject = {
+    nodePubKey: string,
+  }
 }
 
-export class GetNodeInfoResponse extends jspb.Message { 
-    getReputationscore(): number;
-    setReputationscore(value: number): void;
+export class GetNodeInfoResponse extends jspb.Message {
+  getReputationscore(): number;
+  setReputationscore(value: number): void;
 
-    getBanned(): boolean;
-    setBanned(value: boolean): void;
+  getBanned(): boolean;
+  setBanned(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetNodeInfoResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetNodeInfoResponse): GetNodeInfoResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetNodeInfoResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetNodeInfoResponse;
-    static deserializeBinaryFromReader(message: GetNodeInfoResponse, reader: jspb.BinaryReader): GetNodeInfoResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetNodeInfoResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetNodeInfoResponse): GetNodeInfoResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetNodeInfoResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetNodeInfoResponse;
+  static deserializeBinaryFromReader(message: GetNodeInfoResponse, reader: jspb.BinaryReader): GetNodeInfoResponse;
 }
 
 export namespace GetNodeInfoResponse {
-    export type AsObject = {
-        reputationscore: number,
-        banned: boolean,
-    }
+  export type AsObject = {
+    reputationscore: number,
+    banned: boolean,
+  }
 }
 
-export class GetOrdersRequest extends jspb.Message { 
-    getPairId(): string;
-    setPairId(value: string): void;
+export class GetOrdersRequest extends jspb.Message {
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getIncludeOwnOrders(): boolean;
-    setIncludeOwnOrders(value: boolean): void;
+  getIncludeOwnOrders(): boolean;
+  setIncludeOwnOrders(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetOrdersRequest): GetOrdersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetOrdersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetOrdersRequest;
-    static deserializeBinaryFromReader(message: GetOrdersRequest, reader: jspb.BinaryReader): GetOrdersRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetOrdersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetOrdersRequest): GetOrdersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetOrdersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetOrdersRequest;
+  static deserializeBinaryFromReader(message: GetOrdersRequest, reader: jspb.BinaryReader): GetOrdersRequest;
 }
 
 export namespace GetOrdersRequest {
-    export type AsObject = {
-        pairId: string,
-        includeOwnOrders: boolean,
-    }
+  export type AsObject = {
+    pairId: string,
+    includeOwnOrders: boolean,
+  }
 }
 
-export class GetOrdersResponse extends jspb.Message { 
-
-    getOrdersMap(): jspb.Map<string, Orders>;
-    clearOrdersMap(): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetOrdersResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetOrdersResponse): GetOrdersResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetOrdersResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetOrdersResponse;
-    static deserializeBinaryFromReader(message: GetOrdersResponse, reader: jspb.BinaryReader): GetOrdersResponse;
+export class GetOrdersResponse extends jspb.Message {
+  getOrdersMap(): jspb.Map<string, Orders>;
+  clearOrdersMap(): void;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetOrdersResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetOrdersResponse): GetOrdersResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetOrdersResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetOrdersResponse;
+  static deserializeBinaryFromReader(message: GetOrdersResponse, reader: jspb.BinaryReader): GetOrdersResponse;
 }
 
 export namespace GetOrdersResponse {
-    export type AsObject = {
-
-        ordersMap: Array<[string, Orders.AsObject]>,
-    }
+  export type AsObject = {
+    ordersMap: Array<[string, Orders.AsObject]>,
+  }
 }
 
-export class ListCurrenciesRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListCurrenciesRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListCurrenciesRequest): ListCurrenciesRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListCurrenciesRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListCurrenciesRequest;
-    static deserializeBinaryFromReader(message: ListCurrenciesRequest, reader: jspb.BinaryReader): ListCurrenciesRequest;
+export class ListCurrenciesRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListCurrenciesRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListCurrenciesRequest): ListCurrenciesRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListCurrenciesRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListCurrenciesRequest;
+  static deserializeBinaryFromReader(message: ListCurrenciesRequest, reader: jspb.BinaryReader): ListCurrenciesRequest;
 }
 
 export namespace ListCurrenciesRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListCurrenciesResponse extends jspb.Message { 
-    clearCurrenciesList(): void;
-    getCurrenciesList(): Array<string>;
-    setCurrenciesList(value: Array<string>): void;
-    addCurrencies(value: string, index?: number): string;
+export class ListCurrenciesResponse extends jspb.Message {
+  clearCurrenciesList(): void;
+  getCurrenciesList(): Array<string>;
+  setCurrenciesList(value: Array<string>): void;
+  addCurrencies(value: string, index?: number): string;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListCurrenciesResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListCurrenciesResponse): ListCurrenciesResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListCurrenciesResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListCurrenciesResponse;
-    static deserializeBinaryFromReader(message: ListCurrenciesResponse, reader: jspb.BinaryReader): ListCurrenciesResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListCurrenciesResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListCurrenciesResponse): ListCurrenciesResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListCurrenciesResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListCurrenciesResponse;
+  static deserializeBinaryFromReader(message: ListCurrenciesResponse, reader: jspb.BinaryReader): ListCurrenciesResponse;
 }
 
 export namespace ListCurrenciesResponse {
-    export type AsObject = {
-        currenciesList: Array<string>,
-    }
+  export type AsObject = {
+    currenciesList: Array<string>,
+  }
 }
 
-export class ListPairsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPairsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPairsRequest): ListPairsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPairsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPairsRequest;
-    static deserializeBinaryFromReader(message: ListPairsRequest, reader: jspb.BinaryReader): ListPairsRequest;
+export class ListPairsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPairsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPairsRequest): ListPairsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPairsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPairsRequest;
+  static deserializeBinaryFromReader(message: ListPairsRequest, reader: jspb.BinaryReader): ListPairsRequest;
 }
 
 export namespace ListPairsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListPairsResponse extends jspb.Message { 
-    clearPairsList(): void;
-    getPairsList(): Array<string>;
-    setPairsList(value: Array<string>): void;
-    addPairs(value: string, index?: number): string;
+export class ListPairsResponse extends jspb.Message {
+  clearPairsList(): void;
+  getPairsList(): Array<string>;
+  setPairsList(value: Array<string>): void;
+  addPairs(value: string, index?: number): string;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPairsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPairsResponse): ListPairsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPairsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPairsResponse;
-    static deserializeBinaryFromReader(message: ListPairsResponse, reader: jspb.BinaryReader): ListPairsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPairsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPairsResponse): ListPairsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPairsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPairsResponse;
+  static deserializeBinaryFromReader(message: ListPairsResponse, reader: jspb.BinaryReader): ListPairsResponse;
 }
 
 export namespace ListPairsResponse {
-    export type AsObject = {
-        pairsList: Array<string>,
-    }
+  export type AsObject = {
+    pairsList: Array<string>,
+  }
 }
 
-export class ListPeersRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPeersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPeersRequest): ListPeersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPeersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPeersRequest;
-    static deserializeBinaryFromReader(message: ListPeersRequest, reader: jspb.BinaryReader): ListPeersRequest;
+export class ListPeersRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPeersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPeersRequest): ListPeersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPeersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPeersRequest;
+  static deserializeBinaryFromReader(message: ListPeersRequest, reader: jspb.BinaryReader): ListPeersRequest;
 }
 
 export namespace ListPeersRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListPeersResponse extends jspb.Message { 
-    clearPeersList(): void;
-    getPeersList(): Array<Peer>;
-    setPeersList(value: Array<Peer>): void;
-    addPeers(value?: Peer, index?: number): Peer;
+export class ListPeersResponse extends jspb.Message {
+  clearPeersList(): void;
+  getPeersList(): Array<Peer>;
+  setPeersList(value: Array<Peer>): void;
+  addPeers(value?: Peer, index?: number): Peer;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPeersResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPeersResponse): ListPeersResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPeersResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPeersResponse;
-    static deserializeBinaryFromReader(message: ListPeersResponse, reader: jspb.BinaryReader): ListPeersResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPeersResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPeersResponse): ListPeersResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPeersResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPeersResponse;
+  static deserializeBinaryFromReader(message: ListPeersResponse, reader: jspb.BinaryReader): ListPeersResponse;
 }
 
 export namespace ListPeersResponse {
-    export type AsObject = {
-        peersList: Array<Peer.AsObject>,
-    }
+  export type AsObject = {
+    peersList: Array<Peer.AsObject>,
+  }
 }
 
-export class LndChannels extends jspb.Message { 
-    getActive(): number;
-    setActive(value: number): void;
+export class LndChannels extends jspb.Message {
+  getActive(): number;
+  setActive(value: number): void;
 
-    getInactive(): number;
-    setInactive(value: number): void;
+  getInactive(): number;
+  setInactive(value: number): void;
 
-    getPending(): number;
-    setPending(value: number): void;
+  getPending(): number;
+  setPending(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LndChannels.AsObject;
-    static toObject(includeInstance: boolean, msg: LndChannels): LndChannels.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LndChannels, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LndChannels;
-    static deserializeBinaryFromReader(message: LndChannels, reader: jspb.BinaryReader): LndChannels;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LndChannels.AsObject;
+  static toObject(includeInstance: boolean, msg: LndChannels): LndChannels.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LndChannels, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LndChannels;
+  static deserializeBinaryFromReader(message: LndChannels, reader: jspb.BinaryReader): LndChannels;
 }
 
 export namespace LndChannels {
-    export type AsObject = {
-        active: number,
-        inactive: number,
-        pending: number,
-    }
+  export type AsObject = {
+    active: number,
+    inactive: number,
+    pending: number,
+  }
 }
 
-export class LndInfo extends jspb.Message { 
-    getError(): string;
-    setError(value: string): void;
+export class LndInfo extends jspb.Message {
+  getError(): string;
+  setError(value: string): void;
 
+  hasChannels(): boolean;
+  clearChannels(): void;
+  getChannels(): LndChannels | undefined;
+  setChannels(value?: LndChannels): void;
 
-    hasChannels(): boolean;
-    clearChannels(): void;
-    getChannels(): LndChannels | undefined;
-    setChannels(value?: LndChannels): void;
+  clearChainsList(): void;
+  getChainsList(): Array<string>;
+  setChainsList(value: Array<string>): void;
+  addChains(value: string, index?: number): string;
 
-    clearChainsList(): void;
-    getChainsList(): Array<string>;
-    setChainsList(value: Array<string>): void;
-    addChains(value: string, index?: number): string;
+  getBlockheight(): number;
+  setBlockheight(value: number): void;
 
-    getBlockheight(): number;
-    setBlockheight(value: number): void;
+  clearUrisList(): void;
+  getUrisList(): Array<string>;
+  setUrisList(value: Array<string>): void;
+  addUris(value: string, index?: number): string;
 
-    clearUrisList(): void;
-    getUrisList(): Array<string>;
-    setUrisList(value: Array<string>): void;
-    addUris(value: string, index?: number): string;
+  getVersion(): string;
+  setVersion(value: string): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LndInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: LndInfo): LndInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LndInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LndInfo;
-    static deserializeBinaryFromReader(message: LndInfo, reader: jspb.BinaryReader): LndInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LndInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: LndInfo): LndInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LndInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LndInfo;
+  static deserializeBinaryFromReader(message: LndInfo, reader: jspb.BinaryReader): LndInfo;
 }
 
 export namespace LndInfo {
-    export type AsObject = {
-        error: string,
-        channels?: LndChannels.AsObject,
-        chainsList: Array<string>,
-        blockheight: number,
-        urisList: Array<string>,
-        version: string,
-        alias: string,
-    }
+  export type AsObject = {
+    error: string,
+    channels?: LndChannels.AsObject,
+    chainsList: Array<string>,
+    blockheight: number,
+    urisList: Array<string>,
+    version: string,
+    alias: string,
+  }
 }
 
-export class Order extends jspb.Message { 
-    getPrice(): number;
-    setPrice(value: number): void;
+export class Order extends jspb.Message {
+  getPrice(): number;
+  setPrice(value: number): void;
 
-    getQuantity(): number;
-    setQuantity(value: number): void;
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getId(): string;
-    setId(value: string): void;
+  getId(): string;
+  setId(value: string): void;
 
+  hasPeerPubKey(): boolean;
+  clearPeerPubKey(): void;
+  getPeerPubKey(): string;
+  setPeerPubKey(value: string): void;
 
-    hasPeerPubKey(): boolean;
-    clearPeerPubKey(): void;
-    getPeerPubKey(): string;
-    setPeerPubKey(value: string): void;
+  hasLocalId(): boolean;
+  clearLocalId(): void;
+  getLocalId(): string;
+  setLocalId(value: string): void;
 
+  getCreatedAt(): number;
+  setCreatedAt(value: number): void;
 
-    hasLocalId(): boolean;
-    clearLocalId(): void;
-    getLocalId(): string;
-    setLocalId(value: string): void;
+  getSide(): OrderSide;
+  setSide(value: OrderSide): void;
 
-    getCreatedAt(): number;
-    setCreatedAt(value: number): void;
+  getIsOwnOrder(): boolean;
+  setIsOwnOrder(value: boolean): void;
 
-    getSide(): OrderSide;
-    setSide(value: OrderSide): void;
+  getHold(): number;
+  setHold(value: number): void;
 
-    getIsOwnOrder(): boolean;
-    setIsOwnOrder(value: boolean): void;
-
-    getHold(): number;
-    setHold(value: number): void;
-
-
-    getOwnOrPeerCase(): Order.OwnOrPeerCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Order.AsObject;
-    static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Order;
-    static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
+  getOwnOrPeerCase(): Order.OwnOrPeerCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Order.AsObject;
+  static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Order;
+  static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
 }
 
 export namespace Order {
-    export type AsObject = {
-        price: number,
-        quantity: number,
-        pairId: string,
-        id: string,
-        peerPubKey: string,
-        localId: string,
-        createdAt: number,
-        side: OrderSide,
-        isOwnOrder: boolean,
-        hold: number,
-    }
+  export type AsObject = {
+    price: number,
+    quantity: number,
+    pairId: string,
+    id: string,
+    peerPubKey: string,
+    localId: string,
+    createdAt: number,
+    side: OrderSide,
+    isOwnOrder: boolean,
+    hold: number,
+  }
 
-    export enum OwnOrPeerCase {
-        OWNORPEER_NOT_SET = 0,
-    
+  export enum OwnOrPeerCase {
+    OWN_OR_PEER_NOT_SET = 0,
     PEER_PUB_KEY = 5,
-
     LOCAL_ID = 6,
-
-    }
-
+  }
 }
 
-export class OrderRemoval extends jspb.Message { 
-    getQuantity(): number;
-    setQuantity(value: number): void;
+export class OrderRemoval extends jspb.Message {
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getOrderId(): string;
-    setOrderId(value: string): void;
+  getOrderId(): string;
+  setOrderId(value: string): void;
 
-    getLocalId(): string;
-    setLocalId(value: string): void;
+  getLocalId(): string;
+  setLocalId(value: string): void;
 
-    getIsOwnOrder(): boolean;
-    setIsOwnOrder(value: boolean): void;
+  getIsOwnOrder(): boolean;
+  setIsOwnOrder(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OrderRemoval.AsObject;
-    static toObject(includeInstance: boolean, msg: OrderRemoval): OrderRemoval.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OrderRemoval, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OrderRemoval;
-    static deserializeBinaryFromReader(message: OrderRemoval, reader: jspb.BinaryReader): OrderRemoval;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OrderRemoval.AsObject;
+  static toObject(includeInstance: boolean, msg: OrderRemoval): OrderRemoval.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OrderRemoval, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OrderRemoval;
+  static deserializeBinaryFromReader(message: OrderRemoval, reader: jspb.BinaryReader): OrderRemoval;
 }
 
 export namespace OrderRemoval {
-    export type AsObject = {
-        quantity: number,
-        pairId: string,
-        orderId: string,
-        localId: string,
-        isOwnOrder: boolean,
-    }
+  export type AsObject = {
+    quantity: number,
+    pairId: string,
+    orderId: string,
+    localId: string,
+    isOwnOrder: boolean,
+  }
 }
 
-export class Orders extends jspb.Message { 
-    clearBuyOrdersList(): void;
-    getBuyOrdersList(): Array<Order>;
-    setBuyOrdersList(value: Array<Order>): void;
-    addBuyOrders(value?: Order, index?: number): Order;
+export class Orders extends jspb.Message {
+  clearBuyOrdersList(): void;
+  getBuyOrdersList(): Array<Order>;
+  setBuyOrdersList(value: Array<Order>): void;
+  addBuyOrders(value?: Order, index?: number): Order;
 
-    clearSellOrdersList(): void;
-    getSellOrdersList(): Array<Order>;
-    setSellOrdersList(value: Array<Order>): void;
-    addSellOrders(value?: Order, index?: number): Order;
+  clearSellOrdersList(): void;
+  getSellOrdersList(): Array<Order>;
+  setSellOrdersList(value: Array<Order>): void;
+  addSellOrders(value?: Order, index?: number): Order;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Orders.AsObject;
-    static toObject(includeInstance: boolean, msg: Orders): Orders.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Orders, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Orders;
-    static deserializeBinaryFromReader(message: Orders, reader: jspb.BinaryReader): Orders;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Orders.AsObject;
+  static toObject(includeInstance: boolean, msg: Orders): Orders.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Orders, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Orders;
+  static deserializeBinaryFromReader(message: Orders, reader: jspb.BinaryReader): Orders;
 }
 
 export namespace Orders {
-    export type AsObject = {
-        buyOrdersList: Array<Order.AsObject>,
-        sellOrdersList: Array<Order.AsObject>,
-    }
+  export type AsObject = {
+    buyOrdersList: Array<Order.AsObject>,
+    sellOrdersList: Array<Order.AsObject>,
+  }
 }
 
-export class OrdersCount extends jspb.Message { 
-    getPeer(): number;
-    setPeer(value: number): void;
+export class OrdersCount extends jspb.Message {
+  getPeer(): number;
+  setPeer(value: number): void;
 
-    getOwn(): number;
-    setOwn(value: number): void;
+  getOwn(): number;
+  setOwn(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OrdersCount.AsObject;
-    static toObject(includeInstance: boolean, msg: OrdersCount): OrdersCount.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OrdersCount, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OrdersCount;
-    static deserializeBinaryFromReader(message: OrdersCount, reader: jspb.BinaryReader): OrdersCount;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OrdersCount.AsObject;
+  static toObject(includeInstance: boolean, msg: OrdersCount): OrdersCount.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OrdersCount, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OrdersCount;
+  static deserializeBinaryFromReader(message: OrdersCount, reader: jspb.BinaryReader): OrdersCount;
 }
 
 export namespace OrdersCount {
-    export type AsObject = {
-        peer: number,
-        own: number,
-    }
+  export type AsObject = {
+    peer: number,
+    own: number,
+  }
 }
 
-export class Peer extends jspb.Message { 
-    getAddress(): string;
-    setAddress(value: string): void;
+export class Peer extends jspb.Message {
+  getAddress(): string;
+  setAddress(value: string): void;
 
-    getNodePubKey(): string;
-    setNodePubKey(value: string): void;
+  getNodePubKey(): string;
+  setNodePubKey(value: string): void;
 
-    getLndBtcPubKey(): string;
-    setLndBtcPubKey(value: string): void;
+  getLndBtcPubKey(): string;
+  setLndBtcPubKey(value: string): void;
 
-    getLndLtcPubKey(): string;
-    setLndLtcPubKey(value: string): void;
+  getLndLtcPubKey(): string;
+  setLndLtcPubKey(value: string): void;
 
-    getInbound(): boolean;
-    setInbound(value: boolean): void;
+  getInbound(): boolean;
+  setInbound(value: boolean): void;
 
-    clearPairsList(): void;
-    getPairsList(): Array<string>;
-    setPairsList(value: Array<string>): void;
-    addPairs(value: string, index?: number): string;
+  clearPairsList(): void;
+  getPairsList(): Array<string>;
+  setPairsList(value: Array<string>): void;
+  addPairs(value: string, index?: number): string;
 
-    getXudVersion(): string;
-    setXudVersion(value: string): void;
+  getXudVersion(): string;
+  setXudVersion(value: string): void;
 
-    getSecondsConnected(): number;
-    setSecondsConnected(value: number): void;
+  getSecondsConnected(): number;
+  setSecondsConnected(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Peer.AsObject;
-    static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Peer, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Peer;
-    static deserializeBinaryFromReader(message: Peer, reader: jspb.BinaryReader): Peer;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Peer.AsObject;
+  static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Peer, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Peer;
+  static deserializeBinaryFromReader(message: Peer, reader: jspb.BinaryReader): Peer;
 }
 
 export namespace Peer {
-    export type AsObject = {
-        address: string,
-        nodePubKey: string,
-        lndBtcPubKey: string,
-        lndLtcPubKey: string,
-        inbound: boolean,
-        pairsList: Array<string>,
-        xudVersion: string,
-        secondsConnected: number,
-    }
+  export type AsObject = {
+    address: string,
+    nodePubKey: string,
+    lndBtcPubKey: string,
+    lndLtcPubKey: string,
+    inbound: boolean,
+    pairsList: Array<string>,
+    xudVersion: string,
+    secondsConnected: number,
+  }
 }
 
-export class PlaceOrderRequest extends jspb.Message { 
-    getPrice(): number;
-    setPrice(value: number): void;
+export class PlaceOrderRequest extends jspb.Message {
+  getPrice(): number;
+  setPrice(value: number): void;
 
-    getQuantity(): number;
-    setQuantity(value: number): void;
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getOrderId(): string;
-    setOrderId(value: string): void;
+  getOrderId(): string;
+  setOrderId(value: string): void;
 
-    getSide(): OrderSide;
-    setSide(value: OrderSide): void;
+  getSide(): OrderSide;
+  setSide(value: OrderSide): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PlaceOrderRequest): PlaceOrderRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PlaceOrderRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PlaceOrderRequest;
-    static deserializeBinaryFromReader(message: PlaceOrderRequest, reader: jspb.BinaryReader): PlaceOrderRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PlaceOrderRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: PlaceOrderRequest): PlaceOrderRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PlaceOrderRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PlaceOrderRequest;
+  static deserializeBinaryFromReader(message: PlaceOrderRequest, reader: jspb.BinaryReader): PlaceOrderRequest;
 }
 
 export namespace PlaceOrderRequest {
-    export type AsObject = {
-        price: number,
-        quantity: number,
-        pairId: string,
-        orderId: string,
-        side: OrderSide,
-    }
+  export type AsObject = {
+    price: number,
+    quantity: number,
+    pairId: string,
+    orderId: string,
+    side: OrderSide,
+  }
 }
 
-export class PlaceOrderResponse extends jspb.Message { 
-    clearInternalMatchesList(): void;
-    getInternalMatchesList(): Array<Order>;
-    setInternalMatchesList(value: Array<Order>): void;
-    addInternalMatches(value?: Order, index?: number): Order;
+export class PlaceOrderResponse extends jspb.Message {
+  clearInternalMatchesList(): void;
+  getInternalMatchesList(): Array<Order>;
+  setInternalMatchesList(value: Array<Order>): void;
+  addInternalMatches(value?: Order, index?: number): Order;
 
-    clearSwapResultsList(): void;
-    getSwapResultsList(): Array<SwapResult>;
-    setSwapResultsList(value: Array<SwapResult>): void;
-    addSwapResults(value?: SwapResult, index?: number): SwapResult;
+  clearSwapResultsList(): void;
+  getSwapResultsList(): Array<SwapResult>;
+  setSwapResultsList(value: Array<SwapResult>): void;
+  addSwapResults(value?: SwapResult, index?: number): SwapResult;
 
+  hasRemainingOrder(): boolean;
+  clearRemainingOrder(): void;
+  getRemainingOrder(): Order | undefined;
+  setRemainingOrder(value?: Order): void;
 
-    hasRemainingOrder(): boolean;
-    clearRemainingOrder(): void;
-    getRemainingOrder(): Order | undefined;
-    setRemainingOrder(value?: Order): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PlaceOrderResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PlaceOrderResponse;
-    static deserializeBinaryFromReader(message: PlaceOrderResponse, reader: jspb.BinaryReader): PlaceOrderResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PlaceOrderResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PlaceOrderResponse;
+  static deserializeBinaryFromReader(message: PlaceOrderResponse, reader: jspb.BinaryReader): PlaceOrderResponse;
 }
 
 export namespace PlaceOrderResponse {
-    export type AsObject = {
-        internalMatchesList: Array<Order.AsObject>,
-        swapResultsList: Array<SwapResult.AsObject>,
-        remainingOrder?: Order.AsObject,
-    }
+  export type AsObject = {
+    internalMatchesList: Array<Order.AsObject>,
+    swapResultsList: Array<SwapResult.AsObject>,
+    remainingOrder?: Order.AsObject,
+  }
 }
 
-export class PlaceOrderEvent extends jspb.Message { 
+export class PlaceOrderEvent extends jspb.Message {
+  hasInternalMatch(): boolean;
+  clearInternalMatch(): void;
+  getInternalMatch(): Order | undefined;
+  setInternalMatch(value?: Order): void;
 
-    hasInternalMatch(): boolean;
-    clearInternalMatch(): void;
-    getInternalMatch(): Order | undefined;
-    setInternalMatch(value?: Order): void;
+  hasSwapResult(): boolean;
+  clearSwapResult(): void;
+  getSwapResult(): SwapResult | undefined;
+  setSwapResult(value?: SwapResult): void;
 
+  hasRemainingOrder(): boolean;
+  clearRemainingOrder(): void;
+  getRemainingOrder(): Order | undefined;
+  setRemainingOrder(value?: Order): void;
 
-    hasSwapResult(): boolean;
-    clearSwapResult(): void;
-    getSwapResult(): SwapResult | undefined;
-    setSwapResult(value?: SwapResult): void;
-
-
-    hasRemainingOrder(): boolean;
-    clearRemainingOrder(): void;
-    getRemainingOrder(): Order | undefined;
-    setRemainingOrder(value?: Order): void;
-
-
-    getEventCase(): PlaceOrderEvent.EventCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PlaceOrderEvent.AsObject;
-    static toObject(includeInstance: boolean, msg: PlaceOrderEvent): PlaceOrderEvent.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PlaceOrderEvent, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PlaceOrderEvent;
-    static deserializeBinaryFromReader(message: PlaceOrderEvent, reader: jspb.BinaryReader): PlaceOrderEvent;
+  getEventCase(): PlaceOrderEvent.EventCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PlaceOrderEvent.AsObject;
+  static toObject(includeInstance: boolean, msg: PlaceOrderEvent): PlaceOrderEvent.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PlaceOrderEvent, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PlaceOrderEvent;
+  static deserializeBinaryFromReader(message: PlaceOrderEvent, reader: jspb.BinaryReader): PlaceOrderEvent;
 }
 
 export namespace PlaceOrderEvent {
-    export type AsObject = {
-        internalMatch?: Order.AsObject,
-        swapResult?: SwapResult.AsObject,
-        remainingOrder?: Order.AsObject,
-    }
+  export type AsObject = {
+    internalMatch?: Order.AsObject,
+    swapResult?: SwapResult.AsObject,
+    remainingOrder?: Order.AsObject,
+  }
 
-    export enum EventCase {
-        EVENT_NOT_SET = 0,
-    
+  export enum EventCase {
+    EVENT_NOT_SET = 0,
     INTERNAL_MATCH = 1,
-
     SWAP_RESULT = 2,
-
     REMAINING_ORDER = 3,
-
-    }
-
+  }
 }
 
-export class ExecuteSwapRequest extends jspb.Message { 
-    getPairId(): string;
-    setPairId(value: string): void;
+export class ExecuteSwapRequest extends jspb.Message {
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getOrderId(): string;
-    setOrderId(value: string): void;
+  getOrderId(): string;
+  setOrderId(value: string): void;
 
-    getPeerPubKey(): string;
-    setPeerPubKey(value: string): void;
+  getPeerPubKey(): string;
+  setPeerPubKey(value: string): void;
 
-    getQuantity(): number;
-    setQuantity(value: number): void;
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
-    static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
+  static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
 }
 
 export namespace ExecuteSwapRequest {
-    export type AsObject = {
-        pairId: string,
-        orderId: string,
-        peerPubKey: string,
-        quantity: number,
-    }
+  export type AsObject = {
+    pairId: string,
+    orderId: string,
+    peerPubKey: string,
+    quantity: number,
+  }
 }
 
-export class RaidenInfo extends jspb.Message { 
-    getError(): string;
-    setError(value: string): void;
+export class RaidenInfo extends jspb.Message {
+  getError(): string;
+  setError(value: string): void;
 
-    getAddress(): string;
-    setAddress(value: string): void;
+  getAddress(): string;
+  setAddress(value: string): void;
 
-    getChannels(): number;
-    setChannels(value: number): void;
+  getChannels(): number;
+  setChannels(value: number): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
+  getVersion(): string;
+  setVersion(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RaidenInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: RaidenInfo): RaidenInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RaidenInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RaidenInfo;
-    static deserializeBinaryFromReader(message: RaidenInfo, reader: jspb.BinaryReader): RaidenInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RaidenInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: RaidenInfo): RaidenInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RaidenInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RaidenInfo;
+  static deserializeBinaryFromReader(message: RaidenInfo, reader: jspb.BinaryReader): RaidenInfo;
 }
 
 export namespace RaidenInfo {
-    export type AsObject = {
-        error: string,
-        address: string,
-        channels: number,
-        version: string,
-    }
+  export type AsObject = {
+    error: string,
+    address: string,
+    channels: number,
+    version: string,
+  }
 }
 
-export class RemoveCurrencyRequest extends jspb.Message { 
-    getCurrency(): string;
-    setCurrency(value: string): void;
+export class RemoveCurrencyRequest extends jspb.Message {
+  getCurrency(): string;
+  setCurrency(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RemoveCurrencyRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: RemoveCurrencyRequest): RemoveCurrencyRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RemoveCurrencyRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RemoveCurrencyRequest;
-    static deserializeBinaryFromReader(message: RemoveCurrencyRequest, reader: jspb.BinaryReader): RemoveCurrencyRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemoveCurrencyRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: RemoveCurrencyRequest): RemoveCurrencyRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemoveCurrencyRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemoveCurrencyRequest;
+  static deserializeBinaryFromReader(message: RemoveCurrencyRequest, reader: jspb.BinaryReader): RemoveCurrencyRequest;
 }
 
 export namespace RemoveCurrencyRequest {
-    export type AsObject = {
-        currency: string,
-    }
+  export type AsObject = {
+    currency: string,
+  }
 }
 
-export class RemoveCurrencyResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RemoveCurrencyResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: RemoveCurrencyResponse): RemoveCurrencyResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RemoveCurrencyResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RemoveCurrencyResponse;
-    static deserializeBinaryFromReader(message: RemoveCurrencyResponse, reader: jspb.BinaryReader): RemoveCurrencyResponse;
+export class RemoveCurrencyResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemoveCurrencyResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: RemoveCurrencyResponse): RemoveCurrencyResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemoveCurrencyResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemoveCurrencyResponse;
+  static deserializeBinaryFromReader(message: RemoveCurrencyResponse, reader: jspb.BinaryReader): RemoveCurrencyResponse;
 }
 
 export namespace RemoveCurrencyResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class RemovePairRequest extends jspb.Message { 
-    getPairId(): string;
-    setPairId(value: string): void;
+export class RemovePairRequest extends jspb.Message {
+  getPairId(): string;
+  setPairId(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RemovePairRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: RemovePairRequest): RemovePairRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RemovePairRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RemovePairRequest;
-    static deserializeBinaryFromReader(message: RemovePairRequest, reader: jspb.BinaryReader): RemovePairRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemovePairRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: RemovePairRequest): RemovePairRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemovePairRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemovePairRequest;
+  static deserializeBinaryFromReader(message: RemovePairRequest, reader: jspb.BinaryReader): RemovePairRequest;
 }
 
 export namespace RemovePairRequest {
-    export type AsObject = {
-        pairId: string,
-    }
+  export type AsObject = {
+    pairId: string,
+  }
 }
 
-export class RemovePairResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RemovePairResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: RemovePairResponse): RemovePairResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RemovePairResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RemovePairResponse;
-    static deserializeBinaryFromReader(message: RemovePairResponse, reader: jspb.BinaryReader): RemovePairResponse;
+export class RemovePairResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemovePairResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: RemovePairResponse): RemovePairResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemovePairResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemovePairResponse;
+  static deserializeBinaryFromReader(message: RemovePairResponse, reader: jspb.BinaryReader): RemovePairResponse;
 }
 
 export namespace RemovePairResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ShutdownRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ShutdownRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ShutdownRequest): ShutdownRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ShutdownRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ShutdownRequest;
-    static deserializeBinaryFromReader(message: ShutdownRequest, reader: jspb.BinaryReader): ShutdownRequest;
+export class ShutdownRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ShutdownRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ShutdownRequest): ShutdownRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ShutdownRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ShutdownRequest;
+  static deserializeBinaryFromReader(message: ShutdownRequest, reader: jspb.BinaryReader): ShutdownRequest;
 }
 
 export namespace ShutdownRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ShutdownResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ShutdownResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ShutdownResponse): ShutdownResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ShutdownResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ShutdownResponse;
-    static deserializeBinaryFromReader(message: ShutdownResponse, reader: jspb.BinaryReader): ShutdownResponse;
+export class ShutdownResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ShutdownResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ShutdownResponse): ShutdownResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ShutdownResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ShutdownResponse;
+  static deserializeBinaryFromReader(message: ShutdownResponse, reader: jspb.BinaryReader): ShutdownResponse;
 }
 
 export namespace ShutdownResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class SubscribeAddedOrdersRequest extends jspb.Message { 
-    getExisting(): boolean;
-    setExisting(value: boolean): void;
+export class SubscribeAddedOrdersRequest extends jspb.Message {
+  getExisting(): boolean;
+  setExisting(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribeAddedOrdersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribeAddedOrdersRequest): SubscribeAddedOrdersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribeAddedOrdersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribeAddedOrdersRequest;
-    static deserializeBinaryFromReader(message: SubscribeAddedOrdersRequest, reader: jspb.BinaryReader): SubscribeAddedOrdersRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribeAddedOrdersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribeAddedOrdersRequest): SubscribeAddedOrdersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribeAddedOrdersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribeAddedOrdersRequest;
+  static deserializeBinaryFromReader(message: SubscribeAddedOrdersRequest, reader: jspb.BinaryReader): SubscribeAddedOrdersRequest;
 }
 
 export namespace SubscribeAddedOrdersRequest {
-    export type AsObject = {
-        existing: boolean,
-    }
+  export type AsObject = {
+    existing: boolean,
+  }
 }
 
-export class SubscribeRemovedOrdersRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribeRemovedOrdersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribeRemovedOrdersRequest): SubscribeRemovedOrdersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribeRemovedOrdersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribeRemovedOrdersRequest;
-    static deserializeBinaryFromReader(message: SubscribeRemovedOrdersRequest, reader: jspb.BinaryReader): SubscribeRemovedOrdersRequest;
+export class SubscribeRemovedOrdersRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribeRemovedOrdersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribeRemovedOrdersRequest): SubscribeRemovedOrdersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribeRemovedOrdersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribeRemovedOrdersRequest;
+  static deserializeBinaryFromReader(message: SubscribeRemovedOrdersRequest, reader: jspb.BinaryReader): SubscribeRemovedOrdersRequest;
 }
 
 export namespace SubscribeRemovedOrdersRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class SubscribeSwapsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SubscribeSwapsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SubscribeSwapsRequest): SubscribeSwapsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SubscribeSwapsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SubscribeSwapsRequest;
-    static deserializeBinaryFromReader(message: SubscribeSwapsRequest, reader: jspb.BinaryReader): SubscribeSwapsRequest;
+export class SubscribeSwapsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SubscribeSwapsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SubscribeSwapsRequest): SubscribeSwapsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SubscribeSwapsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SubscribeSwapsRequest;
+  static deserializeBinaryFromReader(message: SubscribeSwapsRequest, reader: jspb.BinaryReader): SubscribeSwapsRequest;
 }
 
 export namespace SubscribeSwapsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class SwapResult extends jspb.Message { 
-    getOrderId(): string;
-    setOrderId(value: string): void;
+export class SwapResult extends jspb.Message {
+  getOrderId(): string;
+  setOrderId(value: string): void;
 
-    getLocalId(): string;
-    setLocalId(value: string): void;
+  getLocalId(): string;
+  setLocalId(value: string): void;
 
-    getPairId(): string;
-    setPairId(value: string): void;
+  getPairId(): string;
+  setPairId(value: string): void;
 
-    getQuantity(): number;
-    setQuantity(value: number): void;
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
-    getRHash(): string;
-    setRHash(value: string): void;
+  getRHash(): string;
+  setRHash(value: string): void;
 
-    getAmountReceived(): number;
-    setAmountReceived(value: number): void;
+  getAmountReceived(): number;
+  setAmountReceived(value: number): void;
 
-    getAmountSent(): number;
-    setAmountSent(value: number): void;
+  getAmountSent(): number;
+  setAmountSent(value: number): void;
 
-    getPeerPubKey(): string;
-    setPeerPubKey(value: string): void;
+  getPeerPubKey(): string;
+  setPeerPubKey(value: string): void;
 
-    getRole(): SwapResult.Role;
-    setRole(value: SwapResult.Role): void;
+  getRole(): SwapResult.Role;
+  setRole(value: SwapResult.Role): void;
 
-    getCurrencyReceived(): string;
-    setCurrencyReceived(value: string): void;
+  getCurrencyReceived(): string;
+  setCurrencyReceived(value: string): void;
 
-    getCurrencySent(): string;
-    setCurrencySent(value: string): void;
+  getCurrencySent(): string;
+  setCurrencySent(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SwapResult.AsObject;
-    static toObject(includeInstance: boolean, msg: SwapResult): SwapResult.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SwapResult, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SwapResult;
-    static deserializeBinaryFromReader(message: SwapResult, reader: jspb.BinaryReader): SwapResult;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SwapResult.AsObject;
+  static toObject(includeInstance: boolean, msg: SwapResult): SwapResult.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SwapResult, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SwapResult;
+  static deserializeBinaryFromReader(message: SwapResult, reader: jspb.BinaryReader): SwapResult;
 }
 
 export namespace SwapResult {
-    export type AsObject = {
-        orderId: string,
-        localId: string,
-        pairId: string,
-        quantity: number,
-        rHash: string,
-        amountReceived: number,
-        amountSent: number,
-        peerPubKey: string,
-        role: SwapResult.Role,
-        currencyReceived: string,
-        currencySent: string,
-    }
+  export type AsObject = {
+    orderId: string,
+    localId: string,
+    pairId: string,
+    quantity: number,
+    rHash: string,
+    amountReceived: number,
+    amountSent: number,
+    peerPubKey: string,
+    role: SwapResult.Role,
+    currencyReceived: string,
+    currencySent: string,
+  }
 
-    export enum Role {
+  export enum Role {
     TAKER = 0,
     MAKER = 1,
-    }
-
+  }
 }
 
-export class UnbanRequest extends jspb.Message { 
-    getNodePubKey(): string;
-    setNodePubKey(value: string): void;
+export class UnbanRequest extends jspb.Message {
+  getNodePubKey(): string;
+  setNodePubKey(value: string): void;
 
-    getReconnect(): boolean;
-    setReconnect(value: boolean): void;
+  getReconnect(): boolean;
+  setReconnect(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UnbanRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: UnbanRequest): UnbanRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UnbanRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UnbanRequest;
-    static deserializeBinaryFromReader(message: UnbanRequest, reader: jspb.BinaryReader): UnbanRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UnbanRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: UnbanRequest): UnbanRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UnbanRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UnbanRequest;
+  static deserializeBinaryFromReader(message: UnbanRequest, reader: jspb.BinaryReader): UnbanRequest;
 }
 
 export namespace UnbanRequest {
-    export type AsObject = {
-        nodePubKey: string,
-        reconnect: boolean,
-    }
+  export type AsObject = {
+    nodePubKey: string,
+    reconnect: boolean,
+  }
 }
 
-export class UnbanResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UnbanResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: UnbanResponse): UnbanResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UnbanResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UnbanResponse;
-    static deserializeBinaryFromReader(message: UnbanResponse, reader: jspb.BinaryReader): UnbanResponse;
+export class UnbanResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UnbanResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: UnbanResponse): UnbanResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UnbanResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UnbanResponse;
+  static deserializeBinaryFromReader(message: UnbanResponse, reader: jspb.BinaryReader): UnbanResponse;
 }
 
 export namespace UnbanResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
 export enum OrderSide {
-    BUY = 0,
-    SELL = 1,
+  BUY = 0,
+  SELL = 1,
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -752,25 +752,6 @@
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
     },
-    "array-sort": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.4.tgz",
-      "integrity": "sha512-BNcM+RXxndPxiZ2rd76k6nyQLRZr2/B/sdi8pQ+Joafr5AH279L40dfokSUTp8O+AaqYjXWhblBWa2st2nc4fQ==",
-      "dev": true,
-      "requires": {
-        "default-compare": "^1.0.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^5.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
-      }
-    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -868,12 +849,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
-    },
-    "autolinker": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
-      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
-      "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -2074,104 +2049,6 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
-    "create-frame": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/create-frame/-/create-frame-1.0.0.tgz",
-      "integrity": "sha1-i5XyaR4ySbYIBEPjPQutn49pdao=",
-      "dev": true,
-      "requires": {
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "dev": true,
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
@@ -2277,15 +2154,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
       "dev": true
-    },
-    "date.js": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
-      "integrity": "sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==",
-      "dev": true,
-      "requires": {
-        "debug": "~3.1.0"
-      }
     },
     "dateformat": {
       "version": "3.0.3",
@@ -2561,12 +2429,6 @@
         "once": "^1.4.0"
       }
     },
-    "ent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
-      "dev": true
-    },
     "env-variable": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
@@ -2773,57 +2635,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
         }
       }
     },
@@ -3040,12 +2851,6 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3214,12 +3019,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
     "fs-extra": {
@@ -3810,42 +3609,6 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
-    "get-object": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
-      "integrity": "sha1-2S/31RkMZFMM2gVD2sY6PUf+jAw=",
-      "dev": true,
-      "requires": {
-        "is-number": "^2.0.2",
-        "isobject": "^0.2.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
-          "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "get-pkg-repo": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
@@ -4033,42 +3796,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -4683,18 +4410,6 @@
         "node-pre-gyp": "^0.6.38"
       }
     },
-    "grpc_tools_node_protoc_ts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/grpc_tools_node_protoc_ts/-/grpc_tools_node_protoc_ts-2.3.0.tgz",
-      "integrity": "sha512-56ODCQxcA87DQKe0C710x7Ih4zXCyDMvMImguCxc+VqHrVb7w3o3j1cxuLvTFAPtOiwTrGX5IMlbRs1A7hpBQw==",
-      "dev": true,
-      "requires": {
-        "google-protobuf": "^3.5.0",
-        "grpc": "^1.9.0",
-        "handlebars": "^4.0.11",
-        "handlebars-helpers": "^0.8.4"
-      }
-    },
     "gulp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
@@ -4867,249 +4582,6 @@
         }
       }
     },
-    "handlebars-helpers": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.8.4.tgz",
-      "integrity": "sha1-+YgLeujYkOYxoxRvAZBQAFxU7RI=",
-      "dev": true,
-      "requires": {
-        "arr-filter": "^1.1.1",
-        "arr-flatten": "^1.0.1",
-        "array-sort": "^0.1.2",
-        "create-frame": "^1.0.0",
-        "define-property": "^0.2.5",
-        "for-in": "^0.1.6",
-        "for-own": "^0.1.4",
-        "get-object": "^0.2.0",
-        "get-value": "^2.0.6",
-        "handlebars": "^4.0.6",
-        "helper-date": "^0.2.3",
-        "helper-markdown": "^0.2.1",
-        "helper-md": "^0.2.2",
-        "html-tag": "^1.0.0",
-        "index-of": "^0.2.0",
-        "is-even": "^0.1.1",
-        "is-glob": "^3.1.0",
-        "is-number": "^3.0.0",
-        "is-odd": "^0.1.1",
-        "kind-of": "^3.1.0",
-        "lazy-cache": "^2.0.2",
-        "logging-helpers": "^0.4.0",
-        "make-iterator": "^0.3.0",
-        "micromatch": "^2.3.11",
-        "mixin-deep": "^1.1.3",
-        "normalize-path": "^2.0.1",
-        "relative": "^3.0.2",
-        "striptags": "^2.1.1",
-        "to-gfm-code-block": "^0.1.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-              "dev": true
-            }
-          }
-        },
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-          "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.1"
-          },
-          "dependencies": {
-            "for-in": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-              "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-              "dev": true
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        },
-        "is-odd": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
-          "integrity": "sha1-vFc7XONx7yqtbm9JeZtyvvE5eKc=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "dev": true,
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "make-iterator": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.3.1.tgz",
-          "integrity": "sha1-4calMrVGon8TlIoG+CUJsz25gRI=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.1.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-              "dev": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
@@ -5214,83 +4686,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "helper-date": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
-      "integrity": "sha1-2HDKu6BB0ynMhW2yC7jElnTj7yg=",
-      "dev": true,
-      "requires": {
-        "date.js": "^0.3.1",
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^3.1.0",
-        "moment": "^2.17.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "helper-markdown": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
-      "integrity": "sha1-ONt/dxhJ4wrpXJL8AhuutT8uMEA=",
-      "dev": true,
-      "requires": {
-        "isobject": "^2.0.0",
-        "mixin-deep": "^1.1.3",
-        "remarkable": "^1.6.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "helper-md": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
-      "integrity": "sha1-wfWdflW7riM2L9ig6XFgeuxp1B8=",
-      "dev": true,
-      "requires": {
-        "ent": "^2.2.0",
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "remarkable": "^1.6.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
     "highlight.js": {
       "version": "9.13.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
@@ -5325,16 +4720,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
-    },
-    "html-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-1.0.0.tgz",
-      "integrity": "sha1-leVhKuyCvqko7URZX4VBRen34LU=",
-      "dev": true,
-      "requires": {
-        "isobject": "^3.0.0",
-        "void-elements": "^2.0.1"
-      }
     },
     "http-errors": {
       "version": "1.6.3",
@@ -5393,12 +4778,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
-    },
-    "index-of": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
-      "integrity": "sha1-OMHiNn6lXf+tO261kuwcwwkNfWU=",
       "dev": true
     },
     "inflection": {
@@ -5527,41 +4906,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
-    "is-even": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-even/-/is-even-0.1.2.tgz",
-      "integrity": "sha1-4EMqc3ny0gtuu8LLEeab6q8xzWM=",
-      "dev": true,
-      "requires": {
-        "is-odd": "^0.1.2"
-      },
-      "dependencies": {
-        "is-odd": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
-          "integrity": "sha1-vFc7XONx7yqtbm9JeZtyvvE5eKc=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0"
-          }
-        }
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -5685,18 +5029,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -6083,39 +5415,6 @@
         }
       }
     },
-    "logging-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
-      "integrity": "sha1-AObVMWwjdn7BLhIA5PEsXgM+frA=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
     "lolex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
@@ -6227,12 +5526,6 @@
         "resolve": "^1.4.0",
         "stack-trace": "0.0.10"
       }
-    },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
@@ -6910,27 +6203,6 @@
         "make-iterator": "^1.0.0"
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      },
-      "dependencies": {
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        }
-      }
-    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -7075,35 +6347,6 @@
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -7245,12 +6488,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-hrtime": {
@@ -7428,25 +6665,6 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
-    "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
-    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -7559,15 +6777,6 @@
       "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==",
       "dev": true
     },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
-      }
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7594,48 +6803,6 @@
       "dev": true,
       "requires": {
         "rc": "^1.0.1"
-      }
-    },
-    "relative": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
-      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
-      "dev": true,
-      "requires": {
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "remarkable": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
-      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
-      "dev": true,
-      "requires": {
-        "argparse": "~0.1.15",
-        "autolinker": "~0.15.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-          "dev": true,
-          "requires": {
-            "underscore": "~1.7.0",
-            "underscore.string": "~2.4.0"
-          }
-        }
       }
     },
     "remove-bom-buffer": {
@@ -7965,15 +7132,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
-      "requires": {
-        "to-object-path": "^0.3.0"
-      }
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -8728,12 +7886,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
-    "striptags": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
-      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI=",
-      "dev": true
-    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -8950,12 +8102,6 @@
         "is-negated-glob": "^1.0.0"
       }
     },
-    "to-gfm-code-block": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
-      "integrity": "sha1-JdBFpfrlUxielje1kJANpzLYqoI=",
-      "dev": true
-    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -9073,6 +8219,23 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "ts-protoc-gen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.8.0.tgz",
+      "integrity": "sha512-LUFM4Jy3qMSVyRf5ql973cJjltS98MiCz8kPf1Rc9AC9BeLu0WJfoHLf0Tvx2cGH0jSK9BpA0o1tHQQfjeO47Q==",
+      "dev": true,
+      "requires": {
+        "google-protobuf": "^3.6.1"
+      },
+      "dependencies": {
+        "google-protobuf": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
+          "integrity": "sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA==",
           "dev": true
         }
       }
@@ -9388,18 +8551,6 @@
         }
       }
     },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true
-    },
-    "underscore.string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-      "dev": true
-    },
     "undertaker": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.0.tgz",
@@ -9683,12 +8834,6 @@
         "remove-bom-buffer": "^3.0.0",
         "vinyl": "^2.0.0"
       }
-    },
-    "void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
-      "dev": true
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
       "win32": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command ./winFixDeprecation.ps1"
     },
     "proto": {
-      "linux": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",
-      "darwin": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",
+      "linux": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/.bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",
+      "darwin": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/.bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",
       "win32": "node_modules\\grpc-tools\\bin\\protoc --js_out=\"import_style=commonjs,binary:lib\\proto\" --ts_out=\"lib\\proto\" --grpc_out=\"lib\\proto\" --plugin=\"protoc-gen-grpc=node_modules\\.bin\\grpc_tools_node_protoc_plugin.cmd\" --plugin=\"protoc-gen-ts=node_modules\\.bin\\protoc-gen-ts.cmd\" -I=\"proto\" proto\\xudrpc.proto proto\\hash_resolver.proto proto\\lndrpc.proto proto\\annotations.proto proto\\google\\api\\http.proto proto\\google\\protobuf\\descriptor.proto"
     },
     "proto:p2p": {
@@ -163,11 +163,11 @@
     "concurrently": "^3.5.1",
     "conventional-changelog-cli": "^2.0.11",
     "grpc-tools": "^1.6.6",
-    "grpc_tools_node_protoc_ts": "^2.3.0",
     "mocha": "^5.0.5",
     "nodemon": "^1.17.5",
     "sinon": "^7.1.1",
     "ts-node": "^6.0.2",
+    "ts-protoc-gen": "^0.8.0",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.10.0",
     "tslint-no-circular-imports": "^0.5.0",

--- a/proto/lndrpc.proto
+++ b/proto/lndrpc.proto
@@ -896,7 +896,7 @@ message Channel {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 4 [json_name = "chan_id"];
+    uint64 chan_id = 4 [json_name = "chan_id", jstype = JS_STRING];
 
     /// The total amount of funds held in this channel
     int64 capacity = 5 [json_name = "capacity"];
@@ -976,7 +976,7 @@ message ChannelCloseSummary {
     string channel_point = 1 [json_name = "channel_point"];
 
     ///  The unique channel ID for the channel.
-    uint64 chan_id = 2 [json_name = "chan_id"];
+    uint64 chan_id = 2 [json_name = "chan_id", jstype = JS_STRING];
 
     /// The hash of the genesis block that this channel resides within.
     string chain_hash = 3 [json_name = "chain_hash"];
@@ -1364,7 +1364,7 @@ message Hop {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 1 [json_name = "chan_id"];
+    uint64 chan_id = 1 [json_name = "chan_id", jstype = JS_STRING];
     int64 chan_capacity = 2 [json_name = "chan_capacity"];
     int64 amt_to_forward = 3 [json_name = "amt_to_forward", deprecated = true];
     int64 fee = 4 [json_name = "fee", deprecated = true];
@@ -1575,7 +1575,7 @@ message ClosedChannelUpdate {
     height, the next 3 the index within the block, and the last 2 bytes are the
     output index for the channel.
     */
-    uint64 chan_id = 1;
+    uint64 chan_id = 1 [jstype = JS_STRING];
     int64 capacity = 2;
     uint32 closed_height = 3;
     ChannelPoint chan_point = 4;
@@ -1586,7 +1586,7 @@ message HopHint {
     string node_id = 1 [json_name = "node_id"];
 
     /// The unique identifier of the channel.
-    uint64 chan_id = 2 [json_name = "chan_id"];
+    uint64 chan_id = 2 [json_name = "chan_id", jstype = JS_STRING];
 
     /// The base fee of the channel denominated in millisatoshis.
     uint32 fee_base_msat = 3 [json_name = "fee_base_msat"];


### PR DESCRIPTION
This adds `jstype = JS_STRING` annotations on the channel ids in the lnd proto definition so that they use `string` types instead of numbers. Javascript does not natively support 64 bit numbers and precision can be lost, and the channel ids are known to cause issues because of this.

This also adds a new package to generate type definitions from the `.proto` files. This is because of a known bug in the previously used plugin, agreatfool/grpc_tools_node_protoc_ts#10, which does not update the generated type definition when `jstype = JS_STRING` is used.

I hit a wall with my first approach of generating code and type definitions using the [protobuf.js](https://github.com/dcodeIO/protobuf.js) package. I found out the hard way that does not support generating the grpc server/client code and type definitions, as discussed in https://github.com/grpc/grpc-node/issues/528 and https://github.com/dcodeIO/protobuf.js/issues/1017. Fortunately I found this other plugin for generating type definitions from proto files, and that seems to work.

Having to update the lnd proto definition manually to add `jstype = JS_STRING` is not ideal, but it's at least a temporary solution until the grpc/protobuf tools and packages for javascript come up with a better approach. I may also open a PR with lnd to add these annotations to `chan_id` at least.

Fixes #745.