### PR TITLE
fix(p2p): hash order invalidations correctly

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -448,8 +448,8 @@ class Pool extends EventEmitter {
    * Broadcasts an [[OrderInvalidationPacket]] to all currently connected peers.
    * @param nodeToExclude the node pub key of a node to exclude from the packet broadcast
    */
-  public broadcastOrderInvalidation = (order: OrderPortion, nodeToExclude?: string) => {
-    const orderInvalidationPacket = new packets.OrderInvalidationPacket(order);
+  public broadcastOrderInvalidation = ({ id, pairId, quantity }: OrderPortion, nodeToExclude?: string) => {
+    const orderInvalidationPacket = new packets.OrderInvalidationPacket({ id, pairId, quantity });
     this.peers.forEach((peer) => {
       if (!nodeToExclude || peer.nodePubKey !== nodeToExclude) {
         peer.sendPacket(orderInvalidationPacket);

--- a/lib/p2p/packets/types/OrderInvalidationPacket.ts
+++ b/lib/p2p/packets/types/OrderInvalidationPacket.ts
@@ -2,8 +2,6 @@ import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 import { OrderPortion } from '../../../types/orders';
 import * as pb from '../../../proto/xudp2p_pb';
-import { removeUndefinedProps } from '../../../utils/utils';
-import HelloPacket from './HelloPacket';
 import OrderPacket from './OrderPacket';
 
 type OrderInvalidationPacketBody = OrderPortion;


### PR DESCRIPTION
This fixes a bug where the hash calculated for outgoing order invalidation packets wouldn't match the calculated hash for the packet received by the peer due to the order objects being hashed having extraneous properties that are not transmitted to the peer. This would cause the order invalidations to be ignored by the receiver.

Fixes #767.