### PR TITLE
fix(proto): set price as double

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -866,7 +866,7 @@
 | currency_received | [string](#string) |  | The ticker symbol of the currency received. |
 | currency_sent | [string](#string) |  | The ticker symbol of the currency sent. |
 | r_preimage | [string](#string) |  | The hex-encoded preimage. |
-| price | [int64](#int64) |  | The price used for the swap. |
+| price | [double](#double) |  | The price used for the swap. |
 
 
 

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1282,8 +1282,8 @@
           "description": "The hex-encoded preimage."
         },
         "price": {
-          "type": "string",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "description": "The price used for the swap."
         }
       }

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -8690,7 +8690,7 @@ proto.xudrpc.SwapSuccess.toObject = function(includeInstance, msg) {
     currencyReceived: jspb.Message.getFieldWithDefault(msg, 12, ""),
     currencySent: jspb.Message.getFieldWithDefault(msg, 13, ""),
     rPreimage: jspb.Message.getFieldWithDefault(msg, 14, ""),
-    price: jspb.Message.getFieldWithDefault(msg, 15, 0)
+    price: +jspb.Message.getFieldWithDefault(msg, 15, 0.0)
   };
 
   if (includeInstance) {
@@ -8776,7 +8776,7 @@ proto.xudrpc.SwapSuccess.deserializeBinaryFromReader = function(msg, reader) {
       msg.setRPreimage(value);
       break;
     case 15:
-      var value = /** @type {number} */ (reader.readInt64());
+      var value = /** @type {number} */ (reader.readDouble());
       msg.setPrice(value);
       break;
     default:
@@ -8893,8 +8893,8 @@ proto.xudrpc.SwapSuccess.serializeBinaryToWriter = function(message, writer) {
     );
   }
   f = message.getPrice();
-  if (f !== 0) {
-    writer.writeInt64(
+  if (f !== 0.0) {
+    writer.writeDouble(
       15,
       f
     );
@@ -9091,11 +9091,11 @@ proto.xudrpc.SwapSuccess.prototype.setRPreimage = function(value) {
 
 
 /**
- * optional int64 price = 15;
+ * optional double price = 15;
  * @return {number}
  */
 proto.xudrpc.SwapSuccess.prototype.getPrice = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 15, 0));
+  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 15, 0.0));
 };
 
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -297,7 +297,7 @@ message ExecuteSwapRequest {
 
 message SwapFailure {
   // The global UUID for the order that failed the swap.
-  string order_id = 1;
+  string order_id = 1 [json_name = "order_id"];
   // The trading pair that the swap is for.
   string pair_id = 2 [json_name = "pair_id"];
   // The order quantity that was attempted to be swapped.
@@ -567,7 +567,7 @@ message SwapSuccess {
   // The hex-encoded preimage.
   string r_preimage = 14 [json_name = "r_preimage"];
   // The price used for the swap.
-  int64 price = 15 [json_name = "r_preimage"];
+  double price = 15 [json_name = "price"];
 }
 
 message UnbanRequest {


### PR DESCRIPTION
This fixes a bug in the way the `SwapSuccess` proto message was defined where `price` was set as an integer which is inconsistent with how `price` is defined for other messages and with how it is represented and being set internally. This caused the grpc response for the `PlaceOrder` and `ExecuteSwap` calls to be corrupt and fail due to an assertion error.