### PR TITLE
improved streamOrders #687

### DIFF
--- a/lib/cli/commands/subscribeorders.ts
+++ b/lib/cli/commands/subscribeorders.ts
@@ -15,6 +15,22 @@ export const builder = {
 };
 
 export const handler = (argv: Arguments) => {
+  ensureConnection(argv, true);
+};
+
+const ensureConnection = (argv: Arguments, printError?: boolean) => {
+  loadXudClient(argv).getInfo(new xudrpc.GetInfoRequest(), (error: Error | null) => {
+    if (error) {
+      if (printError) console.error(`${error.name}: ${error.message}`);
+      setTimeout(ensureConnection.bind(undefined, argv), 3000);
+    } else {
+      console.log('Successfully connected, subscribing for orders');
+      subscribeOrders(argv);
+    }
+  });
+};
+
+const subscribeOrders = (argv: Arguments) =>  {
   const addedOrdersRequest = new xudrpc.SubscribeAddedOrdersRequest();
   addedOrdersRequest.setExisting(argv.existing);
   const addedOrdersSubscription = loadXudClient(argv).subscribeAddedOrders(addedOrdersRequest);
@@ -22,13 +38,28 @@ export const handler = (argv: Arguments) => {
     console.log(`Order added: ${JSON.stringify(order.toObject())}`);
   });
 
+  // adding end, close, error events only once,
+  // since they'll be thrown for three of subscriptions in the corresponding cases, catching once is enough.
+  addedOrdersSubscription.on('end', ensureConnection.bind(undefined, argv, true));
+  addedOrdersSubscription.on('close', ensureConnection.bind(undefined, argv, true));
+  addedOrdersSubscription.on('error', (err: Error) => {
+    console.log(`Unexpected error occured: ${JSON.stringify(err)}, retrying to connect`);
+    ensureConnection(argv);
+  });
+
   const removedOrdersSubscription = loadXudClient(argv).subscribeRemovedOrders(new xudrpc.SubscribeRemovedOrdersRequest());
   removedOrdersSubscription.on('data', (orderRemoval: xudrpc.OrderRemoval) => {
     console.log(`Order removed: ${JSON.stringify(orderRemoval.toObject())}`);
   });
 
+  // prevent exiting and do nothing, it's already cached above.
+  removedOrdersSubscription.on('error', () => {});
+
   const swapsSubscription = loadXudClient(argv).subscribeSwaps(new xudrpc.SubscribeSwapsRequest());
   swapsSubscription.on('data', (swapResult: xudrpc.SwapResult) => {
     console.log(`Order swapped: ${JSON.stringify(swapResult.toObject())}`);
   });
+
+  // prevent exiting and do nothing, it's already cached above.
+  swapsSubscription.on('error', () => {});
 };


### PR DESCRIPTION
Hello again,

I was trying to work on new order types but since there're lots of struggles there I wanted to focus something else, as requested by @offerm I've implemented all the following changes;

- [x] a. allow it to start before xud. streamorders should wait for xud to start and not issue an error. It is OK to issue a warn/info for waiting for XUD.
- [x] b. print a line upon connection 
- [x] c. upon termination of xud or any other RPC error - reconnect to xud (wait if xud is not available. 
- [x] d. upon connection to xud - print existing orders.

**In a technical overview**;  I've implemented those by calling `GetInfo` to ensure connection and if there's no `xud` node running then I'm trying to connect in `3 seconds` (let me know if you want to adjust time) This seemed to be easiest way to me to implement such logic. Btw. error messages are not being printed every 3 seconds it's only being printed at first. 
