### PR TITLE
feat(rpc): add failed swaps to PlaceOrderSync

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -629,6 +629,7 @@
 | internal_matches | [Order](#xudrpc.Order) | repeated | A list of own orders (or portions thereof) that matched the newly placed order. |
 | swap_successes | [SwapSuccess](#xudrpc.SwapSuccess) | repeated | A list of successful swaps of peer orders that matched the newly placed order. |
 | remaining_order | [Order](#xudrpc.Order) |  | The remaining portion of the order, after matches, that enters the order book. |
+| swap_failures | [SwapFailure](#xudrpc.SwapFailure) | repeated | A list of swap attempts that failed. |
 
 
 

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -13,7 +13,7 @@ import { LndInfo } from '../lndclient/LndClient';
 import { SwapSuccess } from '../swaps/types';
 
 /**
- * Creates an xudrpc Order message from a [[StampedOrder]].
+ * Creates an xudrpc Order message from an [[Order]].
  */
 const createOrder = (order: Order) => {
   const grpcOrder = new xudrpc.Order();
@@ -78,6 +78,9 @@ const createPlaceOrderResponse = (result: PlaceOrderResult) => {
 
   const swapSuccesses = result.swapSuccesses.map(swapSuccess => createSwapSuccess(swapSuccess));
   response.setSwapSuccessesList(swapSuccesses);
+
+  const swapFailures = result.swapFailures.map(swapFailure => createSwapFailure(swapFailure));
+  response.setSwapFailuresList(swapFailures);
 
   if (result.remainingOrder) {
     response.setRemainingOrder(createOrder(result.remainingOrder));

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -247,6 +247,7 @@ class OrderBook extends EventEmitter {
       return {
         internalMatches: [],
         swapSuccesses: [],
+        swapFailures: [],
         remainingOrder: stampedOrder,
       };
     }
@@ -292,6 +293,7 @@ class OrderBook extends EventEmitter {
       return {
         internalMatches: [],
         swapSuccesses: [],
+        swapFailures: [],
         remainingOrder: order,
       };
     }
@@ -306,6 +308,8 @@ class OrderBook extends EventEmitter {
     const internalMatches: OwnOrder[] = [];
     /** Successful swaps performed for the placed order. */
     const swapSuccesses: SwapSuccess[] = [];
+    /** Failed swaps attempted for the placed order. */
+    const swapFailures: PeerOrder[] = [];
 
     /**
      * The routine for retrying a portion of the order that failed a swap attempt.
@@ -371,6 +375,7 @@ class OrderBook extends EventEmitter {
           onUpdate && onUpdate({ type: PlaceOrderEventType.SwapSuccess, payload: swapSuccess });
         } catch (err) {
           this.logger.warn(`swap for ${portion.quantity} failed during order matching, will repeat matching routine for failed swap quantity`);
+          swapFailures.push(maker);
           onUpdate && onUpdate({ type: PlaceOrderEventType.SwapFailure, payload: maker });
           await retryFailedSwap(portion.quantity);
         }
@@ -395,6 +400,7 @@ class OrderBook extends EventEmitter {
     return {
       internalMatches,
       swapSuccesses,
+      swapFailures,
       remainingOrder,
     };
   }

--- a/lib/orderbook/types.ts
+++ b/lib/orderbook/types.ts
@@ -14,6 +14,7 @@ export type MatchingResult = {
 export type PlaceOrderResult = {
   internalMatches: OwnOrder[];
   swapSuccesses: SwapSuccess[];
+  swapFailures: PeerOrder[];
   remainingOrder?: OwnOrder;
 };
 

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1084,6 +1084,13 @@
         "remaining_order": {
           "$ref": "#/definitions/xudrpcOrder",
           "description": "The remaining portion of the order, after matches, that enters the order book."
+        },
+        "swap_failures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/xudrpcSwapFailure"
+          },
+          "description": "A list of swap attempts that failed."
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -910,6 +910,11 @@ export class PlaceOrderResponse extends jspb.Message {
   getRemainingOrder(): Order | undefined;
   setRemainingOrder(value?: Order): void;
 
+  clearSwapFailuresList(): void;
+  getSwapFailuresList(): Array<SwapFailure>;
+  setSwapFailuresList(value: Array<SwapFailure>): void;
+  addSwapFailures(value?: SwapFailure, index?: number): SwapFailure;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PlaceOrderResponse.AsObject;
   static toObject(includeInstance: boolean, msg: PlaceOrderResponse): PlaceOrderResponse.AsObject;
@@ -925,6 +930,7 @@ export namespace PlaceOrderResponse {
     internalMatchesList: Array<Order.AsObject>,
     swapSuccessesList: Array<SwapSuccess.AsObject>,
     remainingOrder?: Order.AsObject,
+    swapFailuresList: Array<SwapFailure.AsObject>,
   }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -6403,7 +6403,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.xudrpc.PlaceOrderResponse.repeatedFields_ = [1,2];
+proto.xudrpc.PlaceOrderResponse.repeatedFields_ = [1,2,4];
 
 
 
@@ -6438,7 +6438,9 @@ proto.xudrpc.PlaceOrderResponse.toObject = function(includeInstance, msg) {
     proto.xudrpc.Order.toObject, includeInstance),
     swapSuccessesList: jspb.Message.toObjectList(msg.getSwapSuccessesList(),
     proto.xudrpc.SwapSuccess.toObject, includeInstance),
-    remainingOrder: (f = msg.getRemainingOrder()) && proto.xudrpc.Order.toObject(includeInstance, f)
+    remainingOrder: (f = msg.getRemainingOrder()) && proto.xudrpc.Order.toObject(includeInstance, f),
+    swapFailuresList: jspb.Message.toObjectList(msg.getSwapFailuresList(),
+    proto.xudrpc.SwapFailure.toObject, includeInstance)
   };
 
   if (includeInstance) {
@@ -6489,6 +6491,11 @@ proto.xudrpc.PlaceOrderResponse.deserializeBinaryFromReader = function(msg, read
       var value = new proto.xudrpc.Order;
       reader.readMessage(value,proto.xudrpc.Order.deserializeBinaryFromReader);
       msg.setRemainingOrder(value);
+      break;
+    case 4:
+      var value = new proto.xudrpc.SwapFailure;
+      reader.readMessage(value,proto.xudrpc.SwapFailure.deserializeBinaryFromReader);
+      msg.addSwapFailures(value);
       break;
     default:
       reader.skipField();
@@ -6541,6 +6548,14 @@ proto.xudrpc.PlaceOrderResponse.serializeBinaryToWriter = function(message, writ
       3,
       f,
       proto.xudrpc.Order.serializeBinaryToWriter
+    );
+  }
+  f = message.getSwapFailuresList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      4,
+      f,
+      proto.xudrpc.SwapFailure.serializeBinaryToWriter
     );
   }
 };
@@ -6635,6 +6650,37 @@ proto.xudrpc.PlaceOrderResponse.prototype.clearRemainingOrder = function() {
  */
 proto.xudrpc.PlaceOrderResponse.prototype.hasRemainingOrder = function() {
   return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * repeated SwapFailure swap_failures = 4;
+ * @return {!Array<!proto.xudrpc.SwapFailure>}
+ */
+proto.xudrpc.PlaceOrderResponse.prototype.getSwapFailuresList = function() {
+  return /** @type{!Array<!proto.xudrpc.SwapFailure>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.xudrpc.SwapFailure, 4));
+};
+
+
+/** @param {!Array<!proto.xudrpc.SwapFailure>} value */
+proto.xudrpc.PlaceOrderResponse.prototype.setSwapFailuresList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 4, value);
+};
+
+
+/**
+ * @param {!proto.xudrpc.SwapFailure=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.xudrpc.SwapFailure}
+ */
+proto.xudrpc.PlaceOrderResponse.prototype.addSwapFailures = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.xudrpc.SwapFailure, opt_index);
+};
+
+
+proto.xudrpc.PlaceOrderResponse.prototype.clearSwapFailuresList = function() {
+  this.setSwapFailuresList([]);
 };
 
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -474,7 +474,9 @@ message PlaceOrderResponse {
   // A list of successful swaps of peer orders that matched the newly placed order.
   repeated SwapSuccess swap_successes = 2 [json_name = "swap_successes"];
   // The remaining portion of the order, after matches, that enters the order book.
-  Order remaining_order = 3 [json_name= "remaining_order"];
+  Order remaining_order = 3 [json_name = "remaining_order"];
+  // A list of swap attempts that failed.
+  repeated SwapFailure swap_failures = 4 [json_name = "swap_failures"];
 }
 
 message PlaceOrderEvent {
@@ -486,7 +488,7 @@ message PlaceOrderEvent {
     // The remaining portion of the order, after matches, that enters the order book.
     Order remaining_order = 3 [json_name= "remaining_order"];
     // A swap attempt that failed.
-    SwapFailure swap_failure = 4 [json_name = "swap_failures"];
+    SwapFailure swap_failure = 4 [json_name = "swap_failure"];
   }
 }
 


### PR DESCRIPTION
This adds a list of failed swaps to the `PlaceOrderSync` response to match the behavior of the asynchronous `PlaceOrder` call which returns information about failed swaps.

Solves part of #807.