### PR TITLE
 feat: parse uri without port

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -6,7 +6,7 @@ import RaidenClient, { RaidenInfo } from '../raidenclient/RaidenClient';
 import { EventEmitter } from 'events';
 import errors from './errors';
 import { SwapClients, OrderSide, SwapRole } from '../types/enums';
-import { parseUri, getUri, UriParts } from '../utils/utils';
+import { parseUri, toUri, UriParts } from '../utils/uriUtils';
 import * as lndrpc from '../proto/lndrpc_pb';
 import { Pair, Order, OrderPortion } from '../types/orders';
 import { PlaceOrderEvent } from '../types/orderBook';
@@ -228,7 +228,7 @@ class Service extends EventEmitter {
 
     if (addresses && addresses.length > 0) {
       addresses.forEach((address) => {
-        uris.push(getUri({ nodePubKey, host: address.host, port: address.port }));
+        uris.push(toUri({ nodePubKey, host: address.host, port: address.port }));
       });
     }
 

--- a/lib/utils/uriUtils.ts
+++ b/lib/utils/uriUtils.ts
@@ -1,0 +1,35 @@
+import assert = require('assert');
+
+export type UriParts = {
+  nodePubKey: string;
+  host: string;
+  port: number;
+};
+
+/**
+ * Creates a URI string from the public key, host and port.
+ */
+export const toUri = (uriParts: UriParts): string => {
+  const { nodePubKey, host, port } = uriParts;
+  return `${nodePubKey}@${host}:${port}`;
+};
+
+/**
+ * Splits a URI in the [pubkey]@[host]:[port] format into the public key, host and port components.
+ * If port is not present in the URI, it defaults to 8885.
+ */
+export const parseUri = (uri: string): UriParts => {
+  // A regex that splits the string by the symbols "@" and ":"
+  const split = uri.split(/[@:]+/);
+
+  assert(split.length === 3 || split.length === 2);
+
+  const port = split[2] !== undefined ? Number(split[2]) : 8885;
+  assert(!isNaN(port));
+
+  return {
+    port,
+    nodePubKey: split[0],
+    host: split[1],
+  };
+};

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,16 +1,9 @@
 import http from 'http';
 import p2pErrors from '../p2p/errors';
-import { assert } from 'chai';
 import { Pair } from '../types/orders';
 import crypto from 'crypto';
 import { promisify } from 'util';
 import moment from 'moment';
-
-export type UriParts = {
-  nodePubKey: string;
-  host: string;
-  port: number;
-};
 
 /**
  * Gets the external IP of the node.
@@ -36,30 +29,6 @@ export const getExternalIp = () => {
       reject(p2pErrors.EXTERNAL_IP_UNRETRIEVABLE(err));
     });
   });
-};
-
-/**
- * Creates a URI from the public key, host and port.
- */
-export const getUri = (uriParts: UriParts): string => {
-  const { nodePubKey, host, port } = uriParts;
-  return `${nodePubKey}@${host}:${port}`;
-};
-
-/**
- * Splits a URI into the public key, host and port.
- */
-export const parseUri = (uri: string): UriParts => {
-  // A regex that splits the string by the symbols "@" and ":"
-  const split = uri.split(/[@:]+/);
-
-  assert(split.length === 3);
-
-  return {
-    nodePubKey: split[0],
-    host: split[1],
-    port: Number(split[2]),
-  };
 };
 
 /**

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -1,7 +1,7 @@
 import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
-import { getUri } from '../../lib/utils/utils';
+import { toUri } from '../../lib/utils/uriUtils';
 import { getUnusedPort } from '../utils';
 import { DisconnectionReason, ReputationEvent } from '../../lib/types/enums';
 
@@ -51,8 +51,8 @@ describe('P2P Sanity Tests', () => {
     await Promise.all([nodeOne.start(nodeOneConfig), nodeTwo.start(nodeTwoConfig)]);
 
     nodeTwoPort = nodeTwo['pool']['listenPort']!;
-    nodeOneUri = getUri({ nodePubKey: nodeOne.nodePubKey, host: 'localhost', port: nodeOne['pool']['listenPort']! });
-    nodeTwoUri = getUri({ nodePubKey: nodeTwo.nodePubKey, host: 'localhost', port: nodeTwoPort });
+    nodeOneUri = toUri({ nodePubKey: nodeOne.nodePubKey, host: 'localhost', port: nodeOne['pool']['listenPort']! });
+    nodeTwoUri = toUri({ nodePubKey: nodeTwo.nodePubKey, host: 'localhost', port: nodeTwoPort });
   });
 
   it('should connect successfully', async () => {
@@ -77,7 +77,7 @@ describe('P2P Sanity Tests', () => {
   });
 
   it('should fail when connecting to an unexpected node pub key', async () => {
-    const connectPromise = nodeOne.service.connect({ nodeUri: getUri({
+    const connectPromise = nodeOne.service.connect({ nodeUri: toUri({
       nodePubKey: 'thewrongpubkey',
       host: 'localhost',
       port: nodeTwoPort,
@@ -95,7 +95,7 @@ describe('P2P Sanity Tests', () => {
 
   it('should fail connecting to a non-existing node', async () => {
     const port = await getUnusedPort();
-    const connectPromise = nodeOne.service.connect({ nodeUri: getUri({ port, nodePubKey: 'notarealnodepubkey', host: 'localhost' }) });
+    const connectPromise = nodeOne.service.connect({ nodeUri: toUri({ port, nodePubKey: 'notarealnodepubkey', host: 'localhost' }) });
     await expect(connectPromise).to.be.rejectedWith(`could not connect to peer at localhost:${port}`);
   });
 

--- a/test/unit/NodeKey.spec.ts
+++ b/test/unit/NodeKey.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import chaiAsPromised = require('chai-as-promised');
 import NodeKey from '../../lib/nodekey/NodeKey';
 import secp256k1 from 'secp256k1';
 

--- a/test/unit/uriUtils.spec.ts
+++ b/test/unit/uriUtils.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { parseUri, toUri, UriParts } from '../../lib/utils/uriUtils';
+
+describe('parseUri', () => {
+  it('should parse a valid uri', async () => {
+    const nodePubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+    const host = '127.0.0.1';
+    const port = 9885;
+    const uriParts = parseUri(`${nodePubKey}@${host}:${port}`);
+    expect(uriParts.nodePubKey).to.equal(nodePubKey);
+    expect(uriParts.host).to.equal(host);
+    expect(uriParts.port).to.equal(port);
+  });
+
+  it('should parse a valid uri without a port specified', async () => {
+    const nodePubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+    const host = 'localhost';
+    const uriParts = parseUri(`${nodePubKey}@${host}`);
+    expect(uriParts.nodePubKey).to.equal(nodePubKey);
+    expect(uriParts.host).to.equal(host);
+    expect(uriParts.port).to.equal(8885);
+  });
+
+  it('should error a uri without a host specified', async () => {
+    const nodePubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+    expect(() => parseUri(`${nodePubKey}`)).to.throw();
+  });
+
+  it('should error a uri without with extra parts', async () => {
+    const nodePubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+    const host = '127.0.0.1';
+    const port = 9885;
+    expect(() => parseUri(`${nodePubKey}@${host}:${port}:extra@part`)).to.throw();
+  });
+
+  it('should error a uri with a non-numeric port', async () => {
+    const nodePubKey = '03029c6a4d80c91da9e40529ec41c93b17cc9d7956b59c7d8334b0318d4a86aef8';
+    const host = '127.0.0.1';
+    const port = 'notanumber';
+    expect(() => parseUri(`${nodePubKey}@${host}:${port}`)).to.throw();
+  });
+});


### PR DESCRIPTION
This allows for node connection uris without a specified port to be parsed and assigned a default port of 8885. This allows the port to be left off in the rpc `Connect` call when connecting to the default port.