### PR TITLE
fix(packets): correct order packet validation

### DIFF
--- a/lib/p2p/packets/types/OrderInvalidationPacket.ts
+++ b/lib/p2p/packets/types/OrderInvalidationPacket.ts
@@ -23,7 +23,7 @@ class OrderInvalidationPacket extends Packet<OrderInvalidationPacketBody> {
     return !!(obj.id
       && obj.orderId
       && obj.pairId
-      && obj.quantity
+      && obj.quantity > 0
     );
   }
 

--- a/lib/p2p/packets/types/OrderPacket.ts
+++ b/lib/p2p/packets/types/OrderPacket.ts
@@ -19,11 +19,11 @@ class OrderPacket extends Packet<OutgoingOrder> {
 
   private static validate = (obj: pb.OrderPacket.AsObject): boolean => {
     return !!(obj.id
-      && obj.id
       && obj.order
+      && obj.order.id
       && obj.order.pairId
-      && obj.order.price
-      && obj.order.quantity
+      && obj.order.price > 0
+      && obj.order.quantity > 0
     );
   }
 


### PR DESCRIPTION
This is a minor fix to the logic to validate an order packet, primarily checking that the `order.id` field is not empty. It also removes a duplicate check on the `id` header field and aligns the logic with the `OrdersPacket` validation which checks that `price` and `quantity` are not just non-zero but positive.