### PR TITLE
feat(swaps): define behavior for swap errors

### DIFF
--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -51,7 +51,7 @@ export enum SwapPhase {
   SendingAmount = 3,
   /** We have received the agreed amount of the swap, and the preimage is now known to both sides. */
   AmountReceived = 4,
-  /* The swap has been formally completed and both sides have confirmed they've received payment. */
+  /** The swap has been formally completed and both sides have confirmed they've received payment. */
   SwapCompleted = 5,
 }
 
@@ -65,10 +65,15 @@ export enum ReputationEvent {
   ManualBan = 0,
   ManualUnban = 1,
   PacketTimeout = 2,
-  SwapFailure = 3,
-  SwapSuccess = 4,
-  WireProtocolErr = 5,
-  InvalidAuth = 6,
+  WireProtocolErr = 3,
+  InvalidAuth = 4,
+  SwapSuccess = 5,
+  /** When a swap is accepted and is attempted to be executed but fails. */
+  SwapFailure = 6,
+  /** When a swap is accepted and then fails due to exceeding time limits. */
+  SwapTimeout = 7,
+  /** When a swap fails due to unexpected or possibly malicious behavior. */
+  SwapMisbehavior = 8,
 }
 
 export enum SwapFailureReason {

--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -134,7 +134,8 @@ class TradingPair {
   }
 
   /**
-   * Remove all orders given a peer pubKey.
+   * Remove all of a peer's orders.
+   * @param peerPubKey the node pub key of the peer
    */
   public removePeerOrders = (peerPubKey?: string): PeerOrder[] => {
     // if incoming peerPubKey is undefined or empty, don't even try to find it in order queues

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -13,6 +13,8 @@ export const reputationEventWeight = {
   [ReputationEvent.SwapSuccess]: 1,
   [ReputationEvent.WireProtocolErr]: -5,
   [ReputationEvent.InvalidAuth]: -20,
+  [ReputationEvent.SwapTimeout]: -15,
+  [ReputationEvent.SwapMisbehavior]: -20,
 };
 
 // TODO: inform node about getting banned

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -82,6 +82,7 @@ class Peer extends EventEmitter {
   private packetCount = 0;
   private network = new Network(NetworkMagic.TestNet); // TODO: inject from constructor to support more networks
   private framer: Framer;
+  private deactivatedPairs = new Set<string>();
   /** Interval to check required responses from peer. */
   private static readonly STALL_INTERVAL = 5000;
   /** Interval for pinging peers. */
@@ -114,8 +115,15 @@ class Peer extends EventEmitter {
     return this.nodeState ? this.nodeState.addresses : undefined;
   }
 
+  /** Returns a list of active trading pairs supported by this peer. */
   public get pairs(): string[] | undefined {
-    return this.nodeState ? this.nodeState.pairs : undefined;
+    if (this.nodeState) {
+      const activePairs = this.nodeState.pairs.filter((pair) => {
+        return !this.deactivatedPairs.has(pair);
+      });
+      return activePairs;
+    }
+    return undefined;
   }
 
   public get connected(): boolean {
@@ -337,6 +345,21 @@ class Peer extends EventEmitter {
   public sendNodes = (nodes: NodeConnectionInfo[], reqId: string): void => {
     const packet = new packets.NodesPacket(nodes, reqId);
     this.sendPacket(packet);
+  }
+
+  /**
+   * Manually deactivates a trading pair with this peer.
+   */
+  public deactivatePair = (pairId: string) => {
+    if (!this.nodeState) {
+      throw new Error('cannot deactivate a trading pair before handshake is complete');
+    }
+    const index = this.nodeState.pairs.indexOf(pairId);
+    if (index >= 0) {
+      this.deactivatedPairs.add(pairId);
+      this.emit('pairDropped', pairId);
+    }
+    // TODO: schedule a timer to see whether this pair can be reactivated
   }
 
   private sendRaw = (data: Buffer) => {
@@ -805,7 +828,7 @@ class Peer extends EventEmitter {
     if (prevNodeState) {
       prevNodeState.pairs.forEach((pairId) => {
         if (!nodeStateUpdate.pairs || !nodeStateUpdate.pairs.includes(pairId)) {
-          // a trading pair was in the old handshake state but not in the updated one
+          // a trading pair was in the old node state but not in the updated one
           this.emit('pairDropped', pairId);
         }
       });

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -415,6 +415,11 @@ class Pool extends EventEmitter {
     }
   }
 
+  // A wrapper for [[NodeList.addReputationEvent]].
+  public addReputationEvent = (nodePubKey: string, event: ReputationEvent) => {
+    return this.nodes.addReputationEvent(nodePubKey, event);
+  }
+
   public sendToPeer = (nodePubKey: string, packet: Packet) => {
     const peer = this.peers.get(nodePubKey);
     if (!peer) {
@@ -423,6 +428,10 @@ class Pool extends EventEmitter {
     peer.sendPacket(packet);
   }
 
+  /**
+   * Gets a peer by its node pub key. Throws a [[NOT_CONNECTED]] error if the pub key does not
+   * match any currently connected peer.
+   */
   public getPeer = (nodePubKey: string) => {
     const peer = this.peers.get(nodePubKey);
     if (!peer) {
@@ -660,7 +669,7 @@ class Pool extends EventEmitter {
     peer.once('reputation', async (event) => {
       this.logger.debug(`Peer (${peer.label}): reputation event: ${ReputationEvent[event]}`);
       if (peer.nodePubKey) {
-        await this.nodes.addReputationEvent(peer.nodePubKey, event);
+        await this.addReputationEvent(peer.nodePubKey, event);
       }
     });
   }

--- a/test/integration/Swap.spec.ts
+++ b/test/integration/Swap.spec.ts
@@ -111,6 +111,7 @@ describe('Swaps.Integration', () => {
     peer.getLndPubKey = () => '1234567890';
     // pool
     pool = sandbox.createStubInstance(Pool) as any;
+    pool.addReputationEvent = () => Promise.resolve(true);
     pool.getPeer = () => peer;
     // queryRoutes response
     queryRoutesResponse = () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "noUnusedLocals": false,                  /* Report errors on unused locals. */
     "noUnusedParameters": true,               /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */

--- a/tslint.json
+++ b/tslint.json
@@ -66,6 +66,7 @@
         "method": "never"
       }
     ],
-    "one-line": [true, "check-catch", "check-finally", "check-open-brace", "check-whitespace"]
+    "one-line": [true, "check-catch", "check-finally", "check-open-brace", "check-whitespace"],
+    "no-switch-case-fall-through": true
   }
 }


### PR DESCRIPTION
Closes #661.

This adds logic to handle swap failures according to the reason for the failure. Certain failures suggest a persistent, underlying issue with swaps for that peer and trading pair, and in this case we drop all orders for that peer and trading pair to avoid subsequent failures. We also penalize the peer for swaps that fail due to potential misbehavior or due to a timeout. Timeouts result in delays that degrade the trading experience moreso than regular swap failures.