### PR TITLE
fix(orderbook): remove entire order correctly

### DIFF
--- a/lib/cli/commands/removeorder.ts
+++ b/lib/cli/commands/removeorder.ts
@@ -12,7 +12,7 @@ export const builder = {
   },
   quantity: {
     type: 'number',
-    describe: 'quantity to remove, if unspecified the entire order is removed',
+    describe: 'quantity to remove, if zero or unspecified the entire order is removed',
   },
 };
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -496,7 +496,7 @@ class OrderBook extends EventEmitter {
 
     const removableQuantity = order.quantity - order.hold;
     if (remainingQuantityToRemove <= removableQuantity) {
-      this.removeOwnOrder(orderIdentifier.id, orderIdentifier.pairId, quantityToRemove);
+      this.removeOwnOrder(orderIdentifier.id, orderIdentifier.pairId, remainingQuantityToRemove);
       remainingQuantityToRemove = 0;
     } else {
       // we can't remove the entire amount because of a hold on the order


### PR DESCRIPTION
Fixes #804.

This fixes an unintentional assertion error when removing an order via the API where removing an order without specifying a quantity, which should remove the entire order, was instead removing none of it.