### PR TITLE
feat(rpc): remove peerpubkey from executeswap

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -249,10 +249,10 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| pair_id | [string](#string) |  | The trading pair of the swap orders. |
 | order_id | [string](#string) |  | The order id of the maker order. |
-| peer_pub_key | [string](#string) |  | The node pub key of the peer which owns the maker order. |
-| quantity | [double](#double) |  | the quantity to swap. the whole order will be swapped if unspecified. |
+| pair_id | [string](#string) |  | The trading pair of the swap orders. |
+| peer_pub_key | [string](#string) |  | The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly. |
+| quantity | [double](#double) |  | The quantity to swap. The whole order will be swapped if unspecified. |
 
 
 

--- a/lib/cli/commands/executeswap.ts
+++ b/lib/cli/commands/executeswap.ts
@@ -2,7 +2,7 @@ import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { ExecuteSwapRequest } from '../../proto/xudrpc_pb';
 
-export const command = 'executeswap <pair_id> <order_id> <peer_pub_key> [quantity]';
+export const command = 'executeswap <pair_id> <order_id> [quantity]';
 
 export const describe = 'execute a swap on a peer order (nomatching mode only)';
 
@@ -11,9 +11,6 @@ export const builder = {
     type: 'string',
   },
   pair_id: {
-    type: 'string',
-  },
-  peer_pub_key: {
     type: 'string',
   },
   quantity: {
@@ -26,7 +23,6 @@ export const handler = (argv: Arguments) => {
   const request = new ExecuteSwapRequest();
   request.setOrderId(argv.order_id);
   request.setPairId(argv.pair_id);
-  request.setPeerPubKey(argv.peer_pub_key);
   request.setQuantity(argv.quantity);
   loadXudClient(argv).executeSwap(request, callback(argv));
 };

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -525,7 +525,7 @@ class OrderBook extends EventEmitter {
    * Removes all or part of a peer order from the order book and emits the `peerOrder.invalidation` event.
    * @param quantityToRemove the quantity to remove from the order, if undefined then the full order is removed
    */
-  public removePeerOrder = (orderId: string, pairId: string, peerPubKey: string, quantityToRemove?: number):
+  public removePeerOrder = (orderId: string, pairId: string, peerPubKey?: string, quantityToRemove?: number):
     { order: PeerOrder, fullyRemoved: boolean } => {
     const tp = this.getTradingPair(pairId);
     return tp.removePeerOrder(orderId, peerPubKey, quantityToRemove);

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -640,22 +640,22 @@
     "xudrpcExecuteSwapRequest": {
       "type": "object",
       "properties": {
-        "pair_id": {
-          "type": "string",
-          "description": "The trading pair of the swap orders."
-        },
         "order_id": {
           "type": "string",
           "description": "The order id of the maker order."
         },
+        "pair_id": {
+          "type": "string",
+          "description": "The trading pair of the swap orders."
+        },
         "peer_pub_key": {
           "type": "string",
-          "description": "The node pub key of the peer which owns the maker order."
+          "description": "The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly."
         },
         "quantity": {
           "type": "number",
           "format": "double",
-          "description": "the quantity to swap. the whole order will be swapped if unspecified."
+          "description": "The quantity to swap. The whole order will be swapped if unspecified."
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -947,11 +947,11 @@ export namespace PlaceOrderEvent {
 }
 
 export class ExecuteSwapRequest extends jspb.Message {
-  getPairId(): string;
-  setPairId(value: string): void;
-
   getOrderId(): string;
   setOrderId(value: string): void;
+
+  getPairId(): string;
+  setPairId(value: string): void;
 
   getPeerPubKey(): string;
   setPeerPubKey(value: string): void;
@@ -971,8 +971,8 @@ export class ExecuteSwapRequest extends jspb.Message {
 
 export namespace ExecuteSwapRequest {
   export type AsObject = {
-    pairId: string,
     orderId: string,
+    pairId: string,
     peerPubKey: string,
     quantity: number,
   }

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -6795,8 +6795,8 @@ proto.xudrpc.ExecuteSwapRequest.prototype.toObject = function(opt_includeInstanc
  */
 proto.xudrpc.ExecuteSwapRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
     orderId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
     peerPubKey: jspb.Message.getFieldWithDefault(msg, 3, ""),
     quantity: +jspb.Message.getFieldWithDefault(msg, 4, 0.0)
   };
@@ -6835,13 +6835,13 @@ proto.xudrpc.ExecuteSwapRequest.deserializeBinaryFromReader = function(msg, read
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setPairId(value);
-      break;
     case 1:
       var value = /** @type {string} */ (reader.readString());
       msg.setOrderId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPairId(value);
       break;
     case 3:
       var value = /** @type {string} */ (reader.readString());
@@ -6880,17 +6880,17 @@ proto.xudrpc.ExecuteSwapRequest.prototype.serializeBinary = function() {
  */
 proto.xudrpc.ExecuteSwapRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getPairId();
-  if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
-  }
   f = message.getOrderId();
   if (f.length > 0) {
     writer.writeString(
       1,
+      f
+    );
+  }
+  f = message.getPairId();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
       f
     );
   }
@@ -6912,21 +6912,6 @@ proto.xudrpc.ExecuteSwapRequest.serializeBinaryToWriter = function(message, writ
 
 
 /**
- * optional string pair_id = 2;
- * @return {string}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.getPairId = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
-};
-
-
-/** @param {string} value */
-proto.xudrpc.ExecuteSwapRequest.prototype.setPairId = function(value) {
-  jspb.Message.setField(this, 2, value);
-};
-
-
-/**
  * optional string order_id = 1;
  * @return {string}
  */
@@ -6938,6 +6923,21 @@ proto.xudrpc.ExecuteSwapRequest.prototype.getOrderId = function() {
 /** @param {string} value */
 proto.xudrpc.ExecuteSwapRequest.prototype.setOrderId = function(value) {
   jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string pair_id = 2;
+ * @return {string}
+ */
+proto.xudrpc.ExecuteSwapRequest.prototype.getPairId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.ExecuteSwapRequest.prototype.setPairId = function(value) {
+  jspb.Message.setField(this, 2, value);
 };
 
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -475,13 +475,13 @@ message PlaceOrderEvent {
 }
 
 message ExecuteSwapRequest {
-  // The trading pair of the swap orders.
-  string pair_id = 2 [json_name = "pair_id"];
   // The order id of the maker order.
   string order_id = 1 [json_name = "order_id"];
-  // The node pub key of the peer which owns the maker order.
+  // The trading pair of the swap orders.
+  string pair_id = 2 [json_name = "pair_id"];
+  // The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly.
   string peer_pub_key = 3 [json_name = "peer_pub_key"];
-  // the quantity to swap. the whole order will be swapped if unspecified.
+  // The quantity to swap. The whole order will be swapped if unspecified.
   double quantity = 4 [json_name = "quantity"];
 }
 


### PR DESCRIPTION
This call removes the `peer_pub_key` field from the `ExecuteSwap` request. This is not truly required information and it is inconvenient to have to provide, particularly from the cli. Finding which peer an order belongs to is not much of a performance concern.  It is constant time in regards to the number of orders and linear in regards to the number of peers.

Closes #694.