### PR TITLE
Swap failureReason field for SwapDeal db model and SwapFailedPacket

### DIFF
--- a/lib/db/models/SwapDeal.ts
+++ b/lib/db/models/SwapDeal.ts
@@ -7,6 +7,7 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
     role: { type: DataTypes.TINYINT, allowNull: false },
     state: { type: DataTypes.TINYINT, allowNull: false },
     phase: { type: DataTypes.TINYINT, allowNull: false },
+    failureReason: { type: DataTypes.TINYINT, allowNull: true },
     errorMessage: { type: DataTypes.STRING, allowNull: true },
     rPreimage: { type: DataTypes.STRING, allowNull: true },
     peerPubKey: {

--- a/lib/db/models/SwapDeal.ts
+++ b/lib/db/models/SwapDeal.ts
@@ -7,7 +7,7 @@ export default (sequelize: Sequelize.Sequelize, DataTypes: Sequelize.DataTypes) 
     role: { type: DataTypes.TINYINT, allowNull: false },
     state: { type: DataTypes.TINYINT, allowNull: false },
     phase: { type: DataTypes.TINYINT, allowNull: false },
-    errorReason: { type: DataTypes.STRING, allowNull: true },
+    errorMessage: { type: DataTypes.STRING, allowNull: true },
     rPreimage: { type: DataTypes.STRING, allowNull: true },
     peerPubKey: {
       type: DataTypes.VIRTUAL,

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -619,6 +619,7 @@ class OrderBook extends EventEmitter {
       // TODO: penalize peer for invalid swap request
       peer.sendPacket(new SwapFailedPacket({
         rHash,
+        failureReason: SwapFailureReason.InvalidSwapRequest,
       }, requestPacket.header.id));
       return;
     }
@@ -627,6 +628,7 @@ class OrderBook extends EventEmitter {
     if (!order) {
       peer.sendPacket(new SwapFailedPacket({
         rHash,
+        failureReason: SwapFailureReason.OrderNotFound,
       }, requestPacket.header.id));
       return;
     }
@@ -654,6 +656,7 @@ class OrderBook extends EventEmitter {
     } else {
       peer.sendPacket(new SwapFailedPacket({
         rHash,
+        failureReason: SwapFailureReason.OrderOnHold,
       }, requestPacket.header.id));
     }
   }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -619,7 +619,6 @@ class OrderBook extends EventEmitter {
       // TODO: penalize peer for invalid swap request
       peer.sendPacket(new SwapFailedPacket({
         rHash,
-        errorMessage: SwapFailureReason[SwapFailureReason.InvalidSwapRequest],
       }, requestPacket.header.id));
       return;
     }
@@ -628,7 +627,6 @@ class OrderBook extends EventEmitter {
     if (!order) {
       peer.sendPacket(new SwapFailedPacket({
         rHash,
-        errorMessage: SwapFailureReason[SwapFailureReason.OrderNotFound],
       }, requestPacket.header.id));
       return;
     }
@@ -656,7 +654,6 @@ class OrderBook extends EventEmitter {
     } else {
       peer.sendPacket(new SwapFailedPacket({
         rHash,
-        errorMessage: SwapFailureReason[SwapFailureReason.OrderOnHold],
       }, requestPacket.header.id));
     }
   }

--- a/lib/p2p/packets/types/SwapCompletePacket.ts
+++ b/lib/p2p/packets/types/SwapCompletePacket.ts
@@ -1,7 +1,6 @@
 import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 import * as pb from '../../../proto/xudp2p_pb';
-import SwapAcceptedPacket from './SwapAcceptedPacket';
 
 export type SwapCompletePacketBody = {
   rHash: string;

--- a/lib/p2p/packets/types/SwapFailedPacket.ts
+++ b/lib/p2p/packets/types/SwapFailedPacket.ts
@@ -1,13 +1,12 @@
 import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 import * as pb from '../../../proto/xudp2p_pb';
-import SwapCompletePacket from './SwapCompletePacket';
 import { removeUndefinedProps } from '../../../utils/utils';
 
 // TODO: proper error handling
 export type SwapFailedPacketBody = {
   rHash: string;
-  errorMessage: string;
+  errorMessage?: string;
 };
 
 class SwapFailedPacket extends Packet<SwapFailedPacketBody> {
@@ -42,10 +41,10 @@ class SwapFailedPacket extends Packet<SwapFailedPacketBody> {
         hash: obj.hash,
         reqId: obj.reqId || undefined,
       }),
-      body: {
+      body: removeUndefinedProps({
         rHash: obj.rHash,
-        errorMessage: obj.errorMessage,
-      },
+        errorMessage: obj.errorMessage || undefined,
+      }),
     });
   }
 
@@ -55,7 +54,9 @@ class SwapFailedPacket extends Packet<SwapFailedPacketBody> {
     msg.setHash(this.header.hash!);
     msg.setReqId(this.header.reqId!);
     msg.setRHash(this.body!.rHash);
-    msg.setErrorMessage(this.body!.errorMessage);
+    if (this.body!.errorMessage) {
+      msg.setErrorMessage(this.body!.errorMessage!);
+    }
 
     return msg.serializeBinary();
   }

--- a/lib/p2p/packets/types/SwapFailedPacket.ts
+++ b/lib/p2p/packets/types/SwapFailedPacket.ts
@@ -2,10 +2,12 @@ import Packet, { PacketDirection } from '../Packet';
 import PacketType from '../PacketType';
 import * as pb from '../../../proto/xudp2p_pb';
 import { removeUndefinedProps } from '../../../utils/utils';
+import { SwapFailureReason } from '../../../types/enums';
 
 // TODO: proper error handling
 export type SwapFailedPacketBody = {
   rHash: string;
+  failureReason: SwapFailureReason;
   errorMessage?: string;
 };
 
@@ -44,6 +46,7 @@ class SwapFailedPacket extends Packet<SwapFailedPacketBody> {
       body: removeUndefinedProps({
         rHash: obj.rHash,
         errorMessage: obj.errorMessage || undefined,
+        failureReason: obj.failureReason,
       }),
     });
   }
@@ -57,6 +60,7 @@ class SwapFailedPacket extends Packet<SwapFailedPacketBody> {
     if (this.body!.errorMessage) {
       msg.setErrorMessage(this.body!.errorMessage!);
     }
+    msg.setFailureReason(this.body!.failureReason);
 
     return msg.serializeBinary();
   }

--- a/lib/proto/xudp2p_pb.d.ts
+++ b/lib/proto/xudp2p_pb.d.ts
@@ -537,6 +537,9 @@ export class SwapFailedPacket extends jspb.Message {
   getErrorMessage(): string;
   setErrorMessage(value: string): void;
 
+  getFailureReason(): number;
+  setFailureReason(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SwapFailedPacket.AsObject;
   static toObject(includeInstance: boolean, msg: SwapFailedPacket): SwapFailedPacket.AsObject;
@@ -554,6 +557,7 @@ export namespace SwapFailedPacket {
     hash: string,
     rHash: string,
     errorMessage: string,
+    failureReason: number,
   }
 }
 

--- a/lib/proto/xudp2p_pb.js
+++ b/lib/proto/xudp2p_pb.js
@@ -3751,7 +3751,8 @@ proto.xudp2p.SwapFailedPacket.toObject = function(includeInstance, msg) {
     reqId: jspb.Message.getFieldWithDefault(msg, 2, ""),
     hash: jspb.Message.getFieldWithDefault(msg, 3, ""),
     rHash: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    errorMessage: jspb.Message.getFieldWithDefault(msg, 5, "")
+    errorMessage: jspb.Message.getFieldWithDefault(msg, 5, ""),
+    failureReason: jspb.Message.getFieldWithDefault(msg, 6, 0)
   };
 
   if (includeInstance) {
@@ -3807,6 +3808,10 @@ proto.xudp2p.SwapFailedPacket.deserializeBinaryFromReader = function(msg, reader
     case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setErrorMessage(value);
+      break;
+    case 6:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setFailureReason(value);
       break;
     default:
       reader.skipField();
@@ -3869,6 +3874,13 @@ proto.xudp2p.SwapFailedPacket.serializeBinaryToWriter = function(message, writer
   if (f.length > 0) {
     writer.writeString(
       5,
+      f
+    );
+  }
+  f = message.getFailureReason();
+  if (f !== 0) {
+    writer.writeUint32(
+      6,
       f
     );
   }
@@ -3947,6 +3959,21 @@ proto.xudp2p.SwapFailedPacket.prototype.getErrorMessage = function() {
 /** @param {string} value */
 proto.xudp2p.SwapFailedPacket.prototype.setErrorMessage = function(value) {
   jspb.Message.setField(this, 5, value);
+};
+
+
+/**
+ * optional uint32 failure_reason = 6;
+ * @return {number}
+ */
+proto.xudp2p.SwapFailedPacket.prototype.getFailureReason = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 6, 0));
+};
+
+
+/** @param {number} value */
+proto.xudp2p.SwapFailedPacket.prototype.setFailureReason = function(value) {
+  jspb.Message.setField(this, 6, value);
 };
 
 

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -12,7 +12,7 @@ export type SwapDeal = {
    */
   state: SwapState;
   /** The reason for being in the current state. */
-  errorReason?: string;
+  errorMessage?: string;
   failureReason?: SwapFailureReason;
   /** The xud node pub key of the counterparty to this swap deal. */
   peerPubKey: string;

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -82,7 +82,8 @@ export enum SwapFailureReason {
   SendPaymentFailure = 7,
   /** The swap resolver request from lnd was invalid. */
   InvalidResolveRequest = 8,
-  PeerFailedSwap, // TODO: this generic reason can be replaced with the failure reason reported by the peer
+  /** The swap request attempts to reuse a payment hash. */
+  PaymentHashReuse = 9,
 }
 
 export enum DisconnectionReason {

--- a/proto/xudp2p.proto
+++ b/proto/xudp2p.proto
@@ -118,4 +118,5 @@ message SwapFailedPacket {
     string hash = 3 [json_name = "hash"];
     string r_hash = 4 [json_name = "r_hash"];
     string error_message = 5 [json_name = "error_message"];
+    uint32 failure_reason = 6[json_name = "failure_reason"];
 }

--- a/test/integration/Swap.spec.ts
+++ b/test/integration/Swap.spec.ts
@@ -78,7 +78,7 @@ const validSwapDeal = () => {
     makerCltvDelta: 1152,
     quantity: 0.00001,
     executeTime: 1542033726871,
-    errorReason: 'UnknownPaymentHash',
+    errorMessage: 'UnknownPaymentHash',
   };
 };
 

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -4,9 +4,10 @@ import Parser, { ParserErrorType } from '../../lib/p2p/Parser';
 import { Packet, PacketType } from '../../lib/p2p/packets';
 import * as packets from '../../lib/p2p/packets/types';
 import { removeUndefinedProps } from '../../lib/utils/utils';
-import { DisconnectionReason } from '../../lib/types/enums';
+import { DisconnectionReason, SwapFailureReason } from '../../lib/types/enums';
 import uuid = require('uuid');
 import { Address } from '../../lib/types/p2p';
+import stringify from 'json-stable-stringify';
 
 chai.use(chaiAsPromised);
 
@@ -240,12 +241,14 @@ describe('Parser', () => {
 
     const swapFailedPacketBody = {
       rHash: uuid(),
-      errorMessage: uuid(),
+      errorMessage: 'this is a test',
+      failureReason: SwapFailureReason.SendPaymentFailure,
     };
     testValidPacket(new packets.SwapFailedPacket(swapFailedPacketBody));
     testValidPacket(new packets.SwapFailedPacket(swapFailedPacketBody, uuid()));
-    testValidPacket(new packets.SwapCompletePacket(removeUndefinedProps({ ...swapCompletePacketBody, errorMessage: undefined })));
-    testInvalidPacket(new packets.SwapCompletePacket(removeUndefinedProps({ ...swapCompletePacketBody, rHash: undefined })));
+    testValidPacket(new packets.SwapFailedPacket(removeUndefinedProps({ ...swapFailedPacketBody, errorMessage: undefined })));
+    testInvalidPacket(new packets.SwapFailedPacket(removeUndefinedProps({ ...swapFailedPacketBody, rHash: undefined })));
+    testInvalidPacket(new packets.SwapFailedPacket(removeUndefinedProps({ ...swapFailedPacketBody, failureReason: undefined })));
 
   });
   describe('test TCP segmentation/concatenation support', () => {


### PR DESCRIPTION
This is a followup to #753 which includes breaking changes. Here's an overview of what it changes:

- Adds the `failureReason` field to the `SwapDeal` database model as well as the `SwapFailed` packet. It removes the `PeerFailedSwap` failure reason, and assigns swaps the failure reason specified by the peer in cases when the peer fails the swap. It adds a `PaymentHashReuse` reason which was missing to cover all current swap failure reasons.
- Tweaks the Parser tests to verify parsed packets with the
stable `stringify` method we use when hashing packets. This was done to
work around issues where the parsed packet did not deeply equal the
original packet because of the presence of an undefined `failureReason`.
- Renames the `errorReason` swap deal property to `errorMessage` to help differentiate it from `failureReason` and describe it as a field for details about why a swap failed or what caused an error. It also makes it optional on the `SwapFailed` packet to accommodate cases where there are no relevant details to include besides the `failureReason`.
