### PR TITLE
refactor(p2p): use every() to validate packets

### DIFF
--- a/lib/p2p/packets/types/HelloPacket.ts
+++ b/lib/p2p/packets/types/HelloPacket.ts
@@ -24,7 +24,7 @@ class HelloPacket extends Packet<HandshakeState> {
       && obj.version
       && obj.nodepubkey
       && obj.pairsList
-      && obj.addressesList.filter(addr => addr.host).length === obj.addressesList.length
+      && obj.addressesList.every(addr => !!addr.host)
     );
   }
 

--- a/lib/p2p/packets/types/NodesPacket.ts
+++ b/lib/p2p/packets/types/NodesPacket.ts
@@ -26,7 +26,7 @@ class NodesPacket extends Packet<NodeConnectionInfo[]> {
       && obj.nodesList.filter(node =>
         node.nodepubkey
         && node.addressesList.length > 0
-        && node.addressesList.filter(addr => addr.port && addr.host).length === node.addressesList.length,
+        && node.addressesList.every(addr => addr.port > 0 && !!addr.host),
       ).length === obj.nodesList.length
     );
 

--- a/lib/p2p/packets/types/OrdersPacket.ts
+++ b/lib/p2p/packets/types/OrdersPacket.ts
@@ -2,8 +2,6 @@ import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 import { orders } from '../../../types';
 import * as pb from '../../../proto/xudp2p_pb';
-import { removeUndefinedProps } from '../../../utils/utils';
-import OrderPacket from './OrderPacket';
 
 type OrdersPacketBody = orders.OutgoingOrder[];
 
@@ -25,12 +23,12 @@ class OrdersPacket extends Packet<OrdersPacketBody> {
     return !!(obj.id
       && obj.hash
       && obj.reqid
-      && obj.ordersList.filter(order =>
-        order.id
-        && order.pairid
-        && order.price
-        && order.quantity,
-      ).length === obj.ordersList.length
+      && obj.ordersList.every(order =>
+        !!order.id
+        && !!order.pairid
+        && order.price > 0
+        && order.quantity > 0,
+      )
     );
   }
 


### PR DESCRIPTION
This uses the `every` Array method for arrays rather than `filter` to check that every object in a list within a packet passes validation. They function similarly but `every` does not create a new array, whereas `filter` does, so this cuts out an unnecessary step and may provide a very minor performance improvement.