### PR TITLE
test(p2p): add connect test if we are banned

### DIFF
--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -137,6 +137,12 @@ describe('P2P Sanity Tests', () => {
     expect(connectPromise).to.be.rejectedWith(`Connection retry attempts to peer were revoked`);
   });
 
+  it('should fail when connecting to a node that has banned us', async () => {
+    await nodeTwo.service.ban({ nodePubKey: nodeOne.nodePubKey });
+    await expect(nodeOne.service.connect({ nodeUri: nodeTwoUri, retryConnecting: false }))
+      .to.be.rejectedWith('Peer disconnected from us due to Banned');
+  });
+
   after(async () => {
     await Promise.all([nodeOne['shutdown'](), nodeTwo['shutdown']()]);
   });


### PR DESCRIPTION
This adds a test case that isolates a bug that was fixed in #845 where we would successfully connect to a peer that had banned us. Although that peer would immediately disconnect with us after establishing the connection, this was not evident to callers of the `Service.connect` method including the gRPC API. This test fails prior to the recent fix.

Closes #735.