### PR TITLE
refactor(db): add getter types for TradeInstance

### DIFF
--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -68,7 +68,11 @@ export type TradeFactory = {
 
 export type TradeAttributes = TradeFactory;
 
-export type TradeInstance = TradeAttributes & Sequelize.Instance<TradeAttributes>;
+export type TradeInstance = TradeAttributes & Sequelize.Instance<TradeAttributes> & {
+  getMakerOrder: Sequelize.BelongsToGetAssociationMixin<OrderInstance>;
+  getTakerOrder: Sequelize.BelongsToGetAssociationMixin<OrderInstance>;
+  getSwapDeal: Sequelize.BelongsToGetAssociationMixin<SwapDealInstance>;
+};
 
 /* Node */
 export type NodeFactory = NodeConnectionInfo;


### PR DESCRIPTION
This adds type definitions for the getter methods for database objects associated with `TradeInstances`, namely the maker & taker orders and swap deal.