### PR TITLE
feat(rpc): failed swaps for PlaceOrder

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,13 +52,14 @@
     - [SubscribeAddedOrdersRequest](#xudrpc.SubscribeAddedOrdersRequest)
     - [SubscribeRemovedOrdersRequest](#xudrpc.SubscribeRemovedOrdersRequest)
     - [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest)
-    - [SwapResult](#xudrpc.SwapResult)
+    - [SwapFailure](#xudrpc.SwapFailure)
+    - [SwapSuccess](#xudrpc.SwapSuccess)
     - [UnbanRequest](#xudrpc.UnbanRequest)
     - [UnbanResponse](#xudrpc.UnbanResponse)
   
     - [AddCurrencyRequest.SwapClient](#xudrpc.AddCurrencyRequest.SwapClient)
     - [OrderSide](#xudrpc.OrderSide)
-    - [SwapResult.Role](#xudrpc.SwapResult.Role)
+    - [SwapSuccess.Role](#xudrpc.SwapSuccess.Role)
   
   
     - [Xud](#xudrpc.Xud)
@@ -589,8 +590,9 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | internal_match | [Order](#xudrpc.Order) |  | An own orders (or portions thereof) that matched the newly placed order. |
-| swap_result | [SwapResult](#xudrpc.SwapResult) |  | A swap results of peer orders that matched the newly placed order. |
+| swap_success | [SwapSuccess](#xudrpc.SwapSuccess) |  | A swap results of peer orders that matched the newly placed order. |
 | remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
+| swap_failure | [SwapFailure](#xudrpc.SwapFailure) |  | A swap attempt that failed. |
 
 
 
@@ -625,7 +627,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | internal_matches | [Order](#xudrpc.Order) | repeated | A list of own orders (or portions thereof) that matched the newly placed order. |
-| swap_results | [SwapResult](#xudrpc.SwapResult) | repeated | A list of swap results of peer orders that matched the newly placed order. |
+| swap_successes | [SwapSuccess](#xudrpc.SwapSuccess) | repeated | A list of swap results of peer orders that matched the newly placed order. |
 | remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
 
 
@@ -791,9 +793,27 @@
 
 
 
-<a name="xudrpc.SwapResult"></a>
+<a name="xudrpc.SwapFailure"></a>
 
-### SwapResult
+### SwapFailure
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| order_id | [string](#string) |  | The global UUID for the order that failed the swap. |
+| pair_id | [string](#string) |  | The trading pair that the swap is for. |
+| quantity | [double](#double) |  | The order quantity that was attempted to be swapped. |
+| peer_pub_key | [string](#string) |  | The node pub key of the peer that we attempted to swap with. |
+
+
+
+
+
+
+<a name="xudrpc.SwapSuccess"></a>
+
+### SwapSuccess
 
 
 
@@ -801,13 +821,13 @@
 | ----- | ---- | ----- | ----------- |
 | order_id | [string](#string) |  | The global UUID for the order that was swapped. |
 | local_id | [string](#string) |  | The local id for the order that was swapped. |
-| pair_id | [string](#string) |  | The trading pair that this order is for. |
+| pair_id | [string](#string) |  | The trading pair that the swap is for. |
 | quantity | [double](#double) |  | The order quantity that was swapped. |
 | r_hash | [string](#string) |  | The hex-encoded payment hash for the swaps. |
 | amount_received | [int64](#int64) |  | The amount of subunits (satoshis) received. |
 | amount_sent | [int64](#int64) |  | The amount of subunits (satoshis) sent. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer that executed this order. |
-| role | [SwapResult.Role](#xudrpc.SwapResult.Role) |  | Our role in the swap, either MAKER or TAKER. |
+| role | [SwapSuccess.Role](#xudrpc.SwapSuccess.Role) |  | Our role in the swap, either MAKER or TAKER. |
 | currency_received | [string](#string) |  | The ticker symbol of the currency received. |
 | currency_sent | [string](#string) |  | The ticker symbol of the currency sent. |
 
@@ -868,9 +888,9 @@
 
 
 
-<a name="xudrpc.SwapResult.Role"></a>
+<a name="xudrpc.SwapSuccess.Role"></a>
 
-### SwapResult.Role
+### SwapSuccess.Role
 
 
 | Name | Number | Description |
@@ -906,13 +926,13 @@
 | ListPeers | [ListPeersRequest](#xudrpc.ListPeersRequest) | [ListPeersResponse](#xudrpc.ListPeersResponse) | Gets a list of connected peers. |
 | PlaceOrder | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderEvent](#xudrpc.PlaceOrderEvent) stream | Adds an order to the order book. If price is zero or unspecified a market order will get added. |
 | PlaceOrderSync | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderResponse](#xudrpc.PlaceOrderResponse) | The synchronous non-streaming version of PlaceOrder. |
-| ExecuteSwap | [ExecuteSwapRequest](#xudrpc.ExecuteSwapRequest) | [SwapResult](#xudrpc.SwapResult) | Execute a swap on a maker peer order |
+| ExecuteSwap | [ExecuteSwapRequest](#xudrpc.ExecuteSwapRequest) | [SwapSuccess](#xudrpc.SwapSuccess) | Execute a swap on a maker peer order |
 | RemoveCurrency | [RemoveCurrencyRequest](#xudrpc.RemoveCurrencyRequest) | [RemoveCurrencyResponse](#xudrpc.RemoveCurrencyResponse) | Removes a currency from the list of supported currencies. Only currencies that are not in use for any currently supported trading pairs may be removed. Once removed, the currency can no longer be used for any supported trading pairs. |
 | RemovePair | [RemovePairRequest](#xudrpc.RemovePairRequest) | [RemovePairResponse](#xudrpc.RemovePairResponse) | Removes a trading pair from the list of currently supported trading pair. This call will effectively cancel any standing orders for that trading pair. Peers are informed when a pair is no longer supported so that they will know to stop sending orders for it. |
 | Shutdown | [ShutdownRequest](#xudrpc.ShutdownRequest) | [ShutdownResponse](#xudrpc.ShutdownResponse) | Begin gracefully shutting down xud. |
 | SubscribeAddedOrders | [SubscribeAddedOrdersRequest](#xudrpc.SubscribeAddedOrdersRequest) | [Order](#xudrpc.Order) stream | Subscribes to orders being added to the order book. This call, together with SubscribeRemovedOrders, allows the client to maintain an up-to-date view of the order book. For example, an exchange that wants to show its users a real time list of the orders available to them would subscribe to this streaming call to be alerted of new orders as they become available for trading. |
 | SubscribeRemovedOrders | [SubscribeRemovedOrdersRequest](#xudrpc.SubscribeRemovedOrdersRequest) | [OrderRemoval](#xudrpc.OrderRemoval) stream | Subscribes to orders being removed - either in full or in part - from the order book. This call, together with SubscribeAddedOrders, allows the client to maintain an up-to-date view of the order book. For example, an exchange that wants to show its users a real time list of the orders available to them would subscribe to this streaming call to be alerted when part or all of an existing order is no longer available for trading. |
-| SubscribeSwaps | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapResult](#xudrpc.SwapResult) stream | Subscribes to completed swaps. By default, only swaps that are initiated by a remote peer are transmitted unless a flag is set to include swaps initiated by the local node. This call allows the client to get real-time notifications when its orders are filled by a peer. It can be used for tracking order executions, updating balances, and informing a trader when one of their orders is settled through the Exchange Union network. |
+| SubscribeSwaps | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapSuccess](#xudrpc.SwapSuccess) stream | Subscribes to completed swaps. By default, only swaps that are initiated by a remote peer are transmitted unless a flag is set to include swaps initiated by the local node. This call allows the client to get real-time notifications when its orders are filled by a peer. It can be used for tracking order executions, updating balances, and informing a trader when one of their orders is settled through the Exchange Union network. |
 
  
 

--- a/lib/cli/commands/streamorders.ts
+++ b/lib/cli/commands/streamorders.ts
@@ -61,7 +61,7 @@ const streamOrders = (argv: Arguments) =>  {
   const swapsRequest = new xudrpc.SubscribeSwapsRequest();
   swapsRequest.setIncludeTaker(true);
   const swapsSubscription = loadXudClient(argv).subscribeSwaps(swapsRequest);
-  swapsSubscription.on('data', (swapResult: xudrpc.SwapResult) => {
+  swapsSubscription.on('data', (swapResult: xudrpc.SwapSuccess) => {
     console.log(`Order swapped: ${JSON.stringify(swapResult.toObject())}`);
   });
 

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -174,7 +174,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/xudrpcSwapResult"
+              "$ref": "#/definitions/xudrpcSwapSuccess"
             }
           }
         },
@@ -518,7 +518,7 @@
           "200": {
             "description": "A successful response.(streaming responses)",
             "schema": {
-              "$ref": "#/definitions/xudrpcSwapResult"
+              "$ref": "#/definitions/xudrpcSwapSuccess"
             }
           }
         },
@@ -574,7 +574,7 @@
       ],
       "default": "LND"
     },
-    "SwapResultRole": {
+    "SwapSuccessRole": {
       "type": "string",
       "enum": [
         "TAKER",
@@ -1023,13 +1023,17 @@
           "$ref": "#/definitions/xudrpcOrder",
           "description": "An own orders (or portions thereof) that matched the newly placed order."
         },
-        "swap_result": {
-          "$ref": "#/definitions/xudrpcSwapResult",
+        "swap_success": {
+          "$ref": "#/definitions/xudrpcSwapSuccess",
           "description": "A swap results of peer orders that matched the newly placed order."
         },
         "remaining_order": {
           "$ref": "#/definitions/xudrpcOrder",
           "description": "The remaining portion of the order, after matches, that enters the order book."
+        },
+        "swap_failure": {
+          "$ref": "#/definitions/xudrpcSwapFailure",
+          "description": "A swap attempt that failed."
         }
       }
     },
@@ -1070,10 +1074,10 @@
           },
           "description": "A list of own orders (or portions thereof) that matched the newly placed order."
         },
-        "swap_results": {
+        "swap_successes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/xudrpcSwapResult"
+            "$ref": "#/definitions/xudrpcSwapSuccess"
           },
           "description": "A list of swap results of peer orders that matched the newly placed order."
         },
@@ -1150,7 +1154,29 @@
     "xudrpcShutdownResponse": {
       "type": "object"
     },
-    "xudrpcSwapResult": {
+    "xudrpcSwapFailure": {
+      "type": "object",
+      "properties": {
+        "order_id": {
+          "type": "string",
+          "description": "The global UUID for the order that failed the swap."
+        },
+        "pair_id": {
+          "type": "string",
+          "description": "The trading pair that the swap is for."
+        },
+        "quantity": {
+          "type": "number",
+          "format": "double",
+          "description": "The order quantity that was attempted to be swapped."
+        },
+        "peer_pub_key": {
+          "type": "string",
+          "description": "The node pub key of the peer that we attempted to swap with."
+        }
+      }
+    },
+    "xudrpcSwapSuccess": {
       "type": "object",
       "properties": {
         "order_id": {
@@ -1163,7 +1189,7 @@
         },
         "pair_id": {
           "type": "string",
-          "description": "The trading pair that this order is for."
+          "description": "The trading pair that the swap is for."
         },
         "quantity": {
           "type": "number",
@@ -1189,7 +1215,7 @@
           "description": "The node pub key of the peer that executed this order."
         },
         "role": {
-          "$ref": "#/definitions/SwapResultRole",
+          "$ref": "#/definitions/SwapSuccessRole",
           "description": "Our role in the swap, either MAKER or TAKER."
         },
         "currency_received": {

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -455,15 +455,15 @@ function deserialize_xudrpc_SubscribeSwapsRequest(buffer_arg) {
   return xudrpc_pb.SubscribeSwapsRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_xudrpc_SwapResult(arg) {
-  if (!(arg instanceof xudrpc_pb.SwapResult)) {
-    throw new Error('Expected argument of type xudrpc.SwapResult');
+function serialize_xudrpc_SwapSuccess(arg) {
+  if (!(arg instanceof xudrpc_pb.SwapSuccess)) {
+    throw new Error('Expected argument of type xudrpc.SwapSuccess');
   }
   return Buffer.from(arg.serializeBinary());
 }
 
-function deserialize_xudrpc_SwapResult(buffer_arg) {
-  return xudrpc_pb.SwapResult.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_xudrpc_SwapSuccess(buffer_arg) {
+  return xudrpc_pb.SwapSuccess.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
 function serialize_xudrpc_UnbanRequest(arg) {
@@ -690,11 +690,11 @@ var XudService = exports.XudService = {
     requestStream: false,
     responseStream: false,
     requestType: xudrpc_pb.ExecuteSwapRequest,
-    responseType: xudrpc_pb.SwapResult,
+    responseType: xudrpc_pb.SwapSuccess,
     requestSerialize: serialize_xudrpc_ExecuteSwapRequest,
     requestDeserialize: deserialize_xudrpc_ExecuteSwapRequest,
-    responseSerialize: serialize_xudrpc_SwapResult,
-    responseDeserialize: deserialize_xudrpc_SwapResult,
+    responseSerialize: serialize_xudrpc_SwapSuccess,
+    responseDeserialize: deserialize_xudrpc_SwapSuccess,
   },
   // Removes a currency from the list of supported currencies. Only currencies that are not in use
   // for any currently supported trading pairs may be removed. Once removed, the currency can no
@@ -777,11 +777,11 @@ var XudService = exports.XudService = {
     requestStream: false,
     responseStream: true,
     requestType: xudrpc_pb.SubscribeSwapsRequest,
-    responseType: xudrpc_pb.SwapResult,
+    responseType: xudrpc_pb.SwapSuccess,
     requestSerialize: serialize_xudrpc_SubscribeSwapsRequest,
     requestDeserialize: deserialize_xudrpc_SubscribeSwapsRequest,
-    responseSerialize: serialize_xudrpc_SwapResult,
-    responseDeserialize: deserialize_xudrpc_SwapResult,
+    responseSerialize: serialize_xudrpc_SwapSuccess,
+    responseDeserialize: deserialize_xudrpc_SwapSuccess,
   },
 };
 

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -97,43 +97,39 @@ export namespace AddPairResponse {
   }
 }
 
-export class RemoveOrderRequest extends jspb.Message {
-  getOrderId(): string;
-  setOrderId(value: string): void;
+export class BanRequest extends jspb.Message {
+  getNodePubKey(): string;
+  setNodePubKey(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): RemoveOrderRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: RemoveOrderRequest): RemoveOrderRequest.AsObject;
+  toObject(includeInstance?: boolean): BanRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: BanRequest): BanRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: RemoveOrderRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): RemoveOrderRequest;
-  static deserializeBinaryFromReader(message: RemoveOrderRequest, reader: jspb.BinaryReader): RemoveOrderRequest;
+  static serializeBinaryToWriter(message: BanRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): BanRequest;
+  static deserializeBinaryFromReader(message: BanRequest, reader: jspb.BinaryReader): BanRequest;
 }
 
-export namespace RemoveOrderRequest {
+export namespace BanRequest {
   export type AsObject = {
-    orderId: string,
+    nodePubKey: string,
   }
 }
 
-export class RemoveOrderResponse extends jspb.Message {
-  getQuantityOnHold(): number;
-  setQuantityOnHold(value: number): void;
-
+export class BanResponse extends jspb.Message {
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): RemoveOrderResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: RemoveOrderResponse): RemoveOrderResponse.AsObject;
+  toObject(includeInstance?: boolean): BanResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: BanResponse): BanResponse.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: RemoveOrderResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): RemoveOrderResponse;
-  static deserializeBinaryFromReader(message: RemoveOrderResponse, reader: jspb.BinaryReader): RemoveOrderResponse;
+  static serializeBinaryToWriter(message: BanResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): BanResponse;
+  static deserializeBinaryFromReader(message: BanResponse, reader: jspb.BinaryReader): BanResponse;
 }
 
-export namespace RemoveOrderResponse {
+export namespace BanResponse {
   export type AsObject = {
-    quantityOnHold: number,
   }
 }
 
@@ -236,39 +232,67 @@ export namespace ConnectResponse {
   }
 }
 
-export class BanRequest extends jspb.Message {
-  getNodePubKey(): string;
-  setNodePubKey(value: string): void;
+export class ExecuteSwapRequest extends jspb.Message {
+  getOrderId(): string;
+  setOrderId(value: string): void;
+
+  getPairId(): string;
+  setPairId(value: string): void;
+
+  getPeerPubKey(): string;
+  setPeerPubKey(value: string): void;
+
+  getQuantity(): number;
+  setQuantity(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): BanRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: BanRequest): BanRequest.AsObject;
+  toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: BanRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): BanRequest;
-  static deserializeBinaryFromReader(message: BanRequest, reader: jspb.BinaryReader): BanRequest;
+  static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
+  static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
 }
 
-export namespace BanRequest {
+export namespace ExecuteSwapRequest {
   export type AsObject = {
-    nodePubKey: string,
+    orderId: string,
+    pairId: string,
+    peerPubKey: string,
+    quantity: number,
   }
 }
 
-export class BanResponse extends jspb.Message {
+export class SwapFailure extends jspb.Message {
+  getOrderId(): string;
+  setOrderId(value: string): void;
+
+  getPairId(): string;
+  setPairId(value: string): void;
+
+  getQuantity(): number;
+  setQuantity(value: number): void;
+
+  getPeerPubKey(): string;
+  setPeerPubKey(value: string): void;
+
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): BanResponse.AsObject;
-  static toObject(includeInstance: boolean, msg: BanResponse): BanResponse.AsObject;
+  toObject(includeInstance?: boolean): SwapFailure.AsObject;
+  static toObject(includeInstance: boolean, msg: SwapFailure): SwapFailure.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: BanResponse, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): BanResponse;
-  static deserializeBinaryFromReader(message: BanResponse, reader: jspb.BinaryReader): BanResponse;
+  static serializeBinaryToWriter(message: SwapFailure, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SwapFailure;
+  static deserializeBinaryFromReader(message: SwapFailure, reader: jspb.BinaryReader): SwapFailure;
 }
 
-export namespace BanResponse {
+export namespace SwapFailure {
   export type AsObject = {
+    orderId: string,
+    pairId: string,
+    quantity: number,
+    peerPubKey: string,
   }
 }
 
@@ -876,10 +900,10 @@ export class PlaceOrderResponse extends jspb.Message {
   setInternalMatchesList(value: Array<Order>): void;
   addInternalMatches(value?: Order, index?: number): Order;
 
-  clearSwapResultsList(): void;
-  getSwapResultsList(): Array<SwapResult>;
-  setSwapResultsList(value: Array<SwapResult>): void;
-  addSwapResults(value?: SwapResult, index?: number): SwapResult;
+  clearSwapSuccessesList(): void;
+  getSwapSuccessesList(): Array<SwapSuccess>;
+  setSwapSuccessesList(value: Array<SwapSuccess>): void;
+  addSwapSuccesses(value?: SwapSuccess, index?: number): SwapSuccess;
 
   hasRemainingOrder(): boolean;
   clearRemainingOrder(): void;
@@ -899,7 +923,7 @@ export class PlaceOrderResponse extends jspb.Message {
 export namespace PlaceOrderResponse {
   export type AsObject = {
     internalMatchesList: Array<Order.AsObject>,
-    swapResultsList: Array<SwapResult.AsObject>,
+    swapSuccessesList: Array<SwapSuccess.AsObject>,
     remainingOrder?: Order.AsObject,
   }
 }
@@ -910,15 +934,20 @@ export class PlaceOrderEvent extends jspb.Message {
   getInternalMatch(): Order | undefined;
   setInternalMatch(value?: Order): void;
 
-  hasSwapResult(): boolean;
-  clearSwapResult(): void;
-  getSwapResult(): SwapResult | undefined;
-  setSwapResult(value?: SwapResult): void;
+  hasSwapSuccess(): boolean;
+  clearSwapSuccess(): void;
+  getSwapSuccess(): SwapSuccess | undefined;
+  setSwapSuccess(value?: SwapSuccess): void;
 
   hasRemainingOrder(): boolean;
   clearRemainingOrder(): void;
   getRemainingOrder(): Order | undefined;
   setRemainingOrder(value?: Order): void;
+
+  hasSwapFailure(): boolean;
+  clearSwapFailure(): void;
+  getSwapFailure(): SwapFailure | undefined;
+  setSwapFailure(value?: SwapFailure): void;
 
   getEventCase(): PlaceOrderEvent.EventCase;
   serializeBinary(): Uint8Array;
@@ -934,47 +963,17 @@ export class PlaceOrderEvent extends jspb.Message {
 export namespace PlaceOrderEvent {
   export type AsObject = {
     internalMatch?: Order.AsObject,
-    swapResult?: SwapResult.AsObject,
+    swapSuccess?: SwapSuccess.AsObject,
     remainingOrder?: Order.AsObject,
+    swapFailure?: SwapFailure.AsObject,
   }
 
   export enum EventCase {
     EVENT_NOT_SET = 0,
     INTERNAL_MATCH = 1,
-    SWAP_RESULT = 2,
+    SWAP_SUCCESS = 2,
     REMAINING_ORDER = 3,
-  }
-}
-
-export class ExecuteSwapRequest extends jspb.Message {
-  getOrderId(): string;
-  setOrderId(value: string): void;
-
-  getPairId(): string;
-  setPairId(value: string): void;
-
-  getPeerPubKey(): string;
-  setPeerPubKey(value: string): void;
-
-  getQuantity(): number;
-  setQuantity(value: number): void;
-
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): ExecuteSwapRequest.AsObject;
-  static toObject(includeInstance: boolean, msg: ExecuteSwapRequest): ExecuteSwapRequest.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: ExecuteSwapRequest, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): ExecuteSwapRequest;
-  static deserializeBinaryFromReader(message: ExecuteSwapRequest, reader: jspb.BinaryReader): ExecuteSwapRequest;
-}
-
-export namespace ExecuteSwapRequest {
-  export type AsObject = {
-    orderId: string,
-    pairId: string,
-    peerPubKey: string,
-    quantity: number,
+    SWAP_FAILURE = 4,
   }
 }
 
@@ -1043,6 +1042,46 @@ export class RemoveCurrencyResponse extends jspb.Message {
 
 export namespace RemoveCurrencyResponse {
   export type AsObject = {
+  }
+}
+
+export class RemoveOrderRequest extends jspb.Message {
+  getOrderId(): string;
+  setOrderId(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemoveOrderRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: RemoveOrderRequest): RemoveOrderRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemoveOrderRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemoveOrderRequest;
+  static deserializeBinaryFromReader(message: RemoveOrderRequest, reader: jspb.BinaryReader): RemoveOrderRequest;
+}
+
+export namespace RemoveOrderRequest {
+  export type AsObject = {
+    orderId: string,
+  }
+}
+
+export class RemoveOrderResponse extends jspb.Message {
+  getQuantityOnHold(): number;
+  setQuantityOnHold(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RemoveOrderResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: RemoveOrderResponse): RemoveOrderResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RemoveOrderResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RemoveOrderResponse;
+  static deserializeBinaryFromReader(message: RemoveOrderResponse, reader: jspb.BinaryReader): RemoveOrderResponse;
+}
+
+export namespace RemoveOrderResponse {
+  export type AsObject = {
+    quantityOnHold: number,
   }
 }
 
@@ -1170,7 +1209,7 @@ export namespace SubscribeSwapsRequest {
   }
 }
 
-export class SwapResult extends jspb.Message {
+export class SwapSuccess extends jspb.Message {
   getOrderId(): string;
   setOrderId(value: string): void;
 
@@ -1195,8 +1234,8 @@ export class SwapResult extends jspb.Message {
   getPeerPubKey(): string;
   setPeerPubKey(value: string): void;
 
-  getRole(): SwapResult.Role;
-  setRole(value: SwapResult.Role): void;
+  getRole(): SwapSuccess.Role;
+  setRole(value: SwapSuccess.Role): void;
 
   getCurrencyReceived(): string;
   setCurrencyReceived(value: string): void;
@@ -1205,16 +1244,16 @@ export class SwapResult extends jspb.Message {
   setCurrencySent(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SwapResult.AsObject;
-  static toObject(includeInstance: boolean, msg: SwapResult): SwapResult.AsObject;
+  toObject(includeInstance?: boolean): SwapSuccess.AsObject;
+  static toObject(includeInstance: boolean, msg: SwapSuccess): SwapSuccess.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SwapResult, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SwapResult;
-  static deserializeBinaryFromReader(message: SwapResult, reader: jspb.BinaryReader): SwapResult;
+  static serializeBinaryToWriter(message: SwapSuccess, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SwapSuccess;
+  static deserializeBinaryFromReader(message: SwapSuccess, reader: jspb.BinaryReader): SwapSuccess;
 }
 
-export namespace SwapResult {
+export namespace SwapSuccess {
   export type AsObject = {
     orderId: string,
     localId: string,
@@ -1224,7 +1263,7 @@ export namespace SwapResult {
     amountReceived: number,
     amountSent: number,
     peerPubKey: string,
-    role: SwapResult.Role,
+    role: SwapSuccess.Role,
     currencyReceived: string,
     currencySent: string,
   }

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -60,8 +60,9 @@ goog.exportSymbol('proto.xudrpc.ShutdownResponse', null, global);
 goog.exportSymbol('proto.xudrpc.SubscribeAddedOrdersRequest', null, global);
 goog.exportSymbol('proto.xudrpc.SubscribeRemovedOrdersRequest', null, global);
 goog.exportSymbol('proto.xudrpc.SubscribeSwapsRequest', null, global);
-goog.exportSymbol('proto.xudrpc.SwapResult', null, global);
-goog.exportSymbol('proto.xudrpc.SwapResult.Role', null, global);
+goog.exportSymbol('proto.xudrpc.SwapFailure', null, global);
+goog.exportSymbol('proto.xudrpc.SwapSuccess', null, global);
+goog.exportSymbol('proto.xudrpc.SwapSuccess.Role', null, global);
 goog.exportSymbol('proto.xudrpc.UnbanRequest', null, global);
 goog.exportSymbol('proto.xudrpc.UnbanResponse', null, global);
 
@@ -707,12 +708,12 @@ proto.xudrpc.AddPairResponse.serializeBinaryToWriter = function(message, writer)
  * @extends {jspb.Message}
  * @constructor
  */
-proto.xudrpc.RemoveOrderRequest = function(opt_data) {
+proto.xudrpc.BanRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.xudrpc.RemoveOrderRequest, jspb.Message);
+goog.inherits(proto.xudrpc.BanRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.xudrpc.RemoveOrderRequest.displayName = 'proto.xudrpc.RemoveOrderRequest';
+  proto.xudrpc.BanRequest.displayName = 'proto.xudrpc.BanRequest';
 }
 
 
@@ -727,8 +728,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.xudrpc.RemoveOrderRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.xudrpc.RemoveOrderRequest.toObject(opt_includeInstance, this);
+proto.xudrpc.BanRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.BanRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -737,13 +738,13 @@ proto.xudrpc.RemoveOrderRequest.prototype.toObject = function(opt_includeInstanc
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.xudrpc.RemoveOrderRequest} msg The msg instance to transform.
+ * @param {!proto.xudrpc.BanRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.RemoveOrderRequest.toObject = function(includeInstance, msg) {
+proto.xudrpc.BanRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    orderId: jspb.Message.getFieldWithDefault(msg, 1, "")
+    nodePubKey: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
 
   if (includeInstance) {
@@ -757,23 +758,23 @@ proto.xudrpc.RemoveOrderRequest.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.xudrpc.RemoveOrderRequest}
+ * @return {!proto.xudrpc.BanRequest}
  */
-proto.xudrpc.RemoveOrderRequest.deserializeBinary = function(bytes) {
+proto.xudrpc.BanRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.xudrpc.RemoveOrderRequest;
-  return proto.xudrpc.RemoveOrderRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.xudrpc.BanRequest;
+  return proto.xudrpc.BanRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.xudrpc.RemoveOrderRequest} msg The message object to deserialize into.
+ * @param {!proto.xudrpc.BanRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.xudrpc.RemoveOrderRequest}
+ * @return {!proto.xudrpc.BanRequest}
  */
-proto.xudrpc.RemoveOrderRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.xudrpc.BanRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -782,7 +783,7 @@ proto.xudrpc.RemoveOrderRequest.deserializeBinaryFromReader = function(msg, read
     switch (field) {
     case 1:
       var value = /** @type {string} */ (reader.readString());
-      msg.setOrderId(value);
+      msg.setNodePubKey(value);
       break;
     default:
       reader.skipField();
@@ -797,9 +798,9 @@ proto.xudrpc.RemoveOrderRequest.deserializeBinaryFromReader = function(msg, read
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.xudrpc.RemoveOrderRequest.prototype.serializeBinary = function() {
+proto.xudrpc.BanRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.xudrpc.RemoveOrderRequest.serializeBinaryToWriter(this, writer);
+  proto.xudrpc.BanRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -807,13 +808,13 @@ proto.xudrpc.RemoveOrderRequest.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.xudrpc.RemoveOrderRequest} message
+ * @param {!proto.xudrpc.BanRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.RemoveOrderRequest.serializeBinaryToWriter = function(message, writer) {
+proto.xudrpc.BanRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getOrderId();
+  f = message.getNodePubKey();
   if (f.length > 0) {
     writer.writeString(
       1,
@@ -824,16 +825,16 @@ proto.xudrpc.RemoveOrderRequest.serializeBinaryToWriter = function(message, writ
 
 
 /**
- * optional string order_id = 1;
+ * optional string node_pub_key = 1;
  * @return {string}
  */
-proto.xudrpc.RemoveOrderRequest.prototype.getOrderId = function() {
+proto.xudrpc.BanRequest.prototype.getNodePubKey = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.RemoveOrderRequest.prototype.setOrderId = function(value) {
+proto.xudrpc.BanRequest.prototype.setNodePubKey = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -849,12 +850,12 @@ proto.xudrpc.RemoveOrderRequest.prototype.setOrderId = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.xudrpc.RemoveOrderResponse = function(opt_data) {
+proto.xudrpc.BanResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.xudrpc.RemoveOrderResponse, jspb.Message);
+goog.inherits(proto.xudrpc.BanResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.xudrpc.RemoveOrderResponse.displayName = 'proto.xudrpc.RemoveOrderResponse';
+  proto.xudrpc.BanResponse.displayName = 'proto.xudrpc.BanResponse';
 }
 
 
@@ -869,8 +870,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.xudrpc.RemoveOrderResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.xudrpc.RemoveOrderResponse.toObject(opt_includeInstance, this);
+proto.xudrpc.BanResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.BanResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -879,13 +880,13 @@ proto.xudrpc.RemoveOrderResponse.prototype.toObject = function(opt_includeInstan
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.xudrpc.RemoveOrderResponse} msg The msg instance to transform.
+ * @param {!proto.xudrpc.BanResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.RemoveOrderResponse.toObject = function(includeInstance, msg) {
+proto.xudrpc.BanResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    quantityOnHold: +jspb.Message.getFieldWithDefault(msg, 1, 0.0)
+
   };
 
   if (includeInstance) {
@@ -899,33 +900,29 @@ proto.xudrpc.RemoveOrderResponse.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.xudrpc.RemoveOrderResponse}
+ * @return {!proto.xudrpc.BanResponse}
  */
-proto.xudrpc.RemoveOrderResponse.deserializeBinary = function(bytes) {
+proto.xudrpc.BanResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.xudrpc.RemoveOrderResponse;
-  return proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.xudrpc.BanResponse;
+  return proto.xudrpc.BanResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.xudrpc.RemoveOrderResponse} msg The message object to deserialize into.
+ * @param {!proto.xudrpc.BanResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.xudrpc.RemoveOrderResponse}
+ * @return {!proto.xudrpc.BanResponse}
  */
-proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.xudrpc.BanResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {number} */ (reader.readDouble());
-      msg.setQuantityOnHold(value);
-      break;
     default:
       reader.skipField();
       break;
@@ -939,9 +936,9 @@ proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader = function(msg, rea
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.xudrpc.RemoveOrderResponse.prototype.serializeBinary = function() {
+proto.xudrpc.BanResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter(this, writer);
+  proto.xudrpc.BanResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -949,34 +946,12 @@ proto.xudrpc.RemoveOrderResponse.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.xudrpc.RemoveOrderResponse} message
+ * @param {!proto.xudrpc.BanResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter = function(message, writer) {
+proto.xudrpc.BanResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getQuantityOnHold();
-  if (f !== 0.0) {
-    writer.writeDouble(
-      1,
-      f
-    );
-  }
-};
-
-
-/**
- * optional double quantity_on_hold = 1;
- * @return {number}
- */
-proto.xudrpc.RemoveOrderResponse.prototype.getQuantityOnHold = function() {
-  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 1, 0.0));
-};
-
-
-/** @param {number} value */
-proto.xudrpc.RemoveOrderResponse.prototype.setQuantityOnHold = function(value) {
-  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -1704,12 +1679,12 @@ proto.xudrpc.ConnectResponse.serializeBinaryToWriter = function(message, writer)
  * @extends {jspb.Message}
  * @constructor
  */
-proto.xudrpc.BanRequest = function(opt_data) {
+proto.xudrpc.ExecuteSwapRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.xudrpc.BanRequest, jspb.Message);
+goog.inherits(proto.xudrpc.ExecuteSwapRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.xudrpc.BanRequest.displayName = 'proto.xudrpc.BanRequest';
+  proto.xudrpc.ExecuteSwapRequest.displayName = 'proto.xudrpc.ExecuteSwapRequest';
 }
 
 
@@ -1724,8 +1699,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.xudrpc.BanRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.xudrpc.BanRequest.toObject(opt_includeInstance, this);
+proto.xudrpc.ExecuteSwapRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.ExecuteSwapRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -1734,13 +1709,16 @@ proto.xudrpc.BanRequest.prototype.toObject = function(opt_includeInstance) {
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.xudrpc.BanRequest} msg The msg instance to transform.
+ * @param {!proto.xudrpc.ExecuteSwapRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.BanRequest.toObject = function(includeInstance, msg) {
+proto.xudrpc.ExecuteSwapRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    nodePubKey: jspb.Message.getFieldWithDefault(msg, 1, "")
+    orderId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    peerPubKey: jspb.Message.getFieldWithDefault(msg, 3, ""),
+    quantity: +jspb.Message.getFieldWithDefault(msg, 4, 0.0)
   };
 
   if (includeInstance) {
@@ -1754,23 +1732,23 @@ proto.xudrpc.BanRequest.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.xudrpc.BanRequest}
+ * @return {!proto.xudrpc.ExecuteSwapRequest}
  */
-proto.xudrpc.BanRequest.deserializeBinary = function(bytes) {
+proto.xudrpc.ExecuteSwapRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.xudrpc.BanRequest;
-  return proto.xudrpc.BanRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.xudrpc.ExecuteSwapRequest;
+  return proto.xudrpc.ExecuteSwapRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.xudrpc.BanRequest} msg The message object to deserialize into.
+ * @param {!proto.xudrpc.ExecuteSwapRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.xudrpc.BanRequest}
+ * @return {!proto.xudrpc.ExecuteSwapRequest}
  */
-proto.xudrpc.BanRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.xudrpc.ExecuteSwapRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -1779,7 +1757,19 @@ proto.xudrpc.BanRequest.deserializeBinaryFromReader = function(msg, reader) {
     switch (field) {
     case 1:
       var value = /** @type {string} */ (reader.readString());
-      msg.setNodePubKey(value);
+      msg.setOrderId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPairId(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPeerPubKey(value);
+      break;
+    case 4:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setQuantity(value);
       break;
     default:
       reader.skipField();
@@ -1794,9 +1784,9 @@ proto.xudrpc.BanRequest.deserializeBinaryFromReader = function(msg, reader) {
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.xudrpc.BanRequest.prototype.serializeBinary = function() {
+proto.xudrpc.ExecuteSwapRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.xudrpc.BanRequest.serializeBinaryToWriter(this, writer);
+  proto.xudrpc.ExecuteSwapRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -1804,16 +1794,37 @@ proto.xudrpc.BanRequest.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.xudrpc.BanRequest} message
+ * @param {!proto.xudrpc.ExecuteSwapRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.BanRequest.serializeBinaryToWriter = function(message, writer) {
+proto.xudrpc.ExecuteSwapRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getNodePubKey();
+  f = message.getOrderId();
   if (f.length > 0) {
     writer.writeString(
       1,
+      f
+    );
+  }
+  f = message.getPairId();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getPeerPubKey();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+  f = message.getQuantity();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      4,
       f
     );
   }
@@ -1821,17 +1832,62 @@ proto.xudrpc.BanRequest.serializeBinaryToWriter = function(message, writer) {
 
 
 /**
- * optional string node_pub_key = 1;
+ * optional string order_id = 1;
  * @return {string}
  */
-proto.xudrpc.BanRequest.prototype.getNodePubKey = function() {
+proto.xudrpc.ExecuteSwapRequest.prototype.getOrderId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.BanRequest.prototype.setNodePubKey = function(value) {
+proto.xudrpc.ExecuteSwapRequest.prototype.setOrderId = function(value) {
   jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string pair_id = 2;
+ * @return {string}
+ */
+proto.xudrpc.ExecuteSwapRequest.prototype.getPairId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.ExecuteSwapRequest.prototype.setPairId = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string peer_pub_key = 3;
+ * @return {string}
+ */
+proto.xudrpc.ExecuteSwapRequest.prototype.getPeerPubKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.ExecuteSwapRequest.prototype.setPeerPubKey = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * optional double quantity = 4;
+ * @return {number}
+ */
+proto.xudrpc.ExecuteSwapRequest.prototype.getQuantity = function() {
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 4, 0.0));
+};
+
+
+/** @param {number} value */
+proto.xudrpc.ExecuteSwapRequest.prototype.setQuantity = function(value) {
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -1846,12 +1902,12 @@ proto.xudrpc.BanRequest.prototype.setNodePubKey = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.xudrpc.BanResponse = function(opt_data) {
+proto.xudrpc.SwapFailure = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.xudrpc.BanResponse, jspb.Message);
+goog.inherits(proto.xudrpc.SwapFailure, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.xudrpc.BanResponse.displayName = 'proto.xudrpc.BanResponse';
+  proto.xudrpc.SwapFailure.displayName = 'proto.xudrpc.SwapFailure';
 }
 
 
@@ -1866,8 +1922,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.xudrpc.BanResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.xudrpc.BanResponse.toObject(opt_includeInstance, this);
+proto.xudrpc.SwapFailure.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.SwapFailure.toObject(opt_includeInstance, this);
 };
 
 
@@ -1876,13 +1932,16 @@ proto.xudrpc.BanResponse.prototype.toObject = function(opt_includeInstance) {
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.xudrpc.BanResponse} msg The msg instance to transform.
+ * @param {!proto.xudrpc.SwapFailure} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.BanResponse.toObject = function(includeInstance, msg) {
+proto.xudrpc.SwapFailure.toObject = function(includeInstance, msg) {
   var f, obj = {
-
+    orderId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    quantity: +jspb.Message.getFieldWithDefault(msg, 3, 0.0),
+    peerPubKey: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -1896,29 +1955,45 @@ proto.xudrpc.BanResponse.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.xudrpc.BanResponse}
+ * @return {!proto.xudrpc.SwapFailure}
  */
-proto.xudrpc.BanResponse.deserializeBinary = function(bytes) {
+proto.xudrpc.SwapFailure.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.xudrpc.BanResponse;
-  return proto.xudrpc.BanResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.xudrpc.SwapFailure;
+  return proto.xudrpc.SwapFailure.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.xudrpc.BanResponse} msg The message object to deserialize into.
+ * @param {!proto.xudrpc.SwapFailure} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.xudrpc.BanResponse}
+ * @return {!proto.xudrpc.SwapFailure}
  */
-proto.xudrpc.BanResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.xudrpc.SwapFailure.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
     }
     var field = reader.getFieldNumber();
     switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOrderId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPairId(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setQuantity(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPeerPubKey(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1932,9 +2007,9 @@ proto.xudrpc.BanResponse.deserializeBinaryFromReader = function(msg, reader) {
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.xudrpc.BanResponse.prototype.serializeBinary = function() {
+proto.xudrpc.SwapFailure.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.xudrpc.BanResponse.serializeBinaryToWriter(this, writer);
+  proto.xudrpc.SwapFailure.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -1942,12 +2017,100 @@ proto.xudrpc.BanResponse.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.xudrpc.BanResponse} message
+ * @param {!proto.xudrpc.SwapFailure} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.BanResponse.serializeBinaryToWriter = function(message, writer) {
+proto.xudrpc.SwapFailure.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getOrderId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getPairId();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getQuantity();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      3,
+      f
+    );
+  }
+  f = message.getPeerPubKey();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string order_id = 1;
+ * @return {string}
+ */
+proto.xudrpc.SwapFailure.prototype.getOrderId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.SwapFailure.prototype.setOrderId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string pair_id = 2;
+ * @return {string}
+ */
+proto.xudrpc.SwapFailure.prototype.getPairId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.SwapFailure.prototype.setPairId = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional double quantity = 3;
+ * @return {number}
+ */
+proto.xudrpc.SwapFailure.prototype.getQuantity = function() {
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 3, 0.0));
+};
+
+
+/** @param {number} value */
+proto.xudrpc.SwapFailure.prototype.setQuantity = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * optional string peer_pub_key = 4;
+ * @return {string}
+ */
+proto.xudrpc.SwapFailure.prototype.getPeerPubKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.SwapFailure.prototype.setPeerPubKey = function(value) {
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -6272,8 +6435,8 @@ proto.xudrpc.PlaceOrderResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     internalMatchesList: jspb.Message.toObjectList(msg.getInternalMatchesList(),
     proto.xudrpc.Order.toObject, includeInstance),
-    swapResultsList: jspb.Message.toObjectList(msg.getSwapResultsList(),
-    proto.xudrpc.SwapResult.toObject, includeInstance),
+    swapSuccessesList: jspb.Message.toObjectList(msg.getSwapSuccessesList(),
+    proto.xudrpc.SwapSuccess.toObject, includeInstance),
     remainingOrder: (f = msg.getRemainingOrder()) && proto.xudrpc.Order.toObject(includeInstance, f)
   };
 
@@ -6317,9 +6480,9 @@ proto.xudrpc.PlaceOrderResponse.deserializeBinaryFromReader = function(msg, read
       msg.addInternalMatches(value);
       break;
     case 2:
-      var value = new proto.xudrpc.SwapResult;
-      reader.readMessage(value,proto.xudrpc.SwapResult.deserializeBinaryFromReader);
-      msg.addSwapResults(value);
+      var value = new proto.xudrpc.SwapSuccess;
+      reader.readMessage(value,proto.xudrpc.SwapSuccess.deserializeBinaryFromReader);
+      msg.addSwapSuccesses(value);
       break;
     case 3:
       var value = new proto.xudrpc.Order;
@@ -6363,12 +6526,12 @@ proto.xudrpc.PlaceOrderResponse.serializeBinaryToWriter = function(message, writ
       proto.xudrpc.Order.serializeBinaryToWriter
     );
   }
-  f = message.getSwapResultsList();
+  f = message.getSwapSuccessesList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
       2,
       f,
-      proto.xudrpc.SwapResult.serializeBinaryToWriter
+      proto.xudrpc.SwapSuccess.serializeBinaryToWriter
     );
   }
   f = message.getRemainingOrder();
@@ -6414,33 +6577,33 @@ proto.xudrpc.PlaceOrderResponse.prototype.clearInternalMatchesList = function() 
 
 
 /**
- * repeated SwapResult swap_results = 2;
- * @return {!Array.<!proto.xudrpc.SwapResult>}
+ * repeated SwapSuccess swap_successes = 2;
+ * @return {!Array.<!proto.xudrpc.SwapSuccess>}
  */
-proto.xudrpc.PlaceOrderResponse.prototype.getSwapResultsList = function() {
-  return /** @type{!Array.<!proto.xudrpc.SwapResult>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.xudrpc.SwapResult, 2));
+proto.xudrpc.PlaceOrderResponse.prototype.getSwapSuccessesList = function() {
+  return /** @type{!Array.<!proto.xudrpc.SwapSuccess>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.xudrpc.SwapSuccess, 2));
 };
 
 
-/** @param {!Array.<!proto.xudrpc.SwapResult>} value */
-proto.xudrpc.PlaceOrderResponse.prototype.setSwapResultsList = function(value) {
+/** @param {!Array.<!proto.xudrpc.SwapSuccess>} value */
+proto.xudrpc.PlaceOrderResponse.prototype.setSwapSuccessesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
 
 
 /**
- * @param {!proto.xudrpc.SwapResult=} opt_value
+ * @param {!proto.xudrpc.SwapSuccess=} opt_value
  * @param {number=} opt_index
- * @return {!proto.xudrpc.SwapResult}
+ * @return {!proto.xudrpc.SwapSuccess}
  */
-proto.xudrpc.PlaceOrderResponse.prototype.addSwapResults = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.xudrpc.SwapResult, opt_index);
+proto.xudrpc.PlaceOrderResponse.prototype.addSwapSuccesses = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.xudrpc.SwapSuccess, opt_index);
 };
 
 
-proto.xudrpc.PlaceOrderResponse.prototype.clearSwapResultsList = function() {
-  this.setSwapResultsList([]);
+proto.xudrpc.PlaceOrderResponse.prototype.clearSwapSuccessesList = function() {
+  this.setSwapSuccessesList([]);
 };
 
 
@@ -6500,7 +6663,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.xudrpc.PlaceOrderEvent.oneofGroups_ = [[1,2,3]];
+proto.xudrpc.PlaceOrderEvent.oneofGroups_ = [[1,2,3,4]];
 
 /**
  * @enum {number}
@@ -6508,8 +6671,9 @@ proto.xudrpc.PlaceOrderEvent.oneofGroups_ = [[1,2,3]];
 proto.xudrpc.PlaceOrderEvent.EventCase = {
   EVENT_NOT_SET: 0,
   INTERNAL_MATCH: 1,
-  SWAP_RESULT: 2,
-  REMAINING_ORDER: 3
+  SWAP_SUCCESS: 2,
+  REMAINING_ORDER: 3,
+  SWAP_FAILURE: 4
 };
 
 /**
@@ -6549,8 +6713,9 @@ proto.xudrpc.PlaceOrderEvent.prototype.toObject = function(opt_includeInstance) 
 proto.xudrpc.PlaceOrderEvent.toObject = function(includeInstance, msg) {
   var f, obj = {
     internalMatch: (f = msg.getInternalMatch()) && proto.xudrpc.Order.toObject(includeInstance, f),
-    swapResult: (f = msg.getSwapResult()) && proto.xudrpc.SwapResult.toObject(includeInstance, f),
-    remainingOrder: (f = msg.getRemainingOrder()) && proto.xudrpc.Order.toObject(includeInstance, f)
+    swapSuccess: (f = msg.getSwapSuccess()) && proto.xudrpc.SwapSuccess.toObject(includeInstance, f),
+    remainingOrder: (f = msg.getRemainingOrder()) && proto.xudrpc.Order.toObject(includeInstance, f),
+    swapFailure: (f = msg.getSwapFailure()) && proto.xudrpc.SwapFailure.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -6593,14 +6758,19 @@ proto.xudrpc.PlaceOrderEvent.deserializeBinaryFromReader = function(msg, reader)
       msg.setInternalMatch(value);
       break;
     case 2:
-      var value = new proto.xudrpc.SwapResult;
-      reader.readMessage(value,proto.xudrpc.SwapResult.deserializeBinaryFromReader);
-      msg.setSwapResult(value);
+      var value = new proto.xudrpc.SwapSuccess;
+      reader.readMessage(value,proto.xudrpc.SwapSuccess.deserializeBinaryFromReader);
+      msg.setSwapSuccess(value);
       break;
     case 3:
       var value = new proto.xudrpc.Order;
       reader.readMessage(value,proto.xudrpc.Order.deserializeBinaryFromReader);
       msg.setRemainingOrder(value);
+      break;
+    case 4:
+      var value = new proto.xudrpc.SwapFailure;
+      reader.readMessage(value,proto.xudrpc.SwapFailure.deserializeBinaryFromReader);
+      msg.setSwapFailure(value);
       break;
     default:
       reader.skipField();
@@ -6639,12 +6809,12 @@ proto.xudrpc.PlaceOrderEvent.serializeBinaryToWriter = function(message, writer)
       proto.xudrpc.Order.serializeBinaryToWriter
     );
   }
-  f = message.getSwapResult();
+  f = message.getSwapSuccess();
   if (f != null) {
     writer.writeMessage(
       2,
       f,
-      proto.xudrpc.SwapResult.serializeBinaryToWriter
+      proto.xudrpc.SwapSuccess.serializeBinaryToWriter
     );
   }
   f = message.getRemainingOrder();
@@ -6653,6 +6823,14 @@ proto.xudrpc.PlaceOrderEvent.serializeBinaryToWriter = function(message, writer)
       3,
       f,
       proto.xudrpc.Order.serializeBinaryToWriter
+    );
+  }
+  f = message.getSwapFailure();
+  if (f != null) {
+    writer.writeMessage(
+      4,
+      f,
+      proto.xudrpc.SwapFailure.serializeBinaryToWriter
     );
   }
 };
@@ -6689,23 +6867,23 @@ proto.xudrpc.PlaceOrderEvent.prototype.hasInternalMatch = function() {
 
 
 /**
- * optional SwapResult swap_result = 2;
- * @return {?proto.xudrpc.SwapResult}
+ * optional SwapSuccess swap_success = 2;
+ * @return {?proto.xudrpc.SwapSuccess}
  */
-proto.xudrpc.PlaceOrderEvent.prototype.getSwapResult = function() {
-  return /** @type{?proto.xudrpc.SwapResult} */ (
-    jspb.Message.getWrapperField(this, proto.xudrpc.SwapResult, 2));
+proto.xudrpc.PlaceOrderEvent.prototype.getSwapSuccess = function() {
+  return /** @type{?proto.xudrpc.SwapSuccess} */ (
+    jspb.Message.getWrapperField(this, proto.xudrpc.SwapSuccess, 2));
 };
 
 
-/** @param {?proto.xudrpc.SwapResult|undefined} value */
-proto.xudrpc.PlaceOrderEvent.prototype.setSwapResult = function(value) {
+/** @param {?proto.xudrpc.SwapSuccess|undefined} value */
+proto.xudrpc.PlaceOrderEvent.prototype.setSwapSuccess = function(value) {
   jspb.Message.setOneofWrapperField(this, 2, proto.xudrpc.PlaceOrderEvent.oneofGroups_[0], value);
 };
 
 
-proto.xudrpc.PlaceOrderEvent.prototype.clearSwapResult = function() {
-  this.setSwapResult(undefined);
+proto.xudrpc.PlaceOrderEvent.prototype.clearSwapSuccess = function() {
+  this.setSwapSuccess(undefined);
 };
 
 
@@ -6713,7 +6891,7 @@ proto.xudrpc.PlaceOrderEvent.prototype.clearSwapResult = function() {
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.xudrpc.PlaceOrderEvent.prototype.hasSwapResult = function() {
+proto.xudrpc.PlaceOrderEvent.prototype.hasSwapSuccess = function() {
   return jspb.Message.getField(this, 2) != null;
 };
 
@@ -6748,226 +6926,33 @@ proto.xudrpc.PlaceOrderEvent.prototype.hasRemainingOrder = function() {
 };
 
 
-
 /**
- * Generated by JsPbCodeGenerator.
- * @param {Array=} opt_data Optional initial data array, typically from a
- * server response, or constructed directly in Javascript. The array is used
- * in place and becomes part of the constructed object. It is not cloned.
- * If no data is provided, the constructed object will be empty, but still
- * valid.
- * @extends {jspb.Message}
- * @constructor
+ * optional SwapFailure swap_failure = 4;
+ * @return {?proto.xudrpc.SwapFailure}
  */
-proto.xudrpc.ExecuteSwapRequest = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+proto.xudrpc.PlaceOrderEvent.prototype.getSwapFailure = function() {
+  return /** @type{?proto.xudrpc.SwapFailure} */ (
+    jspb.Message.getWrapperField(this, proto.xudrpc.SwapFailure, 4));
 };
-goog.inherits(proto.xudrpc.ExecuteSwapRequest, jspb.Message);
-if (goog.DEBUG && !COMPILED) {
-  proto.xudrpc.ExecuteSwapRequest.displayName = 'proto.xudrpc.ExecuteSwapRequest';
-}
 
 
-if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.xudrpc.ExecuteSwapRequest.toObject(opt_includeInstance, this);
+/** @param {?proto.xudrpc.SwapFailure|undefined} value */
+proto.xudrpc.PlaceOrderEvent.prototype.setSwapFailure = function(value) {
+  jspb.Message.setOneofWrapperField(this, 4, proto.xudrpc.PlaceOrderEvent.oneofGroups_[0], value);
+};
+
+
+proto.xudrpc.PlaceOrderEvent.prototype.clearSwapFailure = function() {
+  this.setSwapFailure(undefined);
 };
 
 
 /**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.xudrpc.ExecuteSwapRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
+ * Returns whether this field is set.
+ * @return {!boolean}
  */
-proto.xudrpc.ExecuteSwapRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    orderId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    peerPubKey: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    quantity: +jspb.Message.getFieldWithDefault(msg, 4, 0.0)
-  };
-
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
-
-
-/**
- * Deserializes binary data (in protobuf wire format).
- * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.xudrpc.ExecuteSwapRequest}
- */
-proto.xudrpc.ExecuteSwapRequest.deserializeBinary = function(bytes) {
-  var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.xudrpc.ExecuteSwapRequest;
-  return proto.xudrpc.ExecuteSwapRequest.deserializeBinaryFromReader(msg, reader);
-};
-
-
-/**
- * Deserializes binary data (in protobuf wire format) from the
- * given reader into the given message object.
- * @param {!proto.xudrpc.ExecuteSwapRequest} msg The message object to deserialize into.
- * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.xudrpc.ExecuteSwapRequest}
- */
-proto.xudrpc.ExecuteSwapRequest.deserializeBinaryFromReader = function(msg, reader) {
-  while (reader.nextField()) {
-    if (reader.isEndGroup()) {
-      break;
-    }
-    var field = reader.getFieldNumber();
-    switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setOrderId(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setPairId(value);
-      break;
-    case 3:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setPeerPubKey(value);
-      break;
-    case 4:
-      var value = /** @type {number} */ (reader.readDouble());
-      msg.setQuantity(value);
-      break;
-    default:
-      reader.skipField();
-      break;
-    }
-  }
-  return msg;
-};
-
-
-/**
- * Serializes the message to binary data (in protobuf wire format).
- * @return {!Uint8Array}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.serializeBinary = function() {
-  var writer = new jspb.BinaryWriter();
-  proto.xudrpc.ExecuteSwapRequest.serializeBinaryToWriter(this, writer);
-  return writer.getResultBuffer();
-};
-
-
-/**
- * Serializes the given message to binary data (in protobuf wire
- * format), writing to the given BinaryWriter.
- * @param {!proto.xudrpc.ExecuteSwapRequest} message
- * @param {!jspb.BinaryWriter} writer
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.xudrpc.ExecuteSwapRequest.serializeBinaryToWriter = function(message, writer) {
-  var f = undefined;
-  f = message.getOrderId();
-  if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
-  }
-  f = message.getPairId();
-  if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
-  }
-  f = message.getPeerPubKey();
-  if (f.length > 0) {
-    writer.writeString(
-      3,
-      f
-    );
-  }
-  f = message.getQuantity();
-  if (f !== 0.0) {
-    writer.writeDouble(
-      4,
-      f
-    );
-  }
-};
-
-
-/**
- * optional string order_id = 1;
- * @return {string}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.getOrderId = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
-};
-
-
-/** @param {string} value */
-proto.xudrpc.ExecuteSwapRequest.prototype.setOrderId = function(value) {
-  jspb.Message.setField(this, 1, value);
-};
-
-
-/**
- * optional string pair_id = 2;
- * @return {string}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.getPairId = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
-};
-
-
-/** @param {string} value */
-proto.xudrpc.ExecuteSwapRequest.prototype.setPairId = function(value) {
-  jspb.Message.setField(this, 2, value);
-};
-
-
-/**
- * optional string peer_pub_key = 3;
- * @return {string}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.getPeerPubKey = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
-};
-
-
-/** @param {string} value */
-proto.xudrpc.ExecuteSwapRequest.prototype.setPeerPubKey = function(value) {
-  jspb.Message.setField(this, 3, value);
-};
-
-
-/**
- * optional double quantity = 4;
- * @return {number}
- */
-proto.xudrpc.ExecuteSwapRequest.prototype.getQuantity = function() {
-  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 4, 0.0));
-};
-
-
-/** @param {number} value */
-proto.xudrpc.ExecuteSwapRequest.prototype.setQuantity = function(value) {
-  jspb.Message.setField(this, 4, value);
+proto.xudrpc.PlaceOrderEvent.prototype.hasSwapFailure = function() {
+  return jspb.Message.getField(this, 4) != null;
 };
 
 
@@ -7449,6 +7434,290 @@ proto.xudrpc.RemoveCurrencyResponse.prototype.serializeBinary = function() {
  */
 proto.xudrpc.RemoveCurrencyResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.xudrpc.RemoveOrderRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.xudrpc.RemoveOrderRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.xudrpc.RemoveOrderRequest.displayName = 'proto.xudrpc.RemoveOrderRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.xudrpc.RemoveOrderRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.RemoveOrderRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.xudrpc.RemoveOrderRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.xudrpc.RemoveOrderRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    orderId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.xudrpc.RemoveOrderRequest}
+ */
+proto.xudrpc.RemoveOrderRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.xudrpc.RemoveOrderRequest;
+  return proto.xudrpc.RemoveOrderRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.xudrpc.RemoveOrderRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.xudrpc.RemoveOrderRequest}
+ */
+proto.xudrpc.RemoveOrderRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOrderId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.xudrpc.RemoveOrderRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.xudrpc.RemoveOrderRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.xudrpc.RemoveOrderRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.xudrpc.RemoveOrderRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getOrderId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string order_id = 1;
+ * @return {string}
+ */
+proto.xudrpc.RemoveOrderRequest.prototype.getOrderId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.RemoveOrderRequest.prototype.setOrderId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.xudrpc.RemoveOrderResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.xudrpc.RemoveOrderResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.xudrpc.RemoveOrderResponse.displayName = 'proto.xudrpc.RemoveOrderResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.xudrpc.RemoveOrderResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.RemoveOrderResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.xudrpc.RemoveOrderResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.xudrpc.RemoveOrderResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    quantityOnHold: +jspb.Message.getFieldWithDefault(msg, 1, 0.0)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.xudrpc.RemoveOrderResponse}
+ */
+proto.xudrpc.RemoveOrderResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.xudrpc.RemoveOrderResponse;
+  return proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.xudrpc.RemoveOrderResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.xudrpc.RemoveOrderResponse}
+ */
+proto.xudrpc.RemoveOrderResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setQuantityOnHold(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.xudrpc.RemoveOrderResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.xudrpc.RemoveOrderResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.xudrpc.RemoveOrderResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getQuantityOnHold();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional double quantity_on_hold = 1;
+ * @return {number}
+ */
+proto.xudrpc.RemoveOrderResponse.prototype.getQuantityOnHold = function() {
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 1, 0.0));
+};
+
+
+/** @param {number} value */
+proto.xudrpc.RemoveOrderResponse.prototype.setQuantityOnHold = function(value) {
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -8357,12 +8626,12 @@ proto.xudrpc.SubscribeSwapsRequest.prototype.setIncludeTaker = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.xudrpc.SwapResult = function(opt_data) {
+proto.xudrpc.SwapSuccess = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.xudrpc.SwapResult, jspb.Message);
+goog.inherits(proto.xudrpc.SwapSuccess, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.xudrpc.SwapResult.displayName = 'proto.xudrpc.SwapResult';
+  proto.xudrpc.SwapSuccess.displayName = 'proto.xudrpc.SwapSuccess';
 }
 
 
@@ -8377,8 +8646,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.xudrpc.SwapResult.prototype.toObject = function(opt_includeInstance) {
-  return proto.xudrpc.SwapResult.toObject(opt_includeInstance, this);
+proto.xudrpc.SwapSuccess.prototype.toObject = function(opt_includeInstance) {
+  return proto.xudrpc.SwapSuccess.toObject(opt_includeInstance, this);
 };
 
 
@@ -8387,11 +8656,11 @@ proto.xudrpc.SwapResult.prototype.toObject = function(opt_includeInstance) {
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.xudrpc.SwapResult} msg The msg instance to transform.
+ * @param {!proto.xudrpc.SwapSuccess} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.SwapResult.toObject = function(includeInstance, msg) {
+proto.xudrpc.SwapSuccess.toObject = function(includeInstance, msg) {
   var f, obj = {
     orderId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     localId: jspb.Message.getFieldWithDefault(msg, 2, ""),
@@ -8417,23 +8686,23 @@ proto.xudrpc.SwapResult.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.xudrpc.SwapResult}
+ * @return {!proto.xudrpc.SwapSuccess}
  */
-proto.xudrpc.SwapResult.deserializeBinary = function(bytes) {
+proto.xudrpc.SwapSuccess.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.xudrpc.SwapResult;
-  return proto.xudrpc.SwapResult.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.xudrpc.SwapSuccess;
+  return proto.xudrpc.SwapSuccess.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.xudrpc.SwapResult} msg The message object to deserialize into.
+ * @param {!proto.xudrpc.SwapSuccess} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.xudrpc.SwapResult}
+ * @return {!proto.xudrpc.SwapSuccess}
  */
-proto.xudrpc.SwapResult.deserializeBinaryFromReader = function(msg, reader) {
+proto.xudrpc.SwapSuccess.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -8473,7 +8742,7 @@ proto.xudrpc.SwapResult.deserializeBinaryFromReader = function(msg, reader) {
       msg.setPeerPubKey(value);
       break;
     case 9:
-      var value = /** @type {!proto.xudrpc.SwapResult.Role} */ (reader.readEnum());
+      var value = /** @type {!proto.xudrpc.SwapSuccess.Role} */ (reader.readEnum());
       msg.setRole(value);
       break;
     case 10:
@@ -8497,9 +8766,9 @@ proto.xudrpc.SwapResult.deserializeBinaryFromReader = function(msg, reader) {
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.xudrpc.SwapResult.prototype.serializeBinary = function() {
+proto.xudrpc.SwapSuccess.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.xudrpc.SwapResult.serializeBinaryToWriter(this, writer);
+  proto.xudrpc.SwapSuccess.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -8507,11 +8776,11 @@ proto.xudrpc.SwapResult.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.xudrpc.SwapResult} message
+ * @param {!proto.xudrpc.SwapSuccess} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.xudrpc.SwapResult.serializeBinaryToWriter = function(message, writer) {
+proto.xudrpc.SwapSuccess.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getOrderId();
   if (f.length > 0) {
@@ -8596,7 +8865,7 @@ proto.xudrpc.SwapResult.serializeBinaryToWriter = function(message, writer) {
 /**
  * @enum {number}
  */
-proto.xudrpc.SwapResult.Role = {
+proto.xudrpc.SwapSuccess.Role = {
   TAKER: 0,
   MAKER: 1
 };
@@ -8605,13 +8874,13 @@ proto.xudrpc.SwapResult.Role = {
  * optional string order_id = 1;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getOrderId = function() {
+proto.xudrpc.SwapSuccess.prototype.getOrderId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setOrderId = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setOrderId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -8620,13 +8889,13 @@ proto.xudrpc.SwapResult.prototype.setOrderId = function(value) {
  * optional string local_id = 2;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getLocalId = function() {
+proto.xudrpc.SwapSuccess.prototype.getLocalId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setLocalId = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setLocalId = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -8635,13 +8904,13 @@ proto.xudrpc.SwapResult.prototype.setLocalId = function(value) {
  * optional string pair_id = 3;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getPairId = function() {
+proto.xudrpc.SwapSuccess.prototype.getPairId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setPairId = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setPairId = function(value) {
   jspb.Message.setField(this, 3, value);
 };
 
@@ -8650,13 +8919,13 @@ proto.xudrpc.SwapResult.prototype.setPairId = function(value) {
  * optional double quantity = 4;
  * @return {number}
  */
-proto.xudrpc.SwapResult.prototype.getQuantity = function() {
+proto.xudrpc.SwapSuccess.prototype.getQuantity = function() {
   return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 4, 0.0));
 };
 
 
 /** @param {number} value */
-proto.xudrpc.SwapResult.prototype.setQuantity = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setQuantity = function(value) {
   jspb.Message.setField(this, 4, value);
 };
 
@@ -8665,13 +8934,13 @@ proto.xudrpc.SwapResult.prototype.setQuantity = function(value) {
  * optional string r_hash = 5;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getRHash = function() {
+proto.xudrpc.SwapSuccess.prototype.getRHash = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setRHash = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setRHash = function(value) {
   jspb.Message.setField(this, 5, value);
 };
 
@@ -8680,13 +8949,13 @@ proto.xudrpc.SwapResult.prototype.setRHash = function(value) {
  * optional int64 amount_received = 6;
  * @return {number}
  */
-proto.xudrpc.SwapResult.prototype.getAmountReceived = function() {
+proto.xudrpc.SwapSuccess.prototype.getAmountReceived = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 6, 0));
 };
 
 
 /** @param {number} value */
-proto.xudrpc.SwapResult.prototype.setAmountReceived = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setAmountReceived = function(value) {
   jspb.Message.setField(this, 6, value);
 };
 
@@ -8695,13 +8964,13 @@ proto.xudrpc.SwapResult.prototype.setAmountReceived = function(value) {
  * optional int64 amount_sent = 7;
  * @return {number}
  */
-proto.xudrpc.SwapResult.prototype.getAmountSent = function() {
+proto.xudrpc.SwapSuccess.prototype.getAmountSent = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 7, 0));
 };
 
 
 /** @param {number} value */
-proto.xudrpc.SwapResult.prototype.setAmountSent = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setAmountSent = function(value) {
   jspb.Message.setField(this, 7, value);
 };
 
@@ -8710,28 +8979,28 @@ proto.xudrpc.SwapResult.prototype.setAmountSent = function(value) {
  * optional string peer_pub_key = 8;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getPeerPubKey = function() {
+proto.xudrpc.SwapSuccess.prototype.getPeerPubKey = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 8, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setPeerPubKey = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setPeerPubKey = function(value) {
   jspb.Message.setField(this, 8, value);
 };
 
 
 /**
  * optional Role role = 9;
- * @return {!proto.xudrpc.SwapResult.Role}
+ * @return {!proto.xudrpc.SwapSuccess.Role}
  */
-proto.xudrpc.SwapResult.prototype.getRole = function() {
-  return /** @type {!proto.xudrpc.SwapResult.Role} */ (jspb.Message.getFieldWithDefault(this, 9, 0));
+proto.xudrpc.SwapSuccess.prototype.getRole = function() {
+  return /** @type {!proto.xudrpc.SwapSuccess.Role} */ (jspb.Message.getFieldWithDefault(this, 9, 0));
 };
 
 
-/** @param {!proto.xudrpc.SwapResult.Role} value */
-proto.xudrpc.SwapResult.prototype.setRole = function(value) {
+/** @param {!proto.xudrpc.SwapSuccess.Role} value */
+proto.xudrpc.SwapSuccess.prototype.setRole = function(value) {
   jspb.Message.setField(this, 9, value);
 };
 
@@ -8740,13 +9009,13 @@ proto.xudrpc.SwapResult.prototype.setRole = function(value) {
  * optional string currency_received = 10;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getCurrencyReceived = function() {
+proto.xudrpc.SwapSuccess.prototype.getCurrencyReceived = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 10, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setCurrencyReceived = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setCurrencyReceived = function(value) {
   jspb.Message.setField(this, 10, value);
 };
 
@@ -8755,13 +9024,13 @@ proto.xudrpc.SwapResult.prototype.setCurrencyReceived = function(value) {
  * optional string currency_sent = 11;
  * @return {string}
  */
-proto.xudrpc.SwapResult.prototype.getCurrencySent = function() {
+proto.xudrpc.SwapSuccess.prototype.getCurrencySent = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 11, ""));
 };
 
 
 /** @param {string} value */
-proto.xudrpc.SwapResult.prototype.setCurrencySent = function(value) {
+proto.xudrpc.SwapSuccess.prototype.setCurrencySent = function(value) {
   jspb.Message.setField(this, 11, value);
 };
 

--- a/lib/types/orderBook.ts
+++ b/lib/types/orderBook.ts
@@ -1,4 +1,4 @@
-import { OwnOrder } from './orders';
+import { OwnOrder, PeerOrder } from './orders';
 import { SwapResult } from 'lib/swaps/types';
 
 export type PlaceOrderResult = {
@@ -8,12 +8,13 @@ export type PlaceOrderResult = {
 };
 
 export type PlaceOrderEvent = {
-  case: PlaceOrderEventCase;
-  payload: OwnOrder | SwapResult;
+  type: PlaceOrderEventType;
+  payload: OwnOrder | SwapResult | PeerOrder;
 };
 
-export enum PlaceOrderEventCase {
+export enum PlaceOrderEventType {
   InternalMatch,
-  SwapResult,
+  SwapSuccess,
   RemainingOrder,
+  SwapFailure,
 }

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -153,7 +153,7 @@ service Xud {
 
 
   /* Execute a swap on a maker peer order */
-  rpc ExecuteSwap(ExecuteSwapRequest) returns (SwapResult) {
+  rpc ExecuteSwap(ExecuteSwapRequest) returns (SwapSuccess) {
     option (google.api.http) = {
       post: "/v1/executeswap"
       body: "*"
@@ -214,7 +214,7 @@ service Xud {
    * the client to get real-time notifications when its orders are filled by a peer. It can be used
    * for tracking order executions, updating balances, and informing a trader when one of their orders
    * is settled through the Exchange Union network. */
-  rpc SubscribeSwaps(SubscribeSwapsRequest) returns (stream SwapResult) {
+  rpc SubscribeSwaps(SubscribeSwapsRequest) returns (stream SwapSuccess) {
     option (google.api.http) = {
       get: "/v1/subscribeswaps"
     };
@@ -254,15 +254,11 @@ message AddPairRequest {
 }
 message AddPairResponse {}
 
-message RemoveOrderRequest {
-  // The local id of the order to remove.
-  string order_id = 1 [json_name = "order_id"];
+message BanRequest {
+  // The node pub key of the node to ban.
+  string node_pub_key = 1 [json_name = "node_pub_key"];
 }
-message RemoveOrderResponse {
-  // Any portion of the order that was on hold due to ongoing swaps at the time of the request
-  // and could not be removed until after the swaps finish.
-  double quantity_on_hold = 1 [json_name = "hold"];
-}
+message BanResponse {}
 
 message ChannelBalance {
   // Sum of channels balances denominated in satoshis or equivalent.
@@ -288,11 +284,27 @@ message ConnectRequest {
 
 message ConnectResponse {}
 
-message BanRequest {
-  // The node pub key of the node to ban.
-  string node_pub_key = 1 [json_name = "node_pub_key"];
+message ExecuteSwapRequest {
+  // The order id of the maker order.
+  string order_id = 1 [json_name = "order_id"];
+  // The trading pair of the swap orders.
+  string pair_id = 2 [json_name = "pair_id"];
+  // The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly.
+  string peer_pub_key = 3 [json_name = "peer_pub_key"];
+  // The quantity to swap. The whole order will be swapped if unspecified.
+  double quantity = 4 [json_name = "quantity"];
 }
-message BanResponse {}
+
+message SwapFailure {
+  // The global UUID for the order that failed the swap.
+  string order_id = 1;
+  // The trading pair that the swap is for.
+  string pair_id = 2 [json_name = "pair_id"];
+  // The order quantity that was attempted to be swapped.
+  double quantity = 3 [json_name = "quantity"];
+  // The node pub key of the peer that we attempted to swap with.
+  string peer_pub_key = 4 [json_name = "peer_pub_key"];
+}
 
 message GetInfoRequest {}
 message GetInfoResponse {
@@ -460,7 +472,7 @@ message PlaceOrderResponse {
   // A list of own orders (or portions thereof) that matched the newly placed order.
   repeated Order internal_matches = 1 [json_name = "internal_matches"];
   // A list of swap results of peer orders that matched the newly placed order.
-  repeated SwapResult swap_results = 2 [json_name = "swap_results"];
+  repeated SwapSuccess swap_successes = 2 [json_name = "swap_successes"];
   // The remaining portion of the order, after matches, that enters the order book.
   Order remaining_order = 3 [json_name= "remaining_order"];
 }
@@ -470,21 +482,12 @@ message PlaceOrderEvent {
     // An own orders (or portions thereof) that matched the newly placed order.
     Order internal_match = 1 [json_name = "internal_match"];
     // A swap results of peer orders that matched the newly placed order.
-    SwapResult swap_result = 2 [json_name = "swap_result"];
+    SwapSuccess swap_success = 2 [json_name = "swap_success"];
     // The remaining portion of the order, after matches, that enters the order book.
     Order remaining_order = 3 [json_name= "remaining_order"];
+    // A swap attempt that failed.
+    SwapFailure swap_failure = 4 [json_name = "swap_failures"];
   }
-}
-
-message ExecuteSwapRequest {
-  // The order id of the maker order.
-  string order_id = 1 [json_name = "order_id"];
-  // The trading pair of the swap orders.
-  string pair_id = 2 [json_name = "pair_id"];
-  // The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly.
-  string peer_pub_key = 3 [json_name = "peer_pub_key"];
-  // The quantity to swap. The whole order will be swapped if unspecified.
-  double quantity = 4 [json_name = "quantity"];
 }
 
 message RaidenInfo {
@@ -499,6 +502,16 @@ message RemoveCurrencyRequest {
   string currency = 1 [json_name = "currency"];
 }
 message RemoveCurrencyResponse {}
+
+message RemoveOrderRequest {
+  // The local id of the order to remove.
+  string order_id = 1 [json_name = "order_id"];
+}
+message RemoveOrderResponse {
+  // Any portion of the order that was on hold due to ongoing swaps at the time of the request
+  // and could not be removed until after the swaps finish.
+  double quantity_on_hold = 1 [json_name = "hold"];
+}
 
 message RemovePairRequest {
   // The trading pair ticker to remove in a format such as "LTC/BTC".
@@ -522,12 +535,12 @@ message SubscribeSwapsRequest {
   bool include_taker = 1 [json_name = "include_taker"]; 
 }
 
-message SwapResult {
+message SwapSuccess {
   // The global UUID for the order that was swapped.
   string order_id = 1;
   // The local id for the order that was swapped.
   string local_id = 2 [json_name = "local_id"];
-  // The trading pair that this order is for.
+  // The trading pair that the swap is for.
   string pair_id = 3 [json_name = "pair_id"];
   // The order quantity that was swapped.
   double quantity = 4 [json_name = "quantity"];


### PR DESCRIPTION
This adds a `FailedSwap` message type to the asynchronous `PlaceOrder` rpc call. It is used to notify the caller in real time when a swap fails for a given order.

Closes #609.

Edit: Closes #734 as well I believe.