### PR TITLE
perf(p2p): use async randomBytes for packet framer

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -624,7 +624,7 @@ class OrderBook extends EventEmitter {
         orders.sell.forEach(order => outgoingOrders.push(OrderBook.createOutgoingOrder(order)));
       }
     });
-    peer.sendOrders(outgoingOrders, reqId);
+    await peer.sendOrders(outgoingOrders, reqId);
   }
 
   /**
@@ -673,7 +673,7 @@ class OrderBook extends EventEmitter {
 
     if (!Swaps.validateSwapRequest(requestPacket.body!)) {
       // TODO: penalize peer for invalid swap request
-      peer.sendPacket(new SwapFailedPacket({
+      await peer.sendPacket(new SwapFailedPacket({
         rHash,
         failureReason: SwapFailureReason.InvalidSwapRequest,
       }, requestPacket.header.id));
@@ -682,7 +682,7 @@ class OrderBook extends EventEmitter {
 
     const order = this.tryGetOwnOrder(orderId, pairId);
     if (!order) {
-      peer.sendPacket(new SwapFailedPacket({
+      await peer.sendPacket(new SwapFailedPacket({
         rHash,
         failureReason: SwapFailureReason.OrderNotFound,
       }, requestPacket.header.id));
@@ -710,7 +710,7 @@ class OrderBook extends EventEmitter {
         this.removeOrderHold(order.id, pairId, quantity);
       }
     } else {
-      peer.sendPacket(new SwapFailedPacket({
+      await peer.sendPacket(new SwapFailedPacket({
         rHash,
         failureReason: SwapFailureReason.OrderOnHold,
       }, requestPacket.header.id));

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -215,29 +215,29 @@ class Peer extends EventEmitter {
     await this.handshake(ownNodeState, nodeKey);
 
     if (this.expectedNodePubKey && this.nodePubKey !== this.expectedNodePubKey) {
-      this.close(DisconnectionReason.UnexpectedIdentity);
+      await this.close(DisconnectionReason.UnexpectedIdentity);
       throw errors.UNEXPECTED_NODE_PUB_KEY(this.nodePubKey!, this.expectedNodePubKey, addressUtils.toString(this.address));
     }
 
     if (this.nodePubKey === ownNodeState.nodePubKey) {
-      this.close(DisconnectionReason.ConnectedToSelf);
+      await this.close(DisconnectionReason.ConnectedToSelf);
       throw errors.ATTEMPTED_CONNECTION_TO_SELF;
     }
 
     // Check if version is semantic, and higher than minCompatibleVersion.
     if (!semver.valid(this.version)) {
-      this.close(DisconnectionReason.MalformedVersion);
+      await this.close(DisconnectionReason.MalformedVersion);
       throw errors.MALFORMED_VERSION(addressUtils.toString(this.address), this.version);
     }
     // dev.note: compare returns 0 if v1 == v2, or 1 if v1 is greater, or -1 if v2 is greater.
     if (semver.compare(this.version, minCompatibleVersion) === -1) {
-      this.close(DisconnectionReason.IncompatibleProtocolVersion);
+      await this.close(DisconnectionReason.IncompatibleProtocolVersion);
       throw errors.INCOMPATIBLE_VERSION(addressUtils.toString(this.address), minCompatibleVersion, this.version);
     }
 
     // request peer's known nodes only if p2p.discover option is true
     if (this.config.discover) {
-      this.sendPacket(new packets.GetNodesPacket());
+      await this.sendPacket(new packets.GetNodesPacket());
       if (this.config.discoverminutes === 0) {
         // timer is disabled
         this.discoverTimer = undefined; // defensive programming
@@ -258,7 +258,7 @@ class Peer extends EventEmitter {
   /**
    * Close a peer by ensuring the socket is destroyed and terminating all timers.
    */
-  public close = (reason?: DisconnectionReason, reasonPayload?: string): void => {
+  public close = async (reason?: DisconnectionReason, reasonPayload?: string): Promise<void> => {
     if (this.closed) {
       return;
     }
@@ -269,7 +269,7 @@ class Peer extends EventEmitter {
       if (reason !== undefined) {
         this.logger.debug(`Peer (${ this.label }): closing socket. reason: ${DisconnectionReason[reason]}`);
         this.sentDisconnectionReason = reason;
-        this.sendPacket(new packets.DisconnectingPacket({ reason, payload: reasonPayload }));
+        await this.sendPacket(new packets.DisconnectingPacket({ reason, payload: reasonPayload }));
       }
 
       if (!this.socket.destroyed) {
@@ -324,8 +324,8 @@ class Peer extends EventEmitter {
     this.connectionRetriesRevoked = true;
   }
 
-  public sendPacket = (packet: Packet): void => {
-    const data = this.framer.frame(packet, this.outEncryptionKey);
+  public sendPacket = async (packet: Packet): Promise<void> => {
+    const data = await this.framer.frame(packet, this.outEncryptionKey);
     this.sendRaw(data);
 
     this.logger.trace(`Sent ${PacketType[packet.type]} packet to ${this.label}: ${JSON.stringify(packet)}`);
@@ -336,15 +336,15 @@ class Peer extends EventEmitter {
     }
   }
 
-  public sendOrders = (orders: OutgoingOrder[], reqId: string): void => {
+  public sendOrders = async (orders: OutgoingOrder[], reqId: string): Promise<void> => {
     const packet = new packets.OrdersPacket(orders, reqId);
-    this.sendPacket(packet);
+    await this.sendPacket(packet);
   }
 
   /** Sends a [[NodesPacket]] containing node connection info to this peer. */
-  public sendNodes = (nodes: NodeConnectionInfo[], reqId: string): void => {
+  public sendNodes = async (nodes: NodeConnectionInfo[], reqId: string): Promise<void> => {
     const packet = new packets.NodesPacket(nodes, reqId);
-    this.sendPacket(packet);
+    await this.sendPacket(packet);
   }
 
   /**
@@ -418,23 +418,23 @@ class Peer extends EventEmitter {
         resolve();
       };
 
-      const onError = (err: Error) => {
+      const onError = async (err: Error) => {
         cleanup();
 
         if (!retry) {
-          this.close();
+          await this.close();
           reject(errors.COULD_NOT_CONNECT(this.address, err));
           return;
         }
 
         if (Date.now() - startTime + retryDelay > Peer.CONNECTION_RETRIES_MAX_PERIOD) {
-          this.close();
+          await this.close();
           reject(errors.CONNECTION_RETRIES_MAX_PERIOD_EXCEEDED);
           return;
         }
 
         if (this.connectionRetriesRevoked) {
-          this.close();
+          await this.close();
           reject(errors.CONNECTION_RETRIES_REVOKED);
           return;
         }
@@ -499,7 +499,7 @@ class Peer extends EventEmitter {
   /**
    * Potentially timeout peer if it hasn't responded.
    */
-  private checkTimeout = () => {
+  private checkTimeout = async () => {
     const now = ms();
 
     for (const [packetId, entry] of this.responseMap) {
@@ -508,8 +508,7 @@ class Peer extends EventEmitter {
         const err = errors.RESPONSE_TIMEOUT(request);
         this.emitError(err.message);
         entry.reject(err.message);
-        this.close(DisconnectionReason.ResponseStalling, packetId);
-        return;
+        await this.close(DisconnectionReason.ResponseStalling, packetId);
       }
     }
   }
@@ -576,7 +575,7 @@ class Peer extends EventEmitter {
       // socket close event will be called immediately after the socket error
     });
 
-    this.socket!.once('close', (hadError) => {
+    this.socket!.once('close', async (hadError) => {
       // emitted once the socket is fully closed
       if (this.nodePubKey === undefined) {
         this.logger.info(`Socket closed prior to handshake (${addressUtils.toString(this.address)})`);
@@ -585,7 +584,7 @@ class Peer extends EventEmitter {
       } else {
         this.logger.info(`Peer ${this.nodePubKey} socket closed`);
       }
-      this.close();
+      await this.close();
     });
 
     this.socket!.on('data', this.parser.feed);
@@ -596,7 +595,7 @@ class Peer extends EventEmitter {
   private bindParser = (parser: Parser): void => {
     parser.on('packet', this.handlePacket);
 
-    parser.on('error', (err: {message: string, code: string}) => {
+    parser.on('error', async (err: {message: string, code: string}) => {
       if (this.closed) {
         return;
       }
@@ -611,8 +610,7 @@ class Peer extends EventEmitter {
         case errorCodes.FRAMER_INVALID_MSG_LENGTH:
           this.logger.warn(`Peer (${this.label}): ${err.message}`);
           this.emit('reputation', ReputationEvent.WireProtocolErr);
-          this.close(DisconnectionReason.WireProtocolErr, err.message);
-          break;
+          await this.close(DisconnectionReason.WireProtocolErr, err.message);
       }
     });
   }
@@ -635,7 +633,7 @@ class Peer extends EventEmitter {
     return solicited;
   }
 
-  private handlePacket = (packet: Packet): void => {
+  private handlePacket = async (packet: Packet): Promise<void> => {
     this.lastRecv = Date.now();
     const sender = this.nodePubKey !== undefined ? this.nodePubKey : addressUtils.toString(this.address);
     this.logger.trace(`Received ${PacketType[packet.type]} packet from ${sender}${JSON.stringify(packet)}`);
@@ -651,7 +649,7 @@ class Peer extends EventEmitter {
           break;
         }
         case PacketType.Ping: {
-          this.handlePing(packet);
+          await this.handlePing(packet);
           break;
         }
         case PacketType.Disconnecting: {
@@ -684,7 +682,7 @@ class Peer extends EventEmitter {
    * @param {SessionInitPacket} packet
    * @param {NodeKey} nodeKey
    */
-  private authenticate = (packet: packets.SessionInitPacket, nodeKey: NodeKey) => {
+  private authenticate = async (packet: packets.SessionInitPacket, nodeKey: NodeKey) => {
     const body = packet.body!;
     const { sign, ...bodyWithoutSign } = body;
     const { nodePubKey } = body.nodeState; // the peer pubkey
@@ -693,7 +691,7 @@ class Peer extends EventEmitter {
     // verify that msg was intended for us
     if (peerPubKey !== nodeKey.nodePubKey) {
       this.emit('reputation', ReputationEvent.InvalidAuth);
-      this.close(DisconnectionReason.AuthFailureInvalidTarget);
+      await this.close(DisconnectionReason.AuthFailureInvalidTarget);
       throw errors.AUTH_FAILURE_INVALID_TARGET(nodePubKey, peerPubKey);
     }
 
@@ -708,7 +706,7 @@ class Peer extends EventEmitter {
 
     if (!verified) {
       this.emit('reputation', ReputationEvent.InvalidAuth);
-      this.close(DisconnectionReason.AuthFailureInvalidSignature);
+      await this.close(DisconnectionReason.AuthFailureInvalidSignature);
       throw errors.AUTH_FAILURE_INVALID_SIGNATURE(nodePubKey);
     }
   }
@@ -717,7 +715,7 @@ class Peer extends EventEmitter {
     const ECDH = crypto.createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
     const packet = this.createSessionInitPacket(ephemeralPubKey, ownNodeState, expectedNodePubKey, nodeKey);
-    this.sendPacket(packet);
+    await this.sendPacket(packet);
     await this.wait(packet.header.id, Peer.RESPONSE_TIMEOUT, (packet: Packet) => {
       // enabling in-encryption synchronously,
       // expecting the following peer msg to be encrypted
@@ -727,14 +725,14 @@ class Peer extends EventEmitter {
     });
   }
 
-  private ackSession = (sessionInit: packets.SessionInitPacket, nodeKey: NodeKey): void => {
-    this.authenticate(sessionInit, nodeKey);
+  private ackSession = async (sessionInit: packets.SessionInitPacket, nodeKey: NodeKey): Promise<void> => {
+    await this.authenticate(sessionInit, nodeKey);
     this.nodeState = sessionInit.body!.nodeState;
 
     const ECDH = crypto.createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
 
-    this.sendPacket(new packets.SessionAckPacket({ ephemeralPubKey }, sessionInit.header.id));
+    await this.sendPacket(new packets.SessionAckPacket({ ephemeralPubKey }, sessionInit.header.id));
 
     // enabling out-encryption synchronously,
     // so that the following msg will be encrypted
@@ -748,35 +746,32 @@ class Peer extends EventEmitter {
       assert(this.expectedNodePubKey);
       await this.initSession(ownNodeState, nodeKey, this.expectedNodePubKey!);
       const sessionInit = await this.waitSessionInit();
-      this.ackSession(sessionInit, nodeKey);
+      await this.ackSession(sessionInit, nodeKey);
     } else {
       // inbound handshake
       const sessionInit = await this.waitSessionInit();
-      this.ackSession(sessionInit, nodeKey);
+      await this.ackSession(sessionInit, nodeKey);
       await this.initSession(ownNodeState, nodeKey, sessionInit.body!.nodeState.nodePubKey);
     }
   }
 
-  private sendPing = (): packets.PingPacket => {
+  private sendPing = async (): Promise<void> => {
     const packet = new packets.PingPacket();
-    this.sendPacket(packet);
-    return packet;
+    await this.sendPacket(packet);
   }
 
-  private sendGetNodes = (): packets.PingPacket => {
+  private sendGetNodes = async (): Promise<void> => {
     const packet =  new packets.GetNodesPacket();
-    this.sendPacket(packet);
-    return packet;
+    await this.sendPacket(packet);
   }
 
-  private sendPong = (pingId: string): packets.PongPacket => {
+  private sendPong = async (pingId: string): Promise<void> => {
     const packet = new packets.PongPacket(undefined, pingId);
-    this.sendPacket(packet);
-    return packet;
+    await this.sendPacket(packet);
   }
 
-  private handlePing = (packet: packets.PingPacket): void  => {
-    this.sendPong(packet.header.id);
+  private handlePing = async (packet: packets.PingPacket): Promise<void>  => {
+    await this.sendPong(packet.header.id);
   }
 
   private createSessionInitPacket = (

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -159,8 +159,8 @@ class Pool extends EventEmitter {
   public updateNodeState = (nodeStateUpdate: NodeStateUpdate) => {
     this.nodeState = { ...this.nodeState, ...nodeStateUpdate };
     const packet = new packets.NodeStateUpdatePacket(this.nodeState);
-    this.peers.forEach((peer) => {
-      peer.sendPacket(packet);
+    this.peers.forEach(async (peer) => {
+      await peer.sendPacket(packet);
     });
   }
 
@@ -174,7 +174,7 @@ class Pool extends EventEmitter {
       await this.unlisten();
     }
 
-    this.closePendingConnections();
+    await this.closePendingConnections();
     this.closePeers();
 
     this.connected = false;
@@ -187,8 +187,9 @@ class Pool extends EventEmitter {
       const peer = this.peers.get(nodePubKey);
       if (peer) {
         const lastNegativeEvents = events.filter(e => reputationEventWeight[e.event] < 0).slice(0, 10);
-        peer.close(DisconnectionReason.Banned, JSON.stringify(lastNegativeEvents));
+        return peer.close(DisconnectionReason.Banned, JSON.stringify(lastNegativeEvents));
       }
+      return;
     });
   }
 
@@ -372,10 +373,10 @@ class Pool extends EventEmitter {
     }
   }
 
-  public closePeer = (nodePubKey: string, reason?: DisconnectionReason, reasonPayload?: string) => {
+  public closePeer = async (nodePubKey: string, reason?: DisconnectionReason, reasonPayload?: string) => {
     const peer = this.peers.get(nodePubKey);
     if (peer) {
-      peer.close(reason, reasonPayload);
+      await peer.close(reason, reasonPayload);
       this.logger.info(`Disconnected from ${peer.nodePubKey}@${addressUtils.toString(peer.address)}`);
     } else {
       throw(errors.NOT_CONNECTED(nodePubKey));
@@ -424,12 +425,12 @@ class Pool extends EventEmitter {
     return this.nodes.addReputationEvent(nodePubKey, event);
   }
 
-  public sendToPeer = (nodePubKey: string, packet: Packet) => {
+  public sendToPeer = async (nodePubKey: string, packet: Packet) => {
     const peer = this.peers.get(nodePubKey);
     if (!peer) {
       throw errors.NOT_CONNECTED(nodePubKey);
     }
-    peer.sendPacket(packet);
+    await peer.sendPacket(packet);
   }
 
   /**
@@ -457,9 +458,9 @@ class Pool extends EventEmitter {
    */
   public broadcastOrderInvalidation = ({ id, pairId, quantity }: OrderPortion, nodeToExclude?: string) => {
     const orderInvalidationPacket = new packets.OrderInvalidationPacket({ id, pairId, quantity });
-    this.peers.forEach((peer) => {
+    this.peers.forEach(async (peer) => {
       if (!nodeToExclude || peer.nodePubKey !== nodeToExclude) {
-        peer.sendPacket(orderInvalidationPacket);
+        await peer.sendPacket(orderInvalidationPacket);
       }
     });
 
@@ -519,7 +520,7 @@ class Pool extends EventEmitter {
         break;
       }
       case PacketType.GetNodes: {
-        this.handleGetNodes(peer, packet.header.id);
+        await this.handleGetNodes(peer, packet.header.id);
         break;
       }
       case PacketType.Nodes: {
@@ -564,20 +565,20 @@ class Pool extends EventEmitter {
 
     if (!this.connected) {
       // if we have disconnected the pool, don't allow any new connections to open
-      peer.close(DisconnectionReason.NotAcceptingConnections);
+      await peer.close(DisconnectionReason.NotAcceptingConnections);
       return;
     }
 
     if (this.nodes.isBanned(peer.nodePubKey)) {
       // TODO: Ban IP address for this session if banned peer attempts repeated connections.
-      peer.close(DisconnectionReason.Banned);
+      await peer.close(DisconnectionReason.Banned);
       return;
     }
 
     if (this.peers.has(peer.nodePubKey)) {
       // TODO: Penalize peers that attempt to create duplicate connections to us more then once.
       // the first time might be due connection retries
-      peer.close(DisconnectionReason.AlreadyConnected);
+      await peer.close(DisconnectionReason.AlreadyConnected);
       return;
     }
 
@@ -593,7 +594,7 @@ class Pool extends EventEmitter {
 
     // request peer's orders
     if (this.nodeState.pairs.length > 0) {
-      peer.sendPacket(new packets.GetOrdersPacket({ pairIds: this.nodeState.pairs }));
+      await peer.sendPacket(new packets.GetOrdersPacket({ pairIds: this.nodeState.pairs }));
     }
 
     // if outbound, update the `lastConnected` field for the address we're actually connected to
@@ -621,7 +622,7 @@ class Pool extends EventEmitter {
   /**
    * Responds to a [[GetNodesPacket]] by populating and sending a [[NodesPacket]].
    */
-  private handleGetNodes = (peer: Peer, reqId: string) => {
+  private handleGetNodes = async (peer: Peer, reqId: string) => {
     const connectedNodesInfo: NodeConnectionInfo[] = [];
     this.peers.forEach((connectedPeer) => {
       if (connectedPeer.nodePubKey !== peer.nodePubKey && connectedPeer.addresses && connectedPeer.addresses.length > 0) {
@@ -632,7 +633,7 @@ class Pool extends EventEmitter {
         });
       }
     });
-    peer.sendNodes(connectedNodesInfo, reqId);
+    await peer.sendNodes(connectedNodesInfo, reqId);
   }
 
   private bindServer = () => {
@@ -718,13 +719,11 @@ class Pool extends EventEmitter {
     this.peers.forEach(peer => peer.close(DisconnectionReason.Shutdown));
   }
 
-  private closePendingConnections = () => {
+  private closePendingConnections = async () => {
     for (const peer of this.pendingOutboundPeers.values()) {
-      peer.close();
+      await peer.close();
     }
-    this.pendingInboundPeers.forEach((peer) => {
-      peer.close();
-    });
+    this.pendingInboundPeers.forEach(peer => peer.close());
   }
 
   /**

--- a/test/integration/Swap.spec.ts
+++ b/test/integration/Swap.spec.ts
@@ -107,7 +107,7 @@ describe('Swaps.Integration', () => {
     sandbox = sinon.createSandbox();
     // peer
     peer = sandbox.createStubInstance(Peer) as any;
-    peer.sendPacket = () => {};
+    peer.sendPacket = async () => {};
     peer.getLndPubKey = () => '1234567890';
     // pool
     pool = sandbox.createStubInstance(Pool) as any;

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -73,8 +73,8 @@ describe('P2P Sanity Tests', () => {
       .to.be.rejectedWith('already connected');
   });
 
-  it('should disconnect successfully', () => {
-    nodeOne['pool']['closePeer'](nodeTwo.nodePubKey, DisconnectionReason.NotAcceptingConnections);
+  it('should disconnect successfully', async () => {
+    await nodeOne['pool']['closePeer'](nodeTwo.nodePubKey, DisconnectionReason.NotAcceptingConnections);
 
     const listPeersResult = nodeOne.service.listPeers();
     expect(listPeersResult).to.be.empty;


### PR DESCRIPTION
This replaces the synchronous usage of `crypto.randomBytes` with the asynchronous version when framing packets. The synchronous version can block the thread until enough entropy is collected. Since this is done every time an encrypted packet is sent, the delay may become noticeable.

This required rewriting synchronous code as asynchronous in several methods and tests which makes up the bulk of the code changes.