### PR TITLE
refactor: conditionally log init connections

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -118,10 +118,14 @@ class Pool extends EventEmitter {
     this.bindNodeList();
 
     this.nodes.load().then(() => {
-      this.logger.info('Connecting to known / previously connected peers');
+      if (this.nodes.count > 0) {
+        this.logger.info('Connecting to known / previously connected peers');
+      }
       return this.connectNodes(this.nodes, false, true);
     }).then(() => {
-      this.logger.info('Completed start-up connections to known peers.');
+      if (this.nodes.count > 0) {
+        this.logger.info('Completed start-up connections to known peers.');
+      }
     }).catch((reason) => {
       this.logger.error('Unexpected error connecting to known peers on startup', reason);
     });


### PR DESCRIPTION
This only logs messages that we've started and completed connecting to known nodes on startup when we have known, unbanned nodes to connect to.