### PR TITLE
feat(swaps): timeout stalled swaps

### DIFF
--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -52,7 +52,7 @@ export type SwapDeal = {
   makerToTakerRoutes?: Route[];
   createTime: number;
   executeTime?: number;
-  completeTime?: number
+  completeTime?: number;
 };
 
 /** The result of a successful swap. */

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -84,6 +84,7 @@ export enum SwapFailureReason {
   InvalidResolveRequest = 8,
   /** The swap request attempts to reuse a payment hash. */
   PaymentHashReuse = 9,
+  Timeout = 10,
 }
 
 export enum DisconnectionReason {

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -84,7 +84,10 @@ export enum SwapFailureReason {
   InvalidResolveRequest = 8,
   /** The swap request attempts to reuse a payment hash. */
   PaymentHashReuse = 9,
-  Timeout = 10,
+  /** The swap timed out while we were waiting for it to complete execution. */
+  SwapTimedOut = 10,
+  /** The deal timed out while we were waiting for the peer to respond to our swap request. */
+  DealTimedOut = 11,
 }
 
 export enum DisconnectionReason {


### PR DESCRIPTION
This adds timeouts to all swap deals to fail them after a certain amount of time. Current time limits are set to 10 seconds for a swap to be accepted and 30 seconds for a swap to be completed once accepted. Previously, swaps that stalled out due to an unresponsive peer or swap client would last indefinitely and the corresponding order would remain on hold.

Closes #653.