### PR TITLE
feat: swapResult now has result status

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -805,6 +805,7 @@
 | role | [SwapResult.Role](#xudrpc.SwapResult.Role) |  | Our role in the swap, either MAKER or TAKER. |
 | currency_received | [string](#string) |  | The ticker symbol of the currency received. |
 | currency_sent | [string](#string) |  | The ticker symbol of the currency sent. |
+| result | [string](#string) |  | Indicate if a swap was completed or failed. |
 
 
 

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -40,6 +40,7 @@ const createOrder = (order: Order) => {
  */
 const createSwapResult = (result: SwapResult) => {
   const swapResult = new xudrpc.SwapResult();
+  swapResult.setResult(result.result)
   swapResult.setOrderId(result.orderId);
   swapResult.setLocalId(result.localId);
   swapResult.setPairId(result.pairId);

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1162,6 +1162,10 @@
         "currency_sent": {
           "type": "string",
           "description": "The ticker symbol of the currency sent."
+        },
+        "result": {
+          "type": "string",
+          "description": "Indicate if a swap was completed or failed."
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -1200,6 +1200,9 @@ export class SwapResult extends jspb.Message {
   getCurrencySent(): string;
   setCurrencySent(value: string): void;
 
+  getResult(): string;
+  setResult(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SwapResult.AsObject;
   static toObject(includeInstance: boolean, msg: SwapResult): SwapResult.AsObject;
@@ -1223,6 +1226,7 @@ export namespace SwapResult {
     role: SwapResult.Role,
     currencyReceived: string,
     currencySent: string,
+    result: string,
   }
 
   export enum Role {

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -8375,7 +8375,8 @@ proto.xudrpc.SwapResult.toObject = function(includeInstance, msg) {
     peerPubKey: jspb.Message.getFieldWithDefault(msg, 8, ""),
     role: jspb.Message.getFieldWithDefault(msg, 9, 0),
     currencyReceived: jspb.Message.getFieldWithDefault(msg, 10, ""),
-    currencySent: jspb.Message.getFieldWithDefault(msg, 11, "")
+    currencySent: jspb.Message.getFieldWithDefault(msg, 11, ""),
+    result: jspb.Message.getFieldWithDefault(msg, 12, "")
   };
 
   if (includeInstance) {
@@ -8455,6 +8456,10 @@ proto.xudrpc.SwapResult.deserializeBinaryFromReader = function(msg, reader) {
     case 11:
       var value = /** @type {string} */ (reader.readString());
       msg.setCurrencySent(value);
+      break;
+    case 12:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setResult(value);
       break;
     default:
       reader.skipField();
@@ -8559,6 +8564,13 @@ proto.xudrpc.SwapResult.serializeBinaryToWriter = function(message, writer) {
   if (f.length > 0) {
     writer.writeString(
       11,
+      f
+    );
+  }
+  f = message.getResult();
+  if (f.length > 0) {
+    writer.writeString(
+      12,
       f
     );
   }
@@ -8735,6 +8747,21 @@ proto.xudrpc.SwapResult.prototype.getCurrencySent = function() {
 /** @param {string} value */
 proto.xudrpc.SwapResult.prototype.setCurrencySent = function(value) {
   jspb.Message.setField(this, 11, value);
+};
+
+
+/**
+ * optional string result = 12;
+ * @return {string}
+ */
+proto.xudrpc.SwapResult.prototype.getResult = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 12, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.SwapResult.prototype.setResult = function(value) {
+  jspb.Message.setField(this, 12, value);
 };
 
 

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -695,6 +695,7 @@ class Swaps extends EventEmitter {
     if (deal.phase === SwapPhase.AmountReceived) {
       const wasMaker = deal.role === SwapRole.Maker;
       const swapResult = {
+        result: 'completed',
         orderId: deal.orderId,
         localId: deal.localId,
         pairId: deal.pairId,

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -57,6 +57,8 @@ export type SwapDeal = {
 
 /** The result of a successful swap. */
 export type SwapResult = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'rHash' | 'peerPubKey' | 'role'> & {
+  /** Indicate if a swap was completed or failed . */
+  result: string;
   /** The amount of satoshis (or equivalent) received. */
   amountReceived: number;
   /** The amount of satoshis (or equivalent) sent. */

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -543,6 +543,8 @@ message SwapResult {
   string currency_received = 10 [json_name = "currency_received"];
   // The ticker symbol of the currency sent.
   string currency_sent = 11 [json_name = "currency_sent"];
+  // Indicate if a swap was completed or failed.
+  string result = 12 [json_name = "result"]; 
 }
 
 message UnbanRequest {


### PR DESCRIPTION
closes #734 
@sangaman Could you have a look because I noticed that we never return failed `swapResults` on `ExecuteSwapRequest`.