### PR TITLE
fix(p2p): open peer before sending session ack

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -164,6 +164,9 @@ class GrpcService {
       case p2pErrorCodes.COULD_NOT_CONNECT:
         code = status.UNAVAILABLE;
         break;
+      case p2pErrorCodes.POOL_CLOSED:
+        code = status.ABORTED;
+        break;
     }
 
     // return a grpc error with the code if we've assigned one, otherwise pass along the caught error as UNKNOWN

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -4,7 +4,6 @@ import { EventEmitter } from 'events';
 import crypto from 'crypto';
 import secp256k1 from 'secp256k1';
 import stringify from 'json-stable-stringify';
-import semver from 'semver';
 import { ReputationEvent, DisconnectionReason, NetworkMagic } from '../constants/enums';
 import Parser from './Parser';
 import * as packets from './packets/types';
@@ -12,14 +11,12 @@ import Logger from '../Logger';
 import { ms } from '../utils/utils';
 import { OutgoingOrder } from '../orderbook/types';
 import { Packet, PacketDirection, PacketType } from './packets';
-import { NodeState, Address, NodeConnectionInfo, PoolConfig } from './types';
+import { NodeState, Address, NodeConnectionInfo } from './types';
 import errors, { errorCodes } from './errors';
 import addressUtils from '../utils/addressUtils';
 import NodeKey from '../nodekey/NodeKey';
 import Network from './Network';
 import Framer from './Framer';
-
-const minCompatibleVersion: string = require('../../package.json').minCompatibleVersion;
 
 /** Key info about a peer for display purposes */
 type PeerInfo = {
@@ -38,11 +35,9 @@ interface Peer {
   on(event: 'pairDropped', listener: (pair: string) => void): this;
   on(event: 'nodeStateUpdate', listener: () => void): this;
   on(event: 'reputation', listener: (event: ReputationEvent) => void): this;
-  once(event: 'open', listener: () => void): this;
   once(event: 'close', listener: () => void): this;
   emit(event: 'connect'): boolean;
   emit(event: 'reputation', reputationEvent: ReputationEvent): boolean;
-  emit(event: 'open'): boolean;
   emit(event: 'close'): boolean;
   emit(event: 'error', err: Error): boolean;
   emit(event: 'packet', packet: Packet): boolean;
@@ -57,10 +52,13 @@ class Peer extends EventEmitter {
   public recvDisconnectionReason?: DisconnectionReason;
   public sentDisconnectionReason?: DisconnectionReason;
   public expectedNodePubKey?: string;
-  public active = false; // added to peer list
+  /** Whether the peer is included in the p2p pool list of peers and will receive broadcasted packets. */
+  public active = false;
   /** Timer to periodically call getNodes #402 */
   public discoverTimer?: NodeJS.Timer;
+  /** Whether we have received and authenticated a [[SessionInitPacket]] from the peer. */
   private opened = false;
+  private opening = false;
   private socket?: Socket;
   private parser: Parser;
   private closed = false;
@@ -94,7 +92,7 @@ class Peer extends EventEmitter {
   /** Connection retries max period. */
   private static readonly CONNECTION_RETRIES_MAX_PERIOD = 604800000;
 
-  private get version(): string {
+  public get version(): string {
     return this.nodeState ? this.nodeState.version : '';
   }
 
@@ -141,7 +139,7 @@ class Peer extends EventEmitter {
   /**
    * @param address The socket address for the connection to this peer.
    */
-  constructor(private logger: Logger, public address: Address, private config: PoolConfig) {
+  constructor(private logger: Logger, public address: Address) {
     super();
 
     this.framer = new Framer(this.network);
@@ -152,8 +150,8 @@ class Peer extends EventEmitter {
   /**
    * Creates a Peer from an inbound socket connection.
    */
-  public static fromInbound = (socket: Socket, logger: Logger, config: PoolConfig): Peer => {
-    const peer = new Peer(logger, addressUtils.fromSocket(socket), config);
+  public static fromInbound = (socket: Socket, logger: Logger): Peer => {
+    const peer = new Peer(logger, addressUtils.fromSocket(socket));
 
     peer.inbound = true;
     peer.socket = socket;
@@ -183,64 +181,49 @@ class Peer extends EventEmitter {
   }
 
   /**
-   * Prepare a connection for use by ensuring it is active, exchanging [[HelloPacket]] with handshake data,
-   * and emit the `open` event if everything succeeds. Throw an error on unexpected handshake data.
-   * @param handshakeData our handshake data to send to the peer
-   * @param nodePubKey the expected nodePubKey of the node we are opening a connection with
+   * Prepares a peer for use by establishing a socket connection and beginning the handshake.
+   * @param ownNodeState our node state data to send to the peer
+   * @param nodeKey our identity node key
+   * @param expectedNodePubKey the expected nodePubKey of the node we are opening a connection with
    * @param retryConnecting whether to retry to connect upon failure
+   * @returns the session init packet from beginning the handshake
    */
-  public open = async (ownNodeState: NodeState, nodeKey: NodeKey, expectedNodePubKey?: string, retryConnecting = false): Promise<void> => {
+  public beginOpen = async (ownNodeState: NodeState, nodeKey: NodeKey, expectedNodePubKey?: string, retryConnecting = false):
+    Promise<packets.SessionInitPacket> => {
+    assert(!this.opening);
     assert(!this.opened);
     assert(!this.closed);
     assert(this.inbound || expectedNodePubKey);
     assert(!retryConnecting || !this.inbound);
 
+    this.opening = true;
     this.expectedNodePubKey = expectedNodePubKey;
 
     await this.initConnection(retryConnecting);
     this.initStall();
 
-    await this.handshake(ownNodeState, nodeKey);
+    return this.beginHandshake(ownNodeState, nodeKey);
+  }
 
-    if (this.expectedNodePubKey && this.nodePubKey !== this.expectedNodePubKey) {
-      await this.close(DisconnectionReason.UnexpectedIdentity);
-      throw errors.UNEXPECTED_NODE_PUB_KEY(this.nodePubKey!, this.expectedNodePubKey, addressUtils.toString(this.address));
-    }
+  /**
+   * Finishes opening a peer for use by marking the peer as opened, completing the handshake,
+   * and setting up the ping packet timer.
+   * @param ownNodeState our node state data to send to the peer
+   * @param nodeKey our identity node key
+   * @param sessionInit the session init packet we received when beginning the handshake
+   */
+  public completeOpen = async (ownNodeState: NodeState, nodeKey: NodeKey, sessionInit: packets.SessionInitPacket) => {
+    assert(this.opening);
+    assert(!this.opened);
+    assert(!this.closed);
 
-    if (this.nodePubKey === ownNodeState.nodePubKey) {
-      await this.close(DisconnectionReason.ConnectedToSelf);
-      throw errors.ATTEMPTED_CONNECTION_TO_SELF;
-    }
+    this.opening = false;
+    this.opened = true;
 
-    // Check if version is semantic, and higher than minCompatibleVersion.
-    if (!semver.valid(this.version)) {
-      await this.close(DisconnectionReason.MalformedVersion);
-      throw errors.MALFORMED_VERSION(addressUtils.toString(this.address), this.version);
-    }
-    // dev.note: compare returns 0 if v1 == v2, or 1 if v1 is greater, or -1 if v2 is greater.
-    if (semver.compare(this.version, minCompatibleVersion) === -1) {
-      await this.close(DisconnectionReason.IncompatibleProtocolVersion);
-      throw errors.INCOMPATIBLE_VERSION(addressUtils.toString(this.address), minCompatibleVersion, this.version);
-    }
-
-    // request peer's known nodes only if p2p.discover option is true
-    if (this.config.discover) {
-      await this.sendPacket(new packets.GetNodesPacket());
-      if (this.config.discoverminutes === 0) {
-        // timer is disabled
-        this.discoverTimer = undefined; // defensive programming
-      } else {
-        // timer is enabled
-        this.discoverTimer = setInterval(this.sendGetNodes, this.config.discoverminutes * 1000 * 60);
-      }
-    }
+    await this.completeHandshake(ownNodeState, nodeKey, sessionInit);
 
     // Setup the ping interval
     this.pingTimer = setInterval(this.sendPing, Peer.PING_INTERVAL);
-
-    // let listeners know that this peer is ready to go
-    this.opened = true;
-    this.emit('open');
   }
 
   /**
@@ -252,6 +235,7 @@ class Peer extends EventEmitter {
     }
 
     this.closed = true;
+    this.opened = false;
 
     if (this.socket) {
       if (reason !== undefined) {
@@ -593,22 +577,20 @@ class Peer extends EventEmitter {
     });
   }
 
-  /** Check if a given packet is solicited and fulfill the pending response entry if it's a response. */
-  private isPacketSolicited = (packet: Packet): boolean => {
-    let solicited = true;
-
+  /** Checks if a given packet is solicited and fulfills the pending response entry if it's a response. */
+  private isPacketSolicited = async (packet: Packet): Promise<boolean> => {
     if (!this.opened && packet.type !== PacketType.SessionInit && packet.type !== PacketType.SessionAck && packet.type !== PacketType.Disconnecting) {
-      // until the connection is opened, we only accept SessionInit/SessionAck packets
-      solicited = false;
+      // until the connection is opened, we only accept SessionInit, SessionAck, and Disconnecting packets
+      return false;
     }
     if (packet.direction === PacketDirection.Response) {
       // lookup a pending response entry for this packet by its reqId
       if (!this.fulfillResponseEntry(packet)) {
-        solicited = false;
+        return false;
       }
     }
 
-    return solicited;
+    return true;
   }
 
   private handlePacket = async (packet: Packet): Promise<void> => {
@@ -616,7 +598,7 @@ class Peer extends EventEmitter {
     const sender = this.nodePubKey !== undefined ? this.nodePubKey : addressUtils.toString(this.address);
     this.logger.trace(`Received ${PacketType[packet.type]} packet from ${sender}${JSON.stringify(packet)}`);
 
-    if (this.isPacketSolicited(packet)) {
+    if (await this.isPacketSolicited(packet)) {
       switch (packet.type) {
         case PacketType.SessionInit: {
           this.handleSessionInit(packet);
@@ -656,21 +638,31 @@ class Peer extends EventEmitter {
   }
 
   /**
-   * Authenticate the identity of the peer through SessionInit packet
-   * @param {SessionInitPacket} packet
-   * @param {NodeKey} nodeKey
+   * Authenticates the identity of a peer with a [[SessionInitPacket]] and sets the peer's node state.
+   * Throws an error and closes the peer if authentication fails.
+   * @param packet the session init packet
+   * @param nodePubKey our node pub key
+   * @param expectedNodePubKey the expected node pub key of the sender of the init packet
    */
-  private authenticate = async (packet: packets.SessionInitPacket, nodeKey: NodeKey) => {
+  private authenticateSessionInit = async (packet: packets.SessionInitPacket, nodePubKey: string, expectedNodePubKey?: string) => {
     const body = packet.body!;
     const { sign, ...bodyWithoutSign } = body;
-    const { nodePubKey } = body.nodeState; // the peer pubkey
-    const { peerPubKey } = body; // our pubkey
+    /** The pub key of the node that sent the init packet. */
+    const sourceNodePubKey = body.nodeState.nodePubKey;
+    /** The pub key of the node that the init packet is intended for. */
+    const targetNodePubKey = body.peerPubKey;
 
-    // verify that msg was intended for us
-    if (peerPubKey !== nodeKey.nodePubKey) {
+    // verify that the init packet came from the expected node
+    if (expectedNodePubKey && expectedNodePubKey !== sourceNodePubKey) {
+      await this.close(DisconnectionReason.UnexpectedIdentity);
+      throw errors.UNEXPECTED_NODE_PUB_KEY(sourceNodePubKey, expectedNodePubKey, addressUtils.toString(this.address));
+    }
+
+    // verify that the init packet was intended for us
+    if (targetNodePubKey !== nodePubKey) {
       this.emit('reputation', ReputationEvent.InvalidAuth);
       await this.close(DisconnectionReason.AuthFailureInvalidTarget);
-      throw errors.AUTH_FAILURE_INVALID_TARGET(nodePubKey, peerPubKey);
+      throw errors.AUTH_FAILURE_INVALID_TARGET(sourceNodePubKey, targetNodePubKey);
     }
 
     // verify that the msg was signed by the peer
@@ -679,16 +671,22 @@ class Peer extends EventEmitter {
     const verified = secp256k1.verify(
       msgHash,
       Buffer.from(sign, 'hex'),
-      Buffer.from(nodePubKey, 'hex'),
+      Buffer.from(sourceNodePubKey, 'hex'),
     );
 
     if (!verified) {
       this.emit('reputation', ReputationEvent.InvalidAuth);
       await this.close(DisconnectionReason.AuthFailureInvalidSignature);
-      throw errors.AUTH_FAILURE_INVALID_SIGNATURE(nodePubKey);
+      throw errors.AUTH_FAILURE_INVALID_SIGNATURE(sourceNodePubKey);
     }
+
+    // finally set this peer's node state to the node state in the init packet body
+    this.nodeState = body.nodeState;
   }
 
+  /**
+   * Sends a [[SessionInitPacket]] and waits for a [[SessionAckPacket]].
+   */
   private initSession = async (ownNodeState: NodeState, nodeKey: NodeKey, expectedNodePubKey: string): Promise<void> => {
     const ECDH = crypto.createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
@@ -703,10 +701,10 @@ class Peer extends EventEmitter {
     });
   }
 
-  private ackSession = async (sessionInit: packets.SessionInitPacket, nodeKey: NodeKey): Promise<void> => {
-    await this.authenticate(sessionInit, nodeKey);
-    this.nodeState = sessionInit.body!.nodeState;
-
+  /**
+   * Sends a [[SessionAckPacket]] in response to a given [[SessionInitPacket]].
+   */
+  private ackSession = async (sessionInit: packets.SessionInitPacket): Promise<void> => {
     const ECDH = crypto.createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
 
@@ -718,17 +716,38 @@ class Peer extends EventEmitter {
     this.setOutEncryption(key);
   }
 
-  private handshake = async (ownNodeState: NodeState, nodeKey: NodeKey) => {
+  /**
+   * Begins the handshake by waiting for a [[SessionInitPacket]] as well as sending our own
+   * [[SessionInitPacket]] first if we are the outbound peer.
+   * @returns the session init packet we receive
+   */
+  private beginHandshake = async (ownNodeState: NodeState, nodeKey: NodeKey) => {
+    let sessionInit: packets.SessionInitPacket;
     if (!this.inbound) {
       // outbound handshake
       assert(this.expectedNodePubKey);
       await this.initSession(ownNodeState, nodeKey, this.expectedNodePubKey!);
-      const sessionInit = await this.waitSessionInit();
-      await this.ackSession(sessionInit, nodeKey);
+      sessionInit = await this.waitSessionInit();
+      await this.authenticateSessionInit(sessionInit, nodeKey.nodePubKey, this.expectedNodePubKey);
     } else {
       // inbound handshake
-      const sessionInit = await this.waitSessionInit();
-      await this.ackSession(sessionInit, nodeKey);
+      sessionInit = await this.waitSessionInit();
+      await this.authenticateSessionInit(sessionInit, nodeKey.nodePubKey);
+    }
+    return sessionInit;
+  }
+
+  /**
+   * Completes the handshake by sending the [[SessionAckPacket]] and our [[SessionInitPacket]] if it
+   * has not been sent already, as is the case with inbound peers.
+   */
+  private completeHandshake = async (ownNodeState: NodeState, nodeKey: NodeKey, sessionInit: packets.SessionInitPacket) => {
+    if (!this.inbound) {
+      // outbound handshake
+      await this.ackSession(sessionInit);
+    } else {
+      // inbound handshake
+      await this.ackSession(sessionInit);
       await this.initSession(ownNodeState, nodeKey, sessionInit.body!.nodeState.nodePubKey);
     }
   }
@@ -738,7 +757,7 @@ class Peer extends EventEmitter {
     await this.sendPacket(packet);
   }
 
-  private sendGetNodes = async (): Promise<void> => {
+  public sendGetNodes = async (): Promise<void> => {
     const packet =  new packets.GetNodesPacket();
     await this.sendPacket(packet);
   }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -16,6 +16,9 @@ import assert from 'assert';
 import { ReputationEvent, DisconnectionReason } from '../constants/enums';
 import NodeKey from '../nodekey/NodeKey';
 import { ReputationEventInstance } from 'lib/db/types';
+import semver from 'semver';
+
+const minCompatibleVersion: string = require('../../package.json').minCompatibleVersion;
 
 type NodeReputationInfo = {
   reputationScore: ReputationEvent;
@@ -202,11 +205,12 @@ class Pool extends EventEmitter {
       const externalAddress = addressUtils.toString(address);
       this.logger.debug(`Verifying reachability of advertised address: ${externalAddress}`);
       try {
-        const peer = new Peer(Logger.DISABLED_LOGGER, address, this.config);
-        await peer.open(this.nodeState, this.nodeKey, this.nodeState.nodePubKey);
-        assert(false, errors.ATTEMPTED_CONNECTION_TO_SELF.message);
+        const peer = new Peer(Logger.DISABLED_LOGGER, address);
+        await peer.beginOpen(this.nodeState, this.nodeKey, this.nodeState.nodePubKey);
+        await peer.close();
+        assert.fail();
       } catch (err) {
-        if (err.code === errors.ATTEMPTED_CONNECTION_TO_SELF.code) {
+        if (typeof err.message === 'string' && err.message.includes(DisconnectionReason[DisconnectionReason.ConnectedToSelf])) {
           this.logger.verbose(`Verified reachability of advertised address: ${externalAddress}`);
         } else {
           this.logger.warn(`Could not verify reachability of advertised address: ${externalAddress}`);
@@ -336,7 +340,7 @@ class Pool extends EventEmitter {
       }
     }
 
-    const peer = new Peer(this.logger, address, this.config);
+    const peer = new Peer(this.logger, address);
     this.pendingOutboundPeers.set(nodePubKey, peer);
     await this.openPeer(peer, nodePubKey, retryConnecting);
     return peer;
@@ -352,32 +356,78 @@ class Pool extends EventEmitter {
     return peerInfos;
   }
 
-  private tryOpenPeer = async (peer: Peer, nodePubKey?: string, retryConnecting = false): Promise<void> => {
+  private tryOpenPeer = async (peer: Peer, peerPubKey?: string, retryConnecting = false): Promise<void> => {
     try {
-      await this.openPeer(peer, nodePubKey, retryConnecting);
+      await this.openPeer(peer, peerPubKey, retryConnecting);
     } catch (err) {}
   }
 
-  private openPeer = async (peer: Peer, nodePubKey?: string, retryConnecting = false): Promise<void> => {
-    const isBanned = nodePubKey ? this.nodes.isBanned(nodePubKey) : false;
-    if (!isBanned) {
-      this.bindPeer(peer);
-      try {
-        await peer.open(this.nodeState, this.nodeKey, nodePubKey, retryConnecting);
-      } catch (err) {
-        // we don't have `nodePubKey` for inbound connections, which might fail on handshake
-        if (typeof err === 'string') {
-          this.logger.warn(`could not open connection to peer (${peer.label}): ${err}`);
-        } else {
-          this.logger.warn(`could not open connection to peer (${peer.label}): ${err.message}`);
-        }
+  private openPeer = async (peer: Peer, expectedNodePubKey?: string, retryConnecting = false): Promise<void> => {
+    this.bindPeer(peer);
 
-        if (err.code === errorCodes.CONNECTION_RETRIES_MAX_PERIOD_EXCEEDED) {
-          await this.nodes.removeAddress(nodePubKey!, peer.address);
-        }
+    try {
+      const sessionInit = await peer.beginOpen(this.nodeState, this.nodeKey, expectedNodePubKey, retryConnecting);
 
-        throw err;
+      await this.validatePeer(peer);
+
+      await peer.completeOpen(this.nodeState, this.nodeKey, sessionInit);
+    } catch (err) {
+      // we don't have nodePubKey for inbound connections, which might fail on handshake
+      if (typeof err === 'string') {
+        this.logger.warn(`could not open connection to peer (${peer.label}): ${err}`);
+      } else {
+        this.logger.warn(`could not open connection to peer (${peer.label}): ${err.message}`);
       }
+
+      if (err.code === errorCodes.CONNECTION_RETRIES_MAX_PERIOD_EXCEEDED) {
+        await this.nodes.removeAddress(expectedNodePubKey!, peer.address);
+      }
+
+      throw err;
+    }
+
+    const peerPubKey = peer.nodePubKey!;
+    this.logger.verbose(`opened connection to ${peerPubKey} at ${addressUtils.toString(peer.address)}`);
+    this.pendingOutboundPeers.delete(peerPubKey);
+    this.peers.set(peerPubKey, peer);
+    peer.active = true;
+
+    // request peer's known nodes only if p2p.discover option is true
+    if (this.config.discover) {
+      await peer.sendGetNodes();
+      if (this.config.discoverminutes === 0) {
+        // timer is disabled
+        peer.discoverTimer = undefined; // defensive programming
+      } else {
+        // timer is enabled
+        peer.discoverTimer = setInterval(peer.sendGetNodes, this.config.discoverminutes * 1000 * 60);
+      }
+    }
+
+    // request peer's orders
+    if (this.nodeState.pairs.length > 0) {
+      await peer.sendPacket(new packets.GetOrdersPacket({ pairIds: this.nodeState.pairs }));
+    }
+
+    // if outbound, update the `lastConnected` field for the address we're actually connected to
+    const addresses = peer.inbound ? peer.addresses! : peer.addresses!.map((address) => {
+      if (addressUtils.areEqual(peer.address, address)) {
+        return { ...address, lastConnected: Date.now() };
+      } else {
+        return address;
+      }
+    });
+
+    // upserting the node entry
+    if (!this.nodes.has(peerPubKey)) {
+      await this.nodes.createNode({
+        addresses,
+        nodePubKey: peerPubKey,
+        lastAddress: peer.inbound ? undefined : peer.address,
+      });
+    } else {
+      // the node is known, update its listening addresses
+      await this.nodes.updateAddresses(peer.nodePubKey!, addresses, peer.inbound ? undefined : peer.address);
     }
   }
 
@@ -476,7 +526,7 @@ class Pool extends EventEmitter {
   }
 
   private addInbound = async (socket: Socket) => {
-    const peer = Peer.fromInbound(socket, this.logger, this.config);
+    const peer = Peer.fromInbound(socket, this.logger);
     this.pendingInboundPeers.add(peer);
     await this.tryOpenPeer(peer);
     this.pendingInboundPeers.delete(peer);
@@ -566,64 +616,50 @@ class Pool extends EventEmitter {
     }
   }
 
-  private handleOpen = async (peer: Peer): Promise<void> => {
-    if (!peer.nodePubKey || peer.nodePubKey === this.nodeState.nodePubKey) {
-      return;
+  /** Validates a peer. If a check fails, closes the peer and throws a p2p error. */
+  private validatePeer = async (peer: Peer): Promise<void> => {
+    assert(peer.nodePubKey);
+    const peerPubKey = peer.nodePubKey!;
+
+    if (peerPubKey === this.nodeState.nodePubKey) {
+      await peer.close(DisconnectionReason.ConnectedToSelf);
+      throw errors.ATTEMPTED_CONNECTION_TO_SELF;
+    }
+
+    // Check if version is semantic, and higher than minCompatibleVersion.
+    if (!semver.valid(peer.version)) {
+      await peer.close(DisconnectionReason.MalformedVersion);
+      throw errors.MALFORMED_VERSION(addressUtils.toString(peer.address), peer.version);
+    }
+    // dev.note: compare returns 0 if v1 == v2, or 1 if v1 is greater, or -1 if v2 is greater.
+    if (semver.compare(peer.version, minCompatibleVersion) === -1) {
+      await peer.close(DisconnectionReason.IncompatibleProtocolVersion);
+      throw errors.INCOMPATIBLE_VERSION(addressUtils.toString(peer.address), minCompatibleVersion, peer.version);
     }
 
     if (!this.connected) {
       // if we have disconnected the pool, don't allow any new connections to open
       await peer.close(DisconnectionReason.NotAcceptingConnections);
-      return;
+      throw errors.POOL_CLOSED;
     }
 
-    if (this.nodes.isBanned(peer.nodePubKey)) {
+    if (this.nodes.isBanned(peerPubKey)) {
       // TODO: Ban IP address for this session if banned peer attempts repeated connections.
       await peer.close(DisconnectionReason.Banned);
-      return;
+      throw errors.NODE_IS_BANNED(peerPubKey);
     }
 
-    if (this.peers.has(peer.nodePubKey)) {
+    if (this.peers.has(peerPubKey)) {
       // TODO: Penalize peers that attempt to create duplicate connections to us more then once.
       // the first time might be due connection retries
       await peer.close(DisconnectionReason.AlreadyConnected);
-      return;
+      throw errors.NODE_ALREADY_CONNECTED(peerPubKey, peer.address);
     }
 
     // check to make sure the socket was not destroyed during or immediately after the handshake
     if (!peer.connected) {
-      this.logger.error(`the socket to node ${peer.nodePubKey} was disconnected`);
-      return;
-    }
-
-    this.logger.verbose(`opened connection to ${peer.nodePubKey} at ${addressUtils.toString(peer.address)}`);
-    this.peers.set(peer.nodePubKey, peer);
-    peer.active = true;
-
-    // request peer's orders
-    if (this.nodeState.pairs.length > 0) {
-      await peer.sendPacket(new packets.GetOrdersPacket({ pairIds: this.nodeState.pairs }));
-    }
-
-    // if outbound, update the `lastConnected` field for the address we're actually connected to
-    const addresses = peer.inbound ? peer.addresses! : peer.addresses!.map((address) => {
-      if (addressUtils.areEqual(peer.address, address)) {
-        return { ...address, lastConnected: Date.now() };
-      } else {
-        return address;
-      }
-    });
-
-    // upserting the node entry
-    if (!this.nodes.has(peer.nodePubKey)) {
-      await this.nodes.createNode({
-        addresses,
-        nodePubKey: peer.nodePubKey,
-        lastAddress: peer.inbound ? undefined : peer.address,
-      });
-    } else {
-      // the node is known, update its listening addresses
-      await this.nodes.updateAddresses(peer.nodePubKey, addresses, peer.inbound ? undefined : peer.address);
+      this.logger.error(`the socket to node ${peerPubKey} was disconnected`);
+      throw errors.NOT_CONNECTED(peerPubKey);
     }
   }
 
@@ -672,11 +708,6 @@ class Pool extends EventEmitter {
       }
     });
 
-    peer.once('open', async () => {
-      await this.handleOpen(peer);
-      this.pendingOutboundPeers.delete(peer.nodePubKey!);
-    });
-
     peer.once('close', () => this.handlePeerClose(peer));
 
     peer.on('reputation', async (event) => {
@@ -701,6 +732,7 @@ class Pool extends EventEmitter {
       this.peers.delete(peer.nodePubKey);
     }
     this.emit('peer.close', peer.nodePubKey);
+    peer.removeAllListeners();
 
     // if handshake passed and peer disconnected from us for stalling or without specifying any reason -
     // reconnect, for that might have been due to a temporary loss in connectivity

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -27,6 +27,7 @@ const errorCodes = {
   FRAMER_MSG_NOT_ENCRYPTED: codesPrefix.concat('.`20'),
   FRAMER_INVALID_NETWORK_MAGIC_VALUE: codesPrefix.concat('.21'),
   FRAMER_INVALID_MSG_LENGTH: codesPrefix.concat('.22'),
+  POOL_CLOSED: codesPrefix.concat('.23'),
 };
 
 const errors = {
@@ -130,6 +131,10 @@ const errors = {
     message: `framer: invalid msg length (expected: ${expected} found: ${found})`,
     code: errorCodes.FRAMER_INVALID_NETWORK_MAGIC_VALUE,
   }),
+  POOL_CLOSED: {
+    message: `p2p pool is closed and not accepting new peers`,
+    code: errorCodes.POOL_CLOSED,
+  },
 };
 
 export { errorCodes };

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -21,13 +21,16 @@ describe('P2P Pool Tests', async () => {
 
   const createPeer = (nodePubKey: string, addresses: Address[]) => {
     const peer = sandbox.createStubInstance(Peer) as any;
-    peer.address = addresses[0];
-    peer.nodeState = {
-      addresses,
-      nodePubKey,
-      version: 'test',
-      pairs: ['LTC/BTC'],
+    peer.beginOpen = () => {
+      peer.nodeState = {
+        addresses,
+        nodePubKey,
+        version: '100.0.0',
+        pairs: ['LTC/BTC'],
+      };
+      peer.address = addresses[0];
     };
+    peer.completeOpen = () => {};
     peer.socket = {};
     peer.sendPacket = () => {};
     peer.close = () => {
@@ -58,15 +61,15 @@ describe('P2P Pool Tests', async () => {
     }, nodeKeyOne);
   });
 
-  it('should handle an opened peer', async () => {
+  it('should open a connection with a peer', async () => {
     const currentNodeCount = pool['nodes'].count;
 
     const addresses = [{ host: '123.123.123.123', port: 8885 }];
     const peer = createPeer(nodeKeyOne.nodePubKey, addresses);
 
-    const handleOpenPromise = pool['handleOpen'](peer);
-    expect(handleOpenPromise).to.be.fulfilled;
-    await handleOpenPromise;
+    const openPromise = pool['openPeer'](peer, nodeKeyOne.nodePubKey);
+    expect(openPromise).to.be.fulfilled;
+    await openPromise;
     expect(pool['nodes'].count).to.equal(currentNodeCount + 1);
     expect(pool['nodes'].has(nodeKeyOne.nodePubKey)).to.be.true;
 
@@ -108,7 +111,7 @@ describe('P2P Pool Tests', async () => {
     const addresses = [{ host: '86.75.30.9', port: 8885 }];
     const peer = createPeer(nodeKeyOne.nodePubKey, addresses);
 
-    pool['handleOpen'](peer);
+    await pool['openPeer'](peer, nodeKeyOne.nodePubKey);
 
     const nodeInstance = await db.models.Node.find({
       where: {

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -83,7 +83,7 @@ describe('P2P Sanity Tests', () => {
   });
 
   it('should fail when connecting to an unexpected node pub key', async () => {
-    const randomPubKey =  (await NodeKey['generate']()).nodePubKey;
+    const randomPubKey = (await NodeKey['generate']()).nodePubKey;
     const connectPromise = nodeOne.service.connect({
       nodeUri: toUri({ nodePubKey: randomPubKey, host: 'localhost', port: nodeTwoPort }),
       retryConnecting: false,
@@ -94,7 +94,7 @@ describe('P2P Sanity Tests', () => {
   });
 
   it('should fail when connecting to an invalid node pub key', async () => {
-    const invalidPubKey =  '0123456789';
+    const invalidPubKey = '0123456789';
     const connectPromise = nodeOne.service.connect({
       nodeUri: toUri({ nodePubKey: invalidPubKey, host: 'localhost', port: nodeTwoPort }),
       retryConnecting: false,


### PR DESCRIPTION
This commit addresses an edge case bug whereby one peer finishes the handshake before the other and begins sending regular packets. It is possible for the other peer to attempt to process these regular packets while it is executing asynchronous code to complete the handshake, which results in the regular packets being discarded as "unsolicited."
 
The key change is marking the peer as `opened` after receiving and authenticating the `SessionInitPacket`, as well as validating the peer (not banned, not ourselves, not an incompatible version, etc...), but before we send the `SessionAckPacket`. This ensures that we are ready to accept packets before the peer is ready to send packets.
 
This involves restructuring the open flow, splitting it into two methods (`beginOpen` and `completeOpen`). The first establishes the socket connection and begins the handshake. The second marks the peer as `opened` and compelts the handshake. In between we validate the peer, and afterwards we perform the routine for newly opened peers including sharing and asking for open orders.
 
Fixes #839.