### PR TITLE
fix(p2p): handle multiple peer reputation events

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -38,9 +38,9 @@ interface Peer {
   on(event: 'error', listener: (err: Error) => void): this;
   on(event: 'pairDropped', listener: (pair: string) => void): this;
   on(event: 'nodeStateUpdate', listener: () => void): this;
+  on(event: 'reputation', listener: (event: ReputationEvent) => void): this;
   once(event: 'open', listener: () => void): this;
   once(event: 'close', listener: () => void): this;
-  once(event: 'reputation', listener: (event: ReputationEvent) => void): this;
   emit(event: 'connect'): boolean;
   emit(event: 'reputation', reputationEvent: ReputationEvent): boolean;
   emit(event: 'open'): boolean;

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -657,7 +657,7 @@ class Pool extends EventEmitter {
 
     peer.once('close', () => this.handlePeerClose(peer));
 
-    peer.once('reputation', async (event) => {
+    peer.on('reputation', async (event) => {
       this.logger.debug(`Peer (${peer.label}): reputation event: ${ReputationEvent[event]}`);
       if (peer.nodePubKey) {
         await this.nodes.addReputationEvent(peer.nodePubKey, event);


### PR DESCRIPTION
This fixes a bug where `once` was being used instead of `on` to handle peer reputation events, meaning that only the first reputation event for a peer would actually update its score.