### PR TITLE
style: add one-line tslint rule

### DIFF
--- a/tasks/config/sample.ts
+++ b/tasks/config/sample.ts
@@ -58,7 +58,7 @@ export default async () => {
       result += value[0] + ' = ';
       if (typeof value[1] === 'string') {
         result += '"' + value[1] + '"\n';
-      }else if (Array.isArray(value[1])) {
+      } else if (Array.isArray(value[1])) {
         result += '[]\n';
       } else {
         result += value[1] + '\n';

--- a/tslint.json
+++ b/tslint.json
@@ -65,6 +65,7 @@
         "asyncArrow": "always",
         "method": "never"
       }
-    ]
+    ],
+    "one-line": [true, "check-catch", "check-finally", "check-open-brace", "check-whitespace"]
   }
 }


### PR DESCRIPTION
This adds a rule to enforce existing style in the codebase regarding whitespace before keywords like `else`, `catch`, and `finally` when they are on the same line as the closing brace for the previous block.