### PR TITLE
fix(p2p): peer error logging

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -366,7 +366,11 @@ class Pool extends EventEmitter {
         await peer.open(this.nodeState, this.nodeKey, nodePubKey, retryConnecting);
       } catch (err) {
         // we don't have `nodePubKey` for inbound connections, which might fail on handshake
-        this.logger.warn(`could not open connection to peer (${peer.label}): ${err.message}`);
+        if (typeof err === 'string') {
+          this.logger.warn(`could not open connection to peer (${peer.label}): ${err}`);
+        } else {
+          this.logger.warn(`could not open connection to peer (${peer.label}): ${err.message}`);
+        }
 
         if (err.code === errorCodes.CONNECTION_RETRIES_MAX_PERIOD_EXCEEDED) {
           await this.nodes.removeAddress(nodePubKey!, peer.address);


### PR DESCRIPTION
This fixes the way certain errors are logged when attempting to connect to peers. Previously it was possible to see messages like:

`[P2P] warn: could not open connection to peer (xud2.test.exchangeunion.com:8885): undefined`

This would occur when the `err` object in the catch block is a `string`. This change ensures we log `string` errors correctly.