### PR TITLE
fix(p2p): toggle opened after handshake

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -207,7 +207,6 @@ class Peer extends EventEmitter {
     assert(this.inbound || expectedNodePubKey);
     assert(!retryConnecting || !this.inbound);
 
-    this.opened = true;
     this.expectedNodePubKey = expectedNodePubKey;
 
     await this.initConnection(retryConnecting);
@@ -252,6 +251,7 @@ class Peer extends EventEmitter {
     this.pingTimer = setInterval(this.sendPing, Peer.PING_INTERVAL);
 
     // let listeners know that this peer is ready to go
+    this.opened = true;
     this.emit('open');
   }
 
@@ -621,7 +621,7 @@ class Peer extends EventEmitter {
   private isPacketSolicited = (packet: Packet): boolean => {
     let solicited = true;
 
-    if (!this.opened && packet.type !== PacketType.SessionInit && packet.type !== PacketType.SessionAck) {
+    if (!this.opened && packet.type !== PacketType.SessionInit && packet.type !== PacketType.SessionAck && packet.type !== PacketType.Disconnecting) {
       // until the connection is opened, we only accept SessionInit/SessionAck packets
       solicited = false;
     }


### PR DESCRIPTION
This moves the logic for toggling the `opened` property of a peer to occur after the handshake is complete and verified. We rely on the `opened` property to determine whether we accept non-handshake packets, previously it would have been possible to accidentally accept all packets from a peer while the handshake was still ongoing.