### PR TITLE
fix(orderbook): use pairs keys iterable

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -537,7 +537,7 @@ class OrderBook extends EventEmitter {
       return;
     }
 
-    for (const pairId of this.pairIds.values()) {
+    for (const pairId of this.pairs.keys()) {
       this.removePeerPair(peerPubKey, pairId);
     }
 


### PR DESCRIPTION
This is an attempt to fix #766. It removes an unnecessary step of converting an iterable to an array when iterating over the supported pair ids for removing peer orders.