### PR TITLE
fix(p2p): order invalidation packet

### DIFF
--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -14,6 +14,7 @@ export const reputationEventWeight = {
   [ReputationEvent.SwapSuccess]: 1,
   [ReputationEvent.InvalidPacket]: -10,
   [ReputationEvent.UnknownPacketType]: -20,
+  [ReputationEvent.PacketDataIntegrityError]: -20,
   [ReputationEvent.MaxParserBufferSizeExceeded]: -20,
 };
 

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -498,6 +498,10 @@ class Peer extends EventEmitter {
           this.logger.warn(`parser: unknown peer packet type: ${err.payload}`);
           this.emit('reputation', ReputationEvent.UnknownPacketType);
           break;
+        case ParserErrorType.DataIntegrityError:
+          this.logger.warn(`parser: packet data integrity error: ${err.payload}`);
+          this.emit('reputation', ReputationEvent.PacketDataIntegrityError);
+          break;
         case ParserErrorType.MaxBufferSizeExceeded:
           this.logger.warn(`parser: max buffer size exceeded: ${err.payload}`);
           this.emit('reputation', ReputationEvent.MaxParserBufferSizeExceeded);

--- a/lib/p2p/packets/types/OrderInvalidationPacket.ts
+++ b/lib/p2p/packets/types/OrderInvalidationPacket.ts
@@ -29,8 +29,8 @@ class OrderInvalidationPacket extends Packet<OrderInvalidationPacketBody> {
     );
   }
 
-  private static convert = (obj: pb.OrderInvalidationPacket.AsObject): OrderPacket => {
-    return new OrderPacket({
+  private static convert = (obj: pb.OrderInvalidationPacket.AsObject): OrderInvalidationPacket => {
+    return new OrderInvalidationPacket({
       header: {
         id: obj.id,
         hash: obj.hash,

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -60,6 +60,7 @@ export enum ReputationEvent {
   MaxParserBufferSizeExceeded = 5,
   InvalidPacket = 6,
   UnknownPacketType = 7,
+  PacketDataIntegrityError = 8,
 }
 
 export enum SwapFailureReason {

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -36,8 +36,9 @@ describe('Parser', () => {
     return new Promise((resolve, reject) => {
       wait(packets.length)
         .then((parsedPackets) => {
-          for (let i = 0; i <= packets.length; i += 1) {
+          for (let i = 0; i < packets.length; i += 1) {
             expect(packets[i]).to.deep.equal(parsedPackets[i]);
+            expect(packets[i].type).to.equal(parsedPackets[i].type);
           }
           resolve();
         })


### PR DESCRIPTION
* fix typing mismatch in order invalidation conversion return type
* fix the tests to be able to find such problems
* adding data integrity errors logging/penalization (taken from #756)

Still need to check if it actually solves #767 or that we have another problem.