### PR TITLE
feat(swaps): comprehensive SwapFailureReason

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1,4 +1,4 @@
-import { SwapPhase, SwapRole, SwapState } from '../types/enums';
+import { SwapPhase, SwapRole, SwapState, SwapFailureReason } from '../types/enums';
 import Peer from '../p2p/Peer';
 import { Models } from '../db/DB';
 import * as packets from '../p2p/packets/types';
@@ -119,8 +119,8 @@ class Swaps extends EventEmitter {
 
   /**
    * Verifies LND setup. Make sure we are connected to BTC and LTC and that
-   * the peer is also connected to these networks. Returns an error message
-   * or undefined in case all is good.
+   * the peer has provided pub keys for these networks.
+   * @returns undefined if the setup is verified, otherwise an error message
    */
   private verifyLndSetup = (deal: SwapDeal, peer: Peer) => {
     if (!peer.getLndPubKey(deal.takerCurrency)) {
@@ -181,10 +181,8 @@ class Swaps extends EventEmitter {
     switch (currency) {
       case 'BTC':
         return this.lndBtcClient;
-        break;
       case 'LTC':
         return this.lndLtcClient;
-        break;
       default:
         return;
     }
@@ -326,7 +324,7 @@ class Swaps extends EventEmitter {
     const errMsg = this.verifyLndSetup(deal, peer);
     if (errMsg) {
       this.logger.error(errMsg);
-      this.setDealState(deal, SwapState.Error, errMsg);
+      this.failDeal(deal, SwapFailureReason.SwapClientNotSetup, errMsg);
       return;
     }
     peer.sendPacket(new packets.SwapRequestPacket(swapRequestBody));
@@ -384,17 +382,14 @@ class Swaps extends EventEmitter {
     // the peer is also connected to these networks.
     const errMsg = this.verifyLndSetup(deal, peer);
     if (errMsg) {
-      this.setDealState(deal, SwapState.Error, errMsg);
+      this.failDeal(deal, SwapFailureReason.SwapClientNotSetup, errMsg);
       this.sendErrorToPeer(peer, deal.rHash, deal.errorReason!, requestPacket.header.id);
       return false;
     }
 
-    let lndclient: LndClient | undefined;
-    try {
-      lndclient = this.getClientForCurrency(deal.takerCurrency);
-      if (!lndclient) throw new Error('swap client not found');
-    } catch {
-      this.setDealState(deal, SwapState.Error, 'Can not swap. Unsupported taker currency.');
+    const lndclient = this.getClientForCurrency(deal.takerCurrency);
+    if (!lndclient) {
+      this.failDeal(deal, SwapFailureReason.SwapClientNotSetup, 'Unsupported taker currency');
       this.sendErrorToPeer(peer, deal.rHash, deal.errorReason!, requestPacket.header.id);
       return false;
     }
@@ -403,11 +398,11 @@ class Swaps extends EventEmitter {
       deal.makerToTakerRoutes = await this.getRoutes(deal.takerCurrency, takerAmount, deal.peerPubKey);
       if (deal.makerToTakerRoutes.length === 0) throw new Error();
     } catch (err) {
-      const cannotSwap = 'Can not swap. unable to find route to destination';
+      const cannotSwap = 'Unable to find route to destination';
       const errMsg = err && err.message
-        ? `${cannotSwap}.`
+        ? `${cannotSwap}`
         : `${cannotSwap}: ${err.message}`;
-      this.setDealState(deal, SwapState.Error, errMsg);
+      this.failDeal(deal, SwapFailureReason.NoRouteFound, errMsg);
       this.sendErrorToPeer(peer, deal.rHash, deal.errorReason!, requestPacket.header.id);
       return false;
     }
@@ -418,7 +413,7 @@ class Swaps extends EventEmitter {
       height = info.getBlockHeight();
       this.logger.debug('got block height of ' + height);
     } catch (err) {
-      this.setDealState(deal, SwapState.Error, 'Can not swap. Unable to fetch block height: ' + err.message);
+      this.failDeal(deal, SwapFailureReason.UnexpectedLndError, 'Unable to fetch block height: ' + err.message);
       this.sendErrorToPeer(peer, deal.rHash, deal.errorReason!, requestPacket.header.id);
       return false;
     }
@@ -468,11 +463,11 @@ class Swaps extends EventEmitter {
     if (quantity) {
       deal.quantity = quantity; // set the accepted quantity for the deal
       if (quantity <= 0) {
-        this.setDealState(deal, SwapState.Error, 'accepted quantity must be a positive number');
+        this.failDeal(deal, SwapFailureReason.InvalidSwapPacketReceived, 'accepted quantity must be a positive number');
         // TODO: penalize peer
         return;
       } else if (quantity > deal.proposedQuantity) {
-        this.setDealState(deal, SwapState.Error, 'accepted quantity should not be greater than proposed quantity');
+        this.failDeal(deal, SwapFailureReason.InvalidSwapPacketReceived, 'accepted quantity should not be greater than proposed quantity');
         // TODO: penalize peer
         return;
       } else if (quantity < deal.proposedQuantity) {
@@ -521,12 +516,11 @@ class Swaps extends EventEmitter {
       peer.sendPacket(new packets.SwapCompletePacket(responseBody));
 
     } catch (err) {
-      this.logger.error(`Got exception from sendPaymentSync ${JSON.stringify(request.toObject())}`, err.message);
-      this.setDealState(deal, SwapState.Error, err.message);
+      this.logger.error(`Got exception from sendPaymentSync: ${JSON.stringify(request.toObject())}`, err.message);
+      this.failDeal(deal, SwapFailureReason.SendPaymentFailure, err.message);
       this.sendErrorToPeer(peer, rHash, err.message);
       return;
     }
-
   }
 
   /**
@@ -555,8 +549,7 @@ class Swaps extends EventEmitter {
         destination = 'Taker';
         break;
       default:
-        this.setDealState(deal, SwapState.Error,
-          'Unknown role detected');
+        this.failDeal(deal, SwapFailureReason.InvalidResolveRequest, 'Unknown role detected');
         return false;
     }
     // convert expected amount to mSat
@@ -564,8 +557,7 @@ class Swaps extends EventEmitter {
 
     if (amount < expectedAmount) {
       this.logger.error(`received ${amount} mSat, expected ${expectedAmount} mSat`);
-      this.setDealState(deal, SwapState.Error,
-          `Amount sent from ${source} to ${destination} is too small`);
+      this.failDeal(deal, SwapFailureReason.InvalidResolveRequest, `Amount sent from ${source} to ${destination} is too small`);
       return false;
     }
 
@@ -573,8 +565,7 @@ class Swaps extends EventEmitter {
     if (cltvDelta - 1 > resolveRequest.getTimeout() - resolveRequest.getHeightNow()) {
       this.logger.error(`got timeout ${resolveRequest.getTimeout()} at height ${resolveRequest.getHeightNow()}`);
       this.logger.error(`cltvDelta is ${resolveRequest.getTimeout() - resolveRequest.getHeightNow()} expected delta of ${cltvDelta}`);
-      this.setDealState(deal, SwapState.Error,
-          `cltvDelta sent from ${source} to ${destination} is too small`);
+      this.failDeal(deal, SwapFailureReason.InvalidResolveRequest, `cltvDelta sent from ${source} to ${destination} is too small`);
       return false;
     }
     return true;
@@ -622,7 +613,7 @@ class Swaps extends EventEmitter {
         const response = await cmdLnd.sendToRouteSync(request);
         if (response.getPaymentError()) {
           this.logger.error('Got error from sendPaymentSync: ' + response.getPaymentError() + ' ' + JSON.stringify(request.toObject()));
-          this.setDealState(deal, SwapState.Error, response.getPaymentError());
+          this.failDeal(deal, SwapFailureReason.SendPaymentFailure, response.getPaymentError());
           return response.getPaymentError();
         }
 
@@ -631,7 +622,7 @@ class Swaps extends EventEmitter {
         return deal.rPreimage;
       } catch (err) {
         this.logger.error('Got exception from sendPaymentSync: ' + ' ' + JSON.stringify(request.toObject()) + err.message);
-        this.setDealState(deal, SwapState.Error, err.message);
+        this.failDeal(deal, SwapFailureReason.SendPaymentFailure, err.message);
         return 'Got exception from sendPaymentSync' + err.message;
       }
     } else {
@@ -644,20 +635,19 @@ class Swaps extends EventEmitter {
 
   }
 
-  private setDealState = (deal: SwapDeal, newState: SwapState, newStateReason: string): void => {
+  private failDeal = (deal: SwapDeal, failureReason: SwapFailureReason, errorReason: string): void => {
     // If we are already in error state and got another error report we
     // aggregate all error reasons by concatenation
-    if (deal.state === newState && deal.state === SwapState.Error) {
-      deal.errorReason = deal.errorReason + '; ' + newStateReason;
+    if (deal.state === SwapState.Error) {
+      deal.errorReason = deal.errorReason + '; ' + errorReason;
       this.logger.debug('new deal state reason: ' + deal.errorReason);
       return;
     }
     assert(deal.state === SwapState.Active, 'deal is not Active. Can not change deal state');
-    deal.state = newState;
-    deal.errorReason = newStateReason;
-    if (deal.state === SwapState.Error) {
-      this.emit('swap.failed', deal);
-    }
+    deal.state = SwapState.Error;
+    deal.failureReason = failureReason;
+    deal.errorReason = errorReason;
+    this.emit('swap.failed', deal);
   }
 
   private setDealPhase = (deal: SwapDeal, newPhase: SwapPhase): void => {
@@ -690,7 +680,7 @@ class Swaps extends EventEmitter {
       case SwapPhase.SwapCompleted:
         assert(deal.phase === SwapPhase.AmountReceived, 'SwapCompleted can be only be set after AmountReceived');
         deal.completeTime = Date.now();
-        this.setDealState(deal, SwapState.Completed, 'Swap completed. preimage = ' + deal.rPreimage);
+        deal.state = SwapState.Completed;
         this.logger.debug('Swap completed. preimage = ' + deal.rPreimage);
         break;
       default:
@@ -736,7 +726,7 @@ class Swaps extends EventEmitter {
       this.logger.error(`received swap error for unknown deal payment hash ${rHash}`);
       return;
     }
-    this.setDealState(deal, SwapState.Error, errorMessage);
+    this.failDeal(deal, SwapFailureReason.PeerFailedSwap, errorMessage);
     return this.persistDeal(deal);
   }
 

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -1,4 +1,4 @@
-import { SwapRole, SwapPhase, SwapState } from 'lib/types/enums';
+import { SwapRole, SwapPhase, SwapState, SwapFailureReason } from 'lib/types/enums';
 import { Route } from '../proto/lndrpc_pb';
 
 export type SwapDeal = {
@@ -13,6 +13,7 @@ export type SwapDeal = {
   state: SwapState;
   /** The reason for being in the current state. */
   errorReason?: string;
+  failureReason?: SwapFailureReason;
   /** The xud node pub key of the counterparty to this swap deal. */
   peerPubKey: string;
   /** The global order id in the XU network for the maker order being executed. */

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -54,11 +54,24 @@ export enum ReputationEvent {
 
 export enum SwapFailureReason {
   /** Could not find the order specified by a swap request. */
-  OrderNotFound,
+  OrderNotFound = 0,
   /** The order specified by a swap request is on hold for a different ongoing swap. */
-  OrderOnHold,
+  OrderOnHold = 1,
   /** The swap request contained invalid data. */
-  InvalidSwapRequest,
+  InvalidSwapRequest = 2,
+  /** We are not connected to both swap clients, or we are missing pub key identifiers for the peer's nodes. */
+  SwapClientNotSetup = 3,
+  /** Could not find a route to complete the swap. */
+  NoRouteFound = 4,
+  /** A call to lnd failed for an unexpected reason. */
+  UnexpectedLndError = 5,
+  /** Received a swap packet from the peer with invalid data. */
+  InvalidSwapPacketReceived = 6,
+  /** The call to lnd to send payment failed. */
+  SendPaymentFailure = 7,
+  /** The swap resolver request from lnd was invalid. */
+  InvalidResolveRequest = 8,
+  PeerFailedSwap, // TODO: this generic reason can be replaced with the failure reason reported by the peer
 }
 
 export enum DisconnectionReason {


### PR DESCRIPTION
This adds `SwapFailureReason` values to cover every reason that a swap may fail. Previously we only set a string error message on swaps when they fail/error. The failure reason can be used to take different actions according to the reason, and is a clean way to categorize the reasons that a swap has failed.

Left to do is updating the swap failure packet to send the failure reason to a peer, and also to update the database to store the failure reason in its own field. But since these are breaking changes, I'm going to put these in a separate PR to be merged shortly before a new release.

Closes #671.