### PR TITLE
Fix peer stalling

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -77,6 +77,11 @@ class OrderBook extends EventEmitter {
     this.bindSwaps();
   }
 
+  private static createOutgoingOrder = (order: orders.OwnOrder): orders.OutgoingOrder => {
+    const { createdAt, localId, initialQuantity, hold, ...outgoingOrder } = order;
+    return outgoingOrder ;
+  }
+
   private bindPool = () => {
     if (this.pool) {
       this.pool.on('packet.order', this.addPeerOrder);
@@ -552,8 +557,8 @@ class OrderBook extends EventEmitter {
       // send only requested pairIds
       if (pairIds.includes(tp.pairId)) {
         const orders = tp.getOwnOrders();
-        orders.buy.forEach(order => outgoingOrders.push(this.createOutgoingOrder(order)));
-        orders.sell.forEach(order => outgoingOrders.push(this.createOutgoingOrder(order)));
+        orders.buy.forEach(order => outgoingOrders.push(OrderBook.createOutgoingOrder(order)));
+        orders.sell.forEach(order => outgoingOrders.push(OrderBook.createOutgoingOrder(order)));
       }
     });
     peer.sendOrders(outgoingOrders, reqId);
@@ -565,7 +570,7 @@ class OrderBook extends EventEmitter {
   private broadcastOrder = (order: orders.OwnOrder) => {
     if (this.pool) {
       if (this.swaps && this.swaps.isPairSupported(order.pairId)) {
-        const outgoingOrder = this.createOutgoingOrder(order);
+        const outgoingOrder = OrderBook.createOutgoingOrder(order);
         this.pool.broadcastOrder(outgoingOrder);
       }
     }
@@ -581,11 +586,6 @@ class OrderBook extends EventEmitter {
     }
 
     return { ...order, id, initialQuantity: order.quantity, createdAt: ms() };
-  }
-
-  private createOutgoingOrder = (order: orders.OwnOrder): orders.OutgoingOrder => {
-    const { createdAt, localId, ...outgoingOrder } = order;
-    return outgoingOrder;
   }
 
   private handleOrderInvalidation = (oi: OrderPortion, peerPubKey: string) => {

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -303,7 +303,10 @@ class Peer extends EventEmitter {
         }
         this.socket!.removeListener('error', onError);
         this.socket!.removeListener('connect', onConnect);
-        this.retryConnectionTimer = undefined;
+        if (this.retryConnectionTimer) {
+          clearTimeout(this.retryConnectionTimer);
+          this.retryConnectionTimer = undefined;
+        }
       };
 
       const onConnect = () => {

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -388,6 +388,7 @@ class Peer extends EventEmitter {
     for (const [packetId, entry] of this.responseMap) {
       if (now > entry.timeout) {
         this.emitError(`Peer is stalling (${packetId})`);
+        entry.reject('response timed out');
         this.close(DisconnectionReason.ResponseStalling, packetId);
         return;
       }

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -44,7 +44,6 @@ interface Peer {
 class Peer extends EventEmitter {
   // TODO: properties documentation
   public inbound!: boolean;
-  public connected = false;
   public recvDisconnectionReason?: DisconnectionReason;
   public sentDisconnectionReason?: DisconnectionReason;
   public expectedNodePubKey?: string;
@@ -89,6 +88,10 @@ class Peer extends EventEmitter {
     return this.handshakeState ? this.handshakeState.addresses : undefined;
   }
 
+  public get connected(): boolean {
+    return this.socket !== undefined && !this.socket.destroyed;
+  }
+
   public get info(): PeerInfo {
     return {
       address: addressUtils.toString(this.address),
@@ -118,7 +121,6 @@ class Peer extends EventEmitter {
     const peer = new Peer(logger, addressUtils.fromSocket(socket));
 
     peer.inbound = true;
-    peer.connected = true;
     peer.socket = socket;
 
     peer.bindSocket();
@@ -200,7 +202,6 @@ class Peer extends EventEmitter {
     }
 
     this.closed = true;
-    this.connected = false;
 
     if (this.socket) {
       if (reason !== undefined) {
@@ -307,7 +308,6 @@ class Peer extends EventEmitter {
 
       const onConnect = () => {
         this.connectTime = Date.now();
-        this.connected = true;
 
         this.bindSocket();
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -370,7 +370,7 @@ class Pool extends EventEmitter {
     }
   }
 
-  public closePeer = async (nodePubKey: string, reason?: DisconnectionReason, reasonPayload?: string): Promise<void> => {
+  public closePeer = (nodePubKey: string, reason?: DisconnectionReason, reasonPayload?: string) => {
     const peer = this.peers.get(nodePubKey);
     if (peer) {
       peer.close(reason, reasonPayload);
@@ -657,41 +657,7 @@ class Pool extends EventEmitter {
       this.pendingOutboundPeers.delete(peer.nodePubKey!);
     });
 
-    peer.once('close', async () => {
-      if (!peer.nodePubKey && peer.expectedNodePubKey) {
-        this.pendingOutboundPeers.delete(peer.expectedNodePubKey);
-      }
-
-      if (!peer.active) {
-        return;
-      }
-
-      if (peer.nodePubKey) {
-        this.pendingOutboundPeers.delete(peer.nodePubKey);
-        this.peers.delete(peer.nodePubKey);
-      }
-      this.emit('peer.close', peer);
-
-      // if handshake passed and peer disconnected from us for stalling or without specifying any reason -
-      // reconnect, for that might have been due to a temporary loss in connectivity
-      const unintentionalDisconnect =
-        (peer.sentDisconnectionReason === undefined || peer.sentDisconnectionReason === DisconnectionReason.ResponseStalling) &&
-        (peer.recvDisconnectionReason === undefined || peer.recvDisconnectionReason === DisconnectionReason.ResponseStalling);
-      const addresses = peer.addresses || [];
-
-      let lastAddress;
-      if (peer.inbound) {
-        lastAddress = addresses.length > 0 ? addresses[0] : undefined;
-      } else {
-        lastAddress = peer.address;
-      }
-
-      if (peer.nodePubKey && unintentionalDisconnect && (addresses.length || lastAddress)) {
-        this.logger.debug(`attempting to reconnect to a disconnected peer ${peer.nodePubKey}`);
-        const node = { lastAddress, addresses, nodePubKey: peer.nodePubKey };
-        await this.tryConnectNode(node, true);
-      }
-    });
+    peer.once('close', () => this.handlePeerClose(peer));
 
     peer.once('reputation', async (event) => {
       this.logger.debug(`Peer (${peer.nodePubKey || addressUtils.toString(peer.address)}), received reputation event: ${ReputationEvent[event]}`);
@@ -699,6 +665,42 @@ class Pool extends EventEmitter {
         await this.nodes.addReputationEvent(peer.nodePubKey, event);
       }
     });
+  }
+
+  private handlePeerClose = async (peer: Peer) => {
+    if (!peer.nodePubKey && peer.expectedNodePubKey) {
+      this.pendingOutboundPeers.delete(peer.expectedNodePubKey);
+    }
+
+    if (!peer.active) {
+      return;
+    }
+
+    if (peer.nodePubKey) {
+      this.pendingOutboundPeers.delete(peer.nodePubKey);
+      this.peers.delete(peer.nodePubKey);
+    }
+    this.emit('peer.close', peer);
+
+    // if handshake passed and peer disconnected from us for stalling or without specifying any reason -
+    // reconnect, for that might have been due to a temporary loss in connectivity
+    const unintentionalDisconnect =
+      (peer.sentDisconnectionReason === undefined || peer.sentDisconnectionReason === DisconnectionReason.ResponseStalling) &&
+      (peer.recvDisconnectionReason === undefined || peer.recvDisconnectionReason === DisconnectionReason.ResponseStalling);
+    const addresses = peer.addresses || [];
+
+    let lastAddress;
+    if (peer.inbound) {
+      lastAddress = addresses.length > 0 ? addresses[0] : undefined;
+    } else {
+      lastAddress = peer.address;
+    }
+
+    if (peer.nodePubKey && unintentionalDisconnect && (addresses.length || lastAddress)) {
+      this.logger.debug(`attempting to reconnect to a disconnected peer ${peer.nodePubKey}`);
+      const node = { lastAddress, addresses, nodePubKey: peer.nodePubKey };
+      await this.tryConnectNode(node, true);
+    }
   }
 
   private closePeers = () => {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -570,6 +570,12 @@ class Pool extends EventEmitter {
       return;
     }
 
+    // check to make sure the socket was not destroyed during or immediately after the handshake
+    if (!peer.connected) {
+      this.logger.error(`the socket to node ${peer.nodePubKey} was disconnected`);
+      return;
+    }
+
     this.logger.verbose(`opened connection to ${peer.nodePubKey} at ${addressUtils.toString(peer.address)}`);
     this.peers.set(peer.nodePubKey, peer);
     peer.active = true;

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -574,8 +574,11 @@ class Pool extends EventEmitter {
     this.peers.set(peer.nodePubKey, peer);
     peer.active = true;
 
-    // request peer's orders
-    peer.sendPacket(new packets.GetOrdersPacket({ pairIds: this.handshakeData.pairs }));
+    if (this.handshakeData.pairs.length > 0) {
+      // request peer's orders
+      peer.sendPacket(new packets.GetOrdersPacket({ pairIds: this.handshakeData.pairs }));
+    }
+
     if (this.config.discover) {
       // request peer's known nodes only if p2p.discover option is true
       peer.sendPacket(new packets.GetNodesPacket());

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -82,15 +82,16 @@ abstract class Packet<T = any> implements PacketInterface {
 
       if (bodyOrPacket) {
         this.body = bodyOrPacket;
-        this.header.hash = this.hash(bodyOrPacket);
+        this.header.hash = Packet.hash(bodyOrPacket);
       }
     }
   }
-  public abstract serialize(): Uint8Array;
 
-  private hash(value: any): string {
+  private static hash(value: any): string {
     return MD5(stringify(value)).toString(CryptoJS.enc.Base64);
   }
+
+  public abstract serialize(): Uint8Array;
 
   /**
    * Verify the header hash against the packet body.
@@ -104,7 +105,7 @@ abstract class Packet<T = any> implements PacketInterface {
       return false;
     }
 
-    return this.header.hash === this.hash(this.body);
+    return this.header.hash === Packet.hash(this.body);
   }
 
   /**

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -8,6 +8,7 @@ import NodeKey from '../../lib/nodekey/NodeKey';
 import Peer from '../../lib/p2p/Peer';
 import { Address } from '../../lib/types/p2p';
 import { DisconnectionReason } from '../../lib/types/enums';
+import sinon from 'sinon';
 
 chai.use(chaiAsPromised);
 
@@ -16,14 +17,22 @@ describe('P2P Pool Tests', async () => {
   let pool: Pool;
   let nodePubKeyOne: string;
   const loggers = Logger.createLoggers(Level.Warn);
+  const sandbox = sinon.createSandbox();
 
   const createPeer = (nodePubKey: string, addresses: Address[]) => {
-    const peer = new Peer(loggers.p2p, addresses[0]);
-    peer['handshakeState'] = {
+    const peer = sandbox.createStubInstance(Peer) as any;
+    peer.address = addresses[0];
+    peer.handshakeState = {
       addresses,
       nodePubKey,
       version: 'test',
       pairs: [],
+    };
+    peer.socket = {};
+    peer.sendPacket = () => {};
+    peer.close = () => {
+      peer.sentDisconnectionReason = DisconnectionReason.NotAcceptingConnections;
+      pool['handlePeerClose'](peer);
     };
     pool['bindPeer'](peer);
 
@@ -35,6 +44,7 @@ describe('P2P Pool Tests', async () => {
 
     const config = new Config();
     config.p2p.listen = false;
+    config.p2p.discover = false;
     db = new DB(loggers.db);
     await db.init();
 
@@ -71,19 +81,17 @@ describe('P2P Pool Tests', async () => {
     expect(nodeInstance!.addresses![0].host).to.equal(addresses[0].host);
   });
 
-  it('should close a peer', async () => {
-    const closePromise = pool.closePeer(nodePubKeyOne, DisconnectionReason.NotAcceptingConnections);
-    expect(closePromise).to.be.fulfilled;
-    await closePromise;
+  it('should close a peer', () => {
+    pool.closePeer(nodePubKeyOne, DisconnectionReason.NotAcceptingConnections);
     expect(pool['peers'].has(nodePubKeyOne)).to.be.false;
     expect(pool['peers'].size).to.equal(0);
   });
 
   it('should update a node on new handshake', async () => {
-   /* const addresses = [{ host: '86.75.30.9', port: 8885 }];
+    const addresses = [{ host: '86.75.30.9', port: 8885 }];
     const peer = createPeer(nodePubKeyOne, addresses);
 
-    await pool['handleOpen'](peer);
+    pool['handleOpen'](peer);
 
     const nodeInstance = await db.models.Node.find({
       where: {
@@ -94,10 +102,7 @@ describe('P2P Pool Tests', async () => {
     expect(nodeInstance!.addresses!).to.have.length(1);
     expect(nodeInstance!.addresses![0].host).to.equal(addresses[0].host);
 
-    const closePromise = pool.closePeer(nodePubKeyOne, DisconnectionReason.NotAcceptingConnections);
-    expect(closePromise).to.be.fulfilled;
-    await closePromise;
-    */
+    pool.closePeer(nodePubKeyOne, DisconnectionReason.NotAcceptingConnections);
   });
 
   after(async () => {

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -69,10 +69,10 @@ describe('P2P Sanity Tests', () => {
       .to.be.rejectedWith('already connected');
   });
 
-  it('should disconnect successfully', async () => {
-    await expect(nodeOne['pool']['closePeer'](nodeTwo.nodePubKey, DisconnectionReason.NotAcceptingConnections)).to.be.fulfilled;
+  it('should disconnect successfully', () => {
+    nodeOne['pool']['closePeer'](nodeTwo.nodePubKey, DisconnectionReason.NotAcceptingConnections);
 
-    const listPeersResult = await nodeOne.service.listPeers();
+    const listPeersResult = nodeOne.service.listPeers();
     expect(listPeersResult).to.be.empty;
   });
 


### PR DESCRIPTION
This includes several fixes I uncovered while trying to figure out what was causing #758, as well as logging enhancements to help debug p2p issues. Each commit has its own description, but the key one is the last one:

> This fixes a bug where the hash calculated for outgoing Order and Orders packets wouldn't match the calculated hash for the packet received by the peer due to the order objects being hashed having extraneous properties that are not transmitted to the peer, namely `hold` and `initialQuantity`.

I've tested the fix between two peers using this branch and they don't stall and disconnect from each other any more, but it would be helpful if we could try this on the seed nodes before merging.

Fixes #758.