### PR TITLE
Execute swaps in parallel when matching orders

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -589,8 +589,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| internal_match | [Order](#xudrpc.Order) |  | An own orders (or portions thereof) that matched the newly placed order. |
-| swap_success | [SwapSuccess](#xudrpc.SwapSuccess) |  | A swap results of peer orders that matched the newly placed order. |
+| internal_match | [Order](#xudrpc.Order) |  | An own order (or portion thereof) that matched the newly placed order. |
+| swap_success | [SwapSuccess](#xudrpc.SwapSuccess) |  | A successful swap of a peer order that matched the newly placed order. |
 | remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
 | swap_failure | [SwapFailure](#xudrpc.SwapFailure) |  | A swap attempt that failed. |
 
@@ -627,7 +627,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | internal_matches | [Order](#xudrpc.Order) | repeated | A list of own orders (or portions thereof) that matched the newly placed order. |
-| swap_successes | [SwapSuccess](#xudrpc.SwapSuccess) | repeated | A list of swap results of peer orders that matched the newly placed order. |
+| swap_successes | [SwapSuccess](#xudrpc.SwapSuccess) | repeated | A list of successful swaps of peer orders that matched the newly placed order. |
 | remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
 
 

--- a/lib/cli/commands/streamorders.ts
+++ b/lib/cli/commands/streamorders.ts
@@ -61,8 +61,8 @@ const streamOrders = (argv: Arguments) =>  {
   const swapsRequest = new xudrpc.SubscribeSwapsRequest();
   swapsRequest.setIncludeTaker(true);
   const swapsSubscription = loadXudClient(argv).subscribeSwaps(swapsRequest);
-  swapsSubscription.on('data', (swapResult: xudrpc.SwapSuccess) => {
-    console.log(`Order swapped: ${JSON.stringify(swapResult.toObject())}`);
+  swapsSubscription.on('data', (swapSuccess: xudrpc.SwapSuccess) => {
+    console.log(`Order swapped: ${JSON.stringify(swapSuccess.toObject())}`);
   });
 
   // prevent exiting and do nothing, it's already caught above.

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -10,7 +10,7 @@ import { errorCodes as serviceErrorCodes } from '../service/errors';
 import { errorCodes as p2pErrorCodes } from '../p2p/errors';
 import { errorCodes as lndErrorCodes } from '../lndclient/errors';
 import { LndInfo } from '../lndclient/LndClient';
-import { SwapResult } from 'lib/swaps/types';
+import { SwapSuccess } from 'lib/swaps/types';
 
 /**
  * Creates an xudrpc Order message from a [[StampedOrder]].
@@ -35,22 +35,22 @@ const createOrder = (order: Order) => {
 };
 
 /**
- * Creates an xudrpc SwapSuccess message from a [[SwapResult]].
+ * Creates an xudrpc SwapSuccess message from a [[SwapSuccess]].
  */
-const createSwapSuccess = (result: SwapResult) => {
-  const swapResult = new xudrpc.SwapSuccess();
-  swapResult.setOrderId(result.orderId);
-  swapResult.setLocalId(result.localId);
-  swapResult.setPairId(result.pairId);
-  swapResult.setQuantity(result.quantity);
-  swapResult.setRHash(result.rHash);
-  swapResult.setAmountReceived(result.amountReceived);
-  swapResult.setAmountSent(result.amountSent);
-  swapResult.setCurrencyReceived(result.currencyReceived);
-  swapResult.setCurrencySent(result.currencySent);
-  swapResult.setPeerPubKey(result.peerPubKey);
-  swapResult.setRole(result.role as number);
-  return swapResult;
+const createSwapSuccess = (result: SwapSuccess) => {
+  const swapSuccess = new xudrpc.SwapSuccess();
+  swapSuccess.setOrderId(result.orderId);
+  swapSuccess.setLocalId(result.localId);
+  swapSuccess.setPairId(result.pairId);
+  swapSuccess.setQuantity(result.quantity);
+  swapSuccess.setRHash(result.rHash);
+  swapSuccess.setAmountReceived(result.amountReceived);
+  swapSuccess.setAmountSent(result.amountSent);
+  swapSuccess.setCurrencyReceived(result.currencyReceived);
+  swapSuccess.setCurrencySent(result.currencySent);
+  swapSuccess.setPeerPubKey(result.peerPubKey);
+  swapSuccess.setRole(result.role as number);
+  return swapSuccess;
 };
 
 /**
@@ -74,7 +74,7 @@ const createPlaceOrderResponse = (result: PlaceOrderResult) => {
   const internalMatches = result.internalMatches.map(match => createOrder(match));
   response.setInternalMatchesList(internalMatches);
 
-  const swapSuccesses = result.swapResults.map(swapResult => createSwapSuccess(swapResult));
+  const swapSuccesses = result.swapSuccesses.map(swapSuccess => createSwapSuccess(swapSuccess));
   response.setSwapSuccessesList(swapSuccesses);
 
   if (result.remainingOrder) {
@@ -94,7 +94,7 @@ const createPlaceOrderEvent = (e: PlaceOrderEvent) => {
       placeOrderEvent.setInternalMatch(createOrder(e.payload as Order));
       break;
     case PlaceOrderEventType.SwapSuccess:
-      placeOrderEvent.setSwapSuccess(createSwapSuccess(e.payload as SwapResult));
+      placeOrderEvent.setSwapSuccess(createSwapSuccess(e.payload as SwapSuccess));
       break;
     case PlaceOrderEventType.RemainingOrder:
       placeOrderEvent.setRemainingOrder(createOrder(e.payload as Order));
@@ -566,7 +566,7 @@ class GrpcService {
    * See [[Service.subscribeSwaps]]
    */
   public subscribeSwaps: grpc.handleServerStreamingCall<xudrpc.SubscribeSwapsRequest, xudrpc.SwapSuccess> = (call) => {
-    this.service.subscribeSwaps(call.request.toObject(), (result: SwapResult) => {
+    this.service.subscribeSwaps(call.request.toObject(), (result: SwapSuccess) => {
       call.write(createSwapSuccess(result));
     });
     this.addStream(call);

--- a/lib/orderbook/OrderBookRepository.ts
+++ b/lib/orderbook/OrderBookRepository.ts
@@ -41,7 +41,7 @@ class OrderbookRepository {
       where: { id: order.id },
     });
     if (count === 0) {
-      return this.models.Order.create(order);
+      return this.models.Order.upsert(order);
     } else {
       return undefined;
     }

--- a/lib/orderbook/types.ts
+++ b/lib/orderbook/types.ts
@@ -1,5 +1,5 @@
 import { SwapClients } from '../constants/enums';
-import { SwapResult } from 'lib/swaps/types';
+import { SwapSuccess } from 'lib/swaps/types';
 
 export type OrderMatch = {
   maker: Order;
@@ -13,13 +13,13 @@ export type MatchingResult = {
 
 export type PlaceOrderResult = {
   internalMatches: OwnOrder[];
-  swapResults: SwapResult[];
+  swapSuccesses: SwapSuccess[];
   remainingOrder?: OwnOrder;
 };
 
 export type PlaceOrderEvent = {
   type: PlaceOrderEventType;
-  payload: OwnOrder | SwapResult | PeerOrder;
+  payload: OwnOrder | SwapSuccess | PeerOrder;
 };
 
 export enum PlaceOrderEventType {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -21,7 +21,7 @@
         "operationId": "AddCurrency",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcAddCurrencyResponse"
             }
@@ -48,7 +48,7 @@
         "operationId": "AddPair",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcAddPairResponse"
             }
@@ -75,7 +75,7 @@
         "operationId": "Ban",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcBanResponse"
             }
@@ -102,7 +102,7 @@
         "operationId": "ChannelBalance",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcChannelBalanceResponse"
             }
@@ -128,7 +128,7 @@
         "operationId": "Connect",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcConnectResponse"
             }
@@ -155,7 +155,7 @@
         "operationId": "ListCurrencies",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListCurrenciesResponse"
             }
@@ -172,7 +172,7 @@
         "operationId": "ExecuteSwap",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcSwapSuccess"
             }
@@ -199,7 +199,7 @@
         "operationId": "GetInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetInfoResponse"
             }
@@ -216,7 +216,7 @@
         "operationId": "GetNodeInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcGetNodeInfoResponse"
             }
@@ -242,7 +242,7 @@
         "operationId": "ListOrders",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListOrdersResponse"
             }
@@ -276,7 +276,7 @@
         "operationId": "ListPairs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListPairsResponse"
             }
@@ -293,7 +293,7 @@
         "operationId": "ListPeers",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcListPeersResponse"
             }
@@ -310,7 +310,7 @@
         "operationId": "PlaceOrder",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcPlaceOrderEvent"
             }
@@ -337,7 +337,7 @@
         "operationId": "PlaceOrderSync",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcPlaceOrderResponse"
             }
@@ -364,7 +364,7 @@
         "operationId": "RemoveCurrency",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemoveCurrencyResponse"
             }
@@ -391,7 +391,7 @@
         "operationId": "RemoveOrder",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemoveOrderResponse"
             }
@@ -418,7 +418,7 @@
         "operationId": "RemovePair",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcRemovePairResponse"
             }
@@ -445,7 +445,7 @@
         "operationId": "Shutdown",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcShutdownResponse"
             }
@@ -499,7 +499,7 @@
         "operationId": "SubscribeRemovedOrders",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcOrderRemoval"
             }
@@ -516,7 +516,7 @@
         "operationId": "SubscribeSwaps",
         "responses": {
           "200": {
-            "description": "(streaming responses)",
+            "description": "A successful response.(streaming responses)",
             "schema": {
               "$ref": "#/definitions/xudrpcSwapSuccess"
             }
@@ -543,7 +543,7 @@
         "operationId": "Unban",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/xudrpcUnbanResponse"
             }
@@ -1021,11 +1021,11 @@
       "properties": {
         "internal_match": {
           "$ref": "#/definitions/xudrpcOrder",
-          "description": "An own orders (or portions thereof) that matched the newly placed order."
+          "description": "An own order (or portion thereof) that matched the newly placed order."
         },
         "swap_success": {
           "$ref": "#/definitions/xudrpcSwapSuccess",
-          "description": "A swap results of peer orders that matched the newly placed order."
+          "description": "A successful swap of a peer order that matched the newly placed order."
         },
         "remaining_order": {
           "$ref": "#/definitions/xudrpcOrder",
@@ -1079,7 +1079,7 @@
           "items": {
             "$ref": "#/definitions/xudrpcSwapSuccess"
           },
-          "description": "A list of swap results of peer orders that matched the newly placed order."
+          "description": "A list of successful swaps of peer orders that matched the newly placed order."
         },
         "remaining_order": {
           "$ref": "#/definitions/xudrpcOrder",

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -11,7 +11,7 @@ import * as lndrpc from '../proto/lndrpc_pb';
 import { Pair, Order, OrderPortion, PlaceOrderEvent } from '../orderbook/types';
 import Swaps from '../swaps/Swaps';
 import { OrderSidesArrays } from '../orderbook/TradingPair';
-import { SwapResult } from 'lib/swaps/types';
+import { SwapSuccess } from 'lib/swaps/types';
 
 /**
  * The components required by the API service layer.
@@ -189,7 +189,7 @@ class Service extends EventEmitter {
     await this.pool.unbanNode(args.nodePubKey, args.reconnect);
   }
 
-  public executeSwap = async (args: { orderId: string, pairId: string, peerPubKey: string, quantity: number }): Promise<SwapResult> => {
+  public executeSwap = async (args: { orderId: string, pairId: string, peerPubKey: string, quantity: number }): Promise<SwapSuccess> => {
     if (!this.orderBook.nomatching) {
       throw errors.NOMATCHING_MODE_IS_REQUIRED();
     }
@@ -395,11 +395,11 @@ class Service extends EventEmitter {
   /*
    * Subscribe to completed swaps.
    */
-  public subscribeSwaps = async (args: { includeTaker: boolean }, callback: (swapResult: SwapResult) => void) => {
-    this.swaps.on('swap.paid', (swapResult) => {
+  public subscribeSwaps = async (args: { includeTaker: boolean }, callback: (swapSuccess: SwapSuccess) => void) => {
+    this.swaps.on('swap.paid', (swapSuccess) => {
       // always alert client for maker matches, taker matches only when specified
-      if (swapResult.role === SwapRole.Maker || args.includeTaker) {
-        callback(swapResult);
+      if (swapSuccess.role === SwapRole.Maker || args.includeTaker) {
+        callback(swapSuccess);
       }
     });
   }

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -56,7 +56,7 @@ export type SwapDeal = {
 };
 
 /** The result of a successful swap. */
-export type SwapResult = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'rHash' | 'peerPubKey' | 'role'> & {
+export type SwapSuccess = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'rHash' | 'peerPubKey' | 'role'> & {
   /** The amount of satoshis (or equivalent) received. */
   amountReceived: number;
   /** The amount of satoshis (or equivalent) sent. */

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -471,7 +471,7 @@ message PlaceOrderRequest {
 message PlaceOrderResponse {
   // A list of own orders (or portions thereof) that matched the newly placed order.
   repeated Order internal_matches = 1 [json_name = "internal_matches"];
-  // A list of swap results of peer orders that matched the newly placed order.
+  // A list of successful swaps of peer orders that matched the newly placed order.
   repeated SwapSuccess swap_successes = 2 [json_name = "swap_successes"];
   // The remaining portion of the order, after matches, that enters the order book.
   Order remaining_order = 3 [json_name= "remaining_order"];
@@ -479,9 +479,9 @@ message PlaceOrderResponse {
 
 message PlaceOrderEvent {
   oneof event {
-    // An own orders (or portions thereof) that matched the newly placed order.
+    // An own order (or portion thereof) that matched the newly placed order.
     Order internal_match = 1 [json_name = "internal_match"];
-    // A swap results of peer orders that matched the newly placed order.
+    // A successful swap of a peer order that matched the newly placed order.
     SwapSuccess swap_success = 2 [json_name = "swap_success"];
     // The remaining portion of the order, after matches, that enters the order book.
     Order remaining_order = 3 [json_name= "remaining_order"];

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -57,8 +57,10 @@ describe('OrderBook', () => {
   });
 
   it('should append two new ownOrder', async () => {
-    const order = { pairId: 'LTC/BTC', quantity: 5, price: 55, isBuy: true, hold: 0 };
-    await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
+    const order = { pairId: PAIR_ID, quantity: 5, price: 55, isBuy: true, hold: 0 };
+    const { remainingOrder } = await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
+    expect(remainingOrder).to.not.be.undefined;
+    expect(orderBook.getOwnOrder(remainingOrder!.id, PAIR_ID)).to.not.be.undefined;
     await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
   });
 
@@ -98,17 +100,17 @@ describe('OrderBook', () => {
   it('should not add a new own order with a duplicated localId', async () => {
     const order: orders.OwnOrder = createOwnOrder(100, 10, false);
 
-    expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 
-    expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
 
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
 
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
 
-    expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 
-    expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
   });
 
   after(async () => {
@@ -150,13 +152,13 @@ describe('nomatching OrderBook', () => {
 
   it('should not place the same order twice', async () => {
     const order = createOwnOrder(100, 10, true);
-    expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
-    expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
   });
 
   it('should not remove the same order twice', async () => {
     const order = createOwnOrder(100, 10, true);
-    expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
   });

--- a/test/integration/Swap.spec.ts
+++ b/test/integration/Swap.spec.ts
@@ -8,7 +8,6 @@ import LndClient from '../../lib/lndclient/LndClient';
 import Logger, { Level } from '../../lib/Logger';
 import DB from '../../lib/db/DB';
 import { waitForSpy } from '../utils';
-import { SwapResult } from '../../lib/swaps/types';
 
 chai.use(chaiAsPromised);
 
@@ -39,7 +38,7 @@ const validTakerOrder = () => {
   };
 };
 
-const validSwapResult = () => {
+const validSwapSuccess = () => {
   return {
     orderId: '760d5291-e43e-11e8-bd56-e5c08173fa7d',
     localId: '76c61b40-e43e-11e8-a3b5-853f31e7d8e6',
@@ -138,13 +137,13 @@ describe('Swaps.Integration', () => {
       const swapListenersAdded = sandbox.spy(swaps, 'on');
       const addDealSpy = sandbox.spy(swaps, 'addDeal');
       const swapListenersRemoved = sandbox.spy(swaps, 'removeListener');
-      const swapResult = validSwapResult();
+      const swapSuccess = validSwapSuccess();
       expect(swaps.executeSwap(validMakerOrder(), validTakerOrder()))
-        .to.eventually.equal(swapResult);
+        .to.eventually.equal(swapSuccess);
       await waitForSpy(swapListenersAdded);
       expect(addDealSpy.calledOnce).to.equal(true);
-      swapResult.rHash = addDealSpy.args[0][0].rHash;
-      swaps.emit('swap.paid', swapResult);
+      swapSuccess.rHash = addDealSpy.args[0][0].rHash;
+      swaps.emit('swap.paid', swapSuccess);
       await waitForSpy(swapListenersRemoved, 'calledTwice');
     });
 


### PR DESCRIPTION
This begins all swaps in parallel when placing/matching an order and retries failed swaps immediately. Any unmatched quantity is tracked and added to the orderbook (for limit orders) after matching and swaps are complete. Previously, swaps would execute one at a time and any failed quantity would wait to be retried until all first-attempt swaps completed. This should result in significantly faster order execution for orders that match with multiple peer orders and therefore require multiple swaps.

Closes #654.