### PR TITLE
fix(p2p): prevent writing to closed socket

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -330,9 +330,13 @@ class Peer extends EventEmitter {
   }
 
   private sendRaw = (data: Buffer) => {
-    if (this.socket) {
-      this.socket.write(data);
-      this.lastSend = Date.now();
+    if (this.socket && !this.socket.destroyed) {
+      try {
+        this.socket.write(data);
+        this.lastSend = Date.now();
+      } catch (err) {
+        this.logger.error('failed sending data to peer', err);
+      }
     }
   }
 


### PR DESCRIPTION
This prevents an edge case bug where the TCP socket to a peer is destroyed as we are about to send data to that peer. This ensures that we check not only that a socket connection exists but that it also hasn't been destroyed. It also adds a try/catch block as a safety measure, since an unhandled error risks crashing the process.

Below is the log from the sort of error this is intended to prevent, note that the socket is closed only 2 milliseconds before responding to a ping packet with a pong packet.

```
19/03/2019 17:59:46.638 [P2P] debug: received disconnecting packet from 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0a:{"reason":1,"payload":"482118c0-4a92-11e9-acfd-4d31407af072"}
19/03/2019 17:59:46.640 [P2P] error: Peer (028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0a): error: response timeout (46e898c0-4a92-11e9-9609-dba5445fcf8d) 
19/03/2019 17:59:46.641 [P2P] debug: Peer (028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0a): closing socket. reason: ResponseStalling
19/03/2019 17:59:46.643 [P2P] trace: Sent Pong packet to 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0a: "{\"header\":{\"id\":\"4f39a7d0-4a92-11e9-9609-dba5445fcf8d\",\"reqId\":\"482118c0-4a92-11e9-acfd-4d31407af072\"}}"
{ Error: This socket has been ended by the other party
    at Socket.writeAfterFIN [as write] (net.js:396:12)
    at Peer.sendRaw (c:\Users\Daniel\Documents\GitHub\xud\dist\p2p\Peer.js:206:29)
    at Peer.<anonymous> (c:\Users\Daniel\Documents\GitHub\xud\dist\p2p\Peer.js:174:18)
    at Generator.next (<anonymous>)
    at fulfilled (c:\Users\Daniel\Documents\GitHub\xud\dist\p2p\Peer.js:4:58) code: 'EPIPE' }
Debugger attached.
c:\Users\Daniel\Documents\GitHub\xud\dist\bootstrap.js:13
        throw err;
```