### PR TITLE
feat(p2p): verify data integrity

### DIFF
--- a/lib/p2p/Parser.ts
+++ b/lib/p2p/Parser.ts
@@ -10,6 +10,7 @@ class ParserError {
 enum ParserErrorType {
   InvalidPacket,
   UnknownPacketType,
+  DataIntegrityError,
   MaxBufferSizeExceeded,
 }
 
@@ -66,7 +67,12 @@ const fromRaw = (type: number, binary: Uint8Array): Packet => {
     throw new ParserError(ParserErrorType.InvalidPacket, `${PacketType[type]} ${JSON.stringify(packetOrPbObj)}`);
   }
 
-  return packetOrPbObj;
+  const packet = packetOrPbObj;
+  if (!packet.verifyDataIntegrity()) {
+    throw new ParserError(ParserErrorType.DataIntegrityError, `${PacketType[type]} ${JSON.stringify(packet)}`);
+  }
+
+  return packet;
 };
 
 interface Parser {

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -2,6 +2,7 @@ import PacketType from './PacketType';
 import CryptoJS from 'crypto-js';
 import MD5 from 'crypto-js/md5';
 import uuidv1 from 'uuid/v1';
+import stringify from 'json-stable-stringify';
 
 type PacketHeader = {
   /** An identifer for the packet which must be unique for a given socket. */
@@ -81,13 +82,32 @@ abstract class Packet<T = any> implements PacketInterface {
 
       if (bodyOrPacket) {
         this.body = bodyOrPacket;
-        this.header.hash = MD5(JSON.stringify(bodyOrPacket)).toString(CryptoJS.enc.Base64);
+        this.header.hash = this.hash(bodyOrPacket);
       }
     }
   }
   public abstract serialize(): Uint8Array;
 
+  private hash(value: any): string {
+    return MD5(stringify(value)).toString(CryptoJS.enc.Base64);
+  }
+
   /**
+   * Verify the header hash against the packet body.
+   */
+  public verifyDataIntegrity(): boolean {
+    if (!this.body) {
+      return true;
+    }
+
+    if (!this.header.hash) {
+      return false;
+    }
+
+    return this.header.hash === this.hash(this.body);
+  }
+
+/**
    * Serialize this packet to binary Buffer.
    * @returns Buffer representation of the packet
    */

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -107,7 +107,7 @@ abstract class Packet<T = any> implements PacketInterface {
     return this.header.hash === this.hash(this.body);
   }
 
-/**
+  /**
    * Serialize this packet to binary Buffer.
    * @returns Buffer representation of the packet
    */

--- a/lib/p2p/packets/types/DisconnectingPacket.ts
+++ b/lib/p2p/packets/types/DisconnectingPacket.ts
@@ -3,7 +3,6 @@ import PacketType from '../PacketType';
 import { DisconnectionReason } from '../../../types/enums';
 import * as pb from '../../../proto/xudp2p_pb';
 import { removeUndefinedProps } from '../../../utils/utils';
-import HelloPacket from './HelloPacket';
 
 export type DisconnectingPacketBody = {
   reason: DisconnectionReason;

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,6 +337,11 @@
       "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
       "dev": true
     },
+    "@types/json-stable-stringify": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz",
+      "integrity": "sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw=="
+    },
     "@types/lodash": {
       "version": "4.14.104",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   ],
   "dependencies": {
     "@exchangeunion/grpc-dynamic-gateway": "^0.3.6",
+    "@types/json-stable-stringify": "^1.0.32",
     "body-parser": "^1.18.3",
     "chalk": "^2.3.2",
     "cli-table3": "^0.5.1",
@@ -129,6 +130,7 @@
     "google-protobuf": "^3.5.0",
     "grpc": "^1.13.1",
     "gulp": "^4.0.0",
+    "json-stable-stringify": "^1.0.1",
     "node-forge": "^0.7.6",
     "secp256k1": "^3.5.0",
     "sequelize": "^4.37.3",


### PR DESCRIPTION
Solves #157.

As discussed [here](https://github.com/ExchangeUnion/xud/pull/712#issuecomment-445180853), the packet body serialization for the hash function is done with `JSON.stringify`. Lack of consistency in the serialization was already found, so I used `json-stable-stringify` to fix it. Without it the tests would fail. 