### PR TITLE
fix(swaps): release order hold on sendpayment err

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -101,7 +101,7 @@ class OrderBook extends EventEmitter {
         }
       });
       this.swaps.on('swap.failed', (deal) => {
-        if (deal.role === SwapRole.Maker && deal.phase === SwapPhase.SwapAgreed) {
+        if (deal.role === SwapRole.Maker && (deal.phase === SwapPhase.SwapAgreed || deal.phase === SwapPhase.SendingAmount)) {
           // if our order is the maker and the swap failed after it was agreed to but before it was executed
           // we must release the hold on the order that we set when we agreed to the deal
           this.removeOrderHold(deal.orderId, deal.pairId, deal.quantity!);

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -505,7 +505,7 @@ class Swaps extends EventEmitter {
     // TODO: use timeout on call
 
     try {
-      this.setDealPhase(deal,  SwapPhase.AmountSent);
+      this.setDealPhase(deal,  SwapPhase.SendingAmount);
       const sendPaymentResponse = await cmdLnd.sendPaymentSync(request);
       if (sendPaymentResponse.getPaymentError()) {
         throw new Error(sendPaymentResponse.getPaymentError());
@@ -618,7 +618,7 @@ class Swaps extends EventEmitter {
       request.setPaymentHashString(deal.rHash);
 
       try {
-        this.setDealPhase(deal, SwapPhase.AmountSent);
+        this.setDealPhase(deal, SwapPhase.SendingAmount);
         const response = await cmdLnd.sendToRouteSync(request);
         if (response.getPaymentError()) {
           this.logger.error('Got error from sendPaymentSync: ' + response.getPaymentError() + ' ' + JSON.stringify(request.toObject()));
@@ -677,14 +677,14 @@ class Swaps extends EventEmitter {
         assert(deal.phase === SwapPhase.SwapCreated, 'SwapAgreed can be only be set after SwapCreated');
         this.logger.debug('Sending swap response to peer ');
         break;
-      case SwapPhase.AmountSent:
+      case SwapPhase.SendingAmount:
         assert(deal.role === SwapRole.Taker && deal.phase === SwapPhase.SwapRequested ||
           deal.role === SwapRole.Maker && deal.phase === SwapPhase.SwapAgreed,
-            'AmountSent can only be set after SwapRequested (taker) or SwapAgreed (maker)');
+            'SendingAmount can only be set after SwapRequested (taker) or SwapAgreed (maker)');
         deal.executeTime = Date.now();
         break;
       case SwapPhase.AmountReceived:
-        assert(deal.phase === SwapPhase.AmountSent, 'AmountReceived can be only be set after AmountSent');
+        assert(deal.phase === SwapPhase.SendingAmount, 'AmountReceived can be only be set after SendingAmount');
         this.logger.debug('Amount received for preImage ' + deal.rPreimage);
         break;
       case SwapPhase.SwapCompleted:

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -27,11 +27,21 @@ export enum SwapRole {
 }
 
 export enum SwapPhase {
+  /** The swap has been created locally. */
   SwapCreated = 0,
+  /** The swap has been sent to a peer to request approval. */
   SwapRequested = 1,
+  /** The terms of the swap have been agreed to, and we will attempt to execute it. */
   SwapAgreed = 2,
-  AmountSent = 3,
+  /**
+   * We have commanded lnd to send payment according to the agreed terms. The payment (and swap)
+   * could still fail due to no route with sufficient capacity, lack of cooperation from the
+   * receiver or any intermediary node along the route, or an unexpected error from lnd.
+   */
+  SendingAmount = 3,
+  /** We have received the agreed amount of the swap, and the preimage is now known to both sides. */
   AmountReceived = 4,
+  /* The swap has been formally completed and both sides have confirmed they've received payment. */
   SwapCompleted = 5,
 }
 


### PR DESCRIPTION
This fixes a bug where the hold on an order would not be released when the swap failed after we had issued the `sendPaymentSync` command to lnd. Doing so changes the `SwapPhase` from `SwapAgreed` to `AmountSent` and the latter phase was overlooked in the logic that released the hold on swap failure.

This also renames the `AmountSent` phase to `SendingAmount` to more accurately describe the current state. Comments have also been added to the swap phases to better describe each one. `SendingAmount` means we've requested `lnd` to make the payment but we don't know if it has succeeded yet.

@offerm On our last call you'd mentioned that you've observed cases where the holds are never released, I think this PR should fix that.