### PR TITLE
 feat(swaps): get peer identifier for swaps

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -591,6 +591,7 @@
 | pairs | [string](#string) | repeated | A list of trading pair tickers supported by this peer. |
 | xud_version | [string](#string) |  | The version of xud being used by the peer. |
 | seconds_connected | [int32](#int32) |  | The time in seconds that we have been connected to this peer. |
+| raiden_address | [string](#string) |  | The raiden address for this peer |
 
 
 

--- a/lib/BaseClient.ts
+++ b/lib/BaseClient.ts
@@ -2,6 +2,7 @@ import Logger from './Logger';
 import { EventEmitter } from 'events';
 import { SwapDeal } from './swaps/types';
 import { Route } from './proto/lndrpc_pb';
+import { SwapClient } from './constants/enums';
 
 enum ClientStatus {
   NotInitialized,
@@ -21,6 +22,7 @@ type ChannelBalance = {
  */
 abstract class BaseClient extends EventEmitter {
   public abstract readonly cltvDelta: number;
+  public abstract readonly type: SwapClient;
   public maximumOutboundCapacity = 0;
   protected status: ClientStatus = ClientStatus.NotInitialized;
   protected reconnectionTimer?: NodeJS.Timer;

--- a/lib/cli/commands/addcurrency.ts
+++ b/lib/cli/commands/addcurrency.ts
@@ -1,7 +1,7 @@
 import { Arguments } from 'yargs';
 import { callback, loadXudClient } from '../command';
 import { AddCurrencyRequest } from '../../proto/xudrpc_pb';
-import { SwapClients } from '../../constants/enums';
+import { SwapClient } from '../../constants/enums';
 
 export const command = 'addcurrency <currency> <swap_client> [decimal_places] [token_address]';
 
@@ -31,7 +31,7 @@ export const builder = {
 export const handler = (argv: Arguments) => {
   const request = new AddCurrencyRequest();
   request.setCurrency(argv.currency.toUpperCase());
-  request.setSwapClient(Number(SwapClients[argv.swap_client]));
+  request.setSwapClient(Number(SwapClient[argv.swap_client]));
   request.setTokenAddress(argv.token_address);
   request.setDecimalPlaces(argv.decimal_places);
   loadXudClient(argv).addCurrency(request, callback(argv));

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -1,5 +1,5 @@
 /** An enumeration of payment channel network clients that support token swaps. */
-export enum SwapClients {
+export enum SwapClient {
   Lnd,
   Raiden,
 }
@@ -87,13 +87,13 @@ export enum SwapFailureReason {
   SwapClientNotSetup = 3,
   /** Could not find a route to complete the swap. */
   NoRouteFound = 4,
-  /** A call to lnd failed for an unexpected reason. */
-  UnexpectedLndError = 5,
+  /** A swap client call failed for an unexpected reason. */
+  UnexpectedClientError = 5,
   /** Received a swap packet from the peer with invalid data. */
   InvalidSwapPacketReceived = 6,
-  /** The call to lnd to send payment failed. */
+  /** The call to send payment failed. */
   SendPaymentFailure = 7,
-  /** The swap resolver request from lnd was invalid. */
+  /** The swap resolver request was invalid. */
   InvalidResolveRequest = 8,
   /** The swap request attempts to reuse a payment hash. */
   PaymentHashReuse = 9,

--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -3,7 +3,7 @@ import Sequelize from 'sequelize';
 import Bluebird from 'bluebird';
 import Logger from '../Logger';
 import * as db from './types';
-import { SwapClients } from '../constants/enums';
+import { SwapClient } from '../constants/enums';
 import { exists, readdir } from '../utils/fsUtils';
 
 type Models = {
@@ -87,8 +87,8 @@ class DB {
       ]));
 
       promises.push(Currency.bulkCreate(<db.CurrencyAttributes[]>[
-        { id: 'BTC', swapClient: SwapClients.Lnd, decimalPlaces: 8 },
-        { id: 'LTC', swapClient: SwapClients.Lnd, decimalPlaces: 8 },
+        { id: 'BTC', swapClient: SwapClient.Lnd, decimalPlaces: 8 },
+        { id: 'LTC', swapClient: SwapClient.Lnd, decimalPlaces: 8 },
         // { id: 'ZRX', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
         // { id: 'GNT', swapClient: SwapClients.Raiden, decimalPlaces: 18 },
       ]));

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -326,7 +326,7 @@ class GrpcService {
           case SwapFailureReason.OrderOnHold:
             code = status.FAILED_PRECONDITION;
             break;
-          case SwapFailureReason.UnexpectedLndError:
+          case SwapFailureReason.UnexpectedClientError:
           case SwapFailureReason.UnknownError:
           default:
             code = status.UNKNOWN;

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -498,6 +498,7 @@ class GrpcService {
         grpcPeer.setPairsList(peer.pairs || []);
         grpcPeer.setSecondsConnected(peer.secondsConnected);
         grpcPeer.setXudVersion(peer.xudVersion || '');
+        grpcPeer.setRaidenAddress(peer.raidenAddress || '');
         peers.push(grpcPeer);
       });
       response.setPeersList(peers);

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -6,7 +6,7 @@ import { LightningClient } from '../proto/lndrpc_grpc_pb';
 import * as lndrpc from '../proto/lndrpc_pb';
 import assert from 'assert';
 import { exists, readFile } from '../utils/fsUtils';
-import { SwapState, SwapRole } from '../constants/enums';
+import { SwapState, SwapRole, SwapClient } from '../constants/enums';
 import { SwapDeal } from '../swaps/types';
 
 /** The configurable options for the lnd client. */
@@ -48,6 +48,7 @@ interface LndClient {
 
 /** A class representing a client to interact with lnd. */
 class LndClient extends BaseClient {
+  public readonly type = SwapClient.Lnd;
   public readonly cltvDelta: number;
   private lightning!: LightningClient | LightningMethodIndex;
   private meta!: grpc.Metadata;

--- a/lib/orderbook/types.ts
+++ b/lib/orderbook/types.ts
@@ -1,4 +1,4 @@
-import { SwapClients } from '../constants/enums';
+import { SwapClient } from '../constants/enums';
 import { SwapSuccess, SwapFailure } from 'lib/swaps/types';
 
 export type OrderMatch = {
@@ -100,7 +100,7 @@ export type Currency = {
   /** The ticker symbol for this currency such as BTC, LTC, ETH, etc... */
   id: string;
   /** The payment channel network client to use for executing swaps. */
-  swapClient: SwapClients;
+  swapClient: SwapClient;
   /**
    * The number of places to the right of the decimal point of the smallest subunit of the currency, For example, BTC, LTC, and others
    * where the smallest subunits (satoshis) are 0.00000001 full units (bitcoins) have 8 decimal places. ETH has 18. This can be thought

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -27,6 +27,7 @@ type PeerInfo = {
   xudVersion?: string,
   secondsConnected: number,
   lndPubKeys?: { [currency: string]: string | undefined },
+  raidenAddress?: string,
 };
 
 interface Peer {
@@ -133,6 +134,7 @@ class Peer extends EventEmitter {
       xudVersion: this.nodeState ? this.nodeState.version : undefined,
       secondsConnected: Math.round((Date.now() - this.connectTime) / 1000),
       lndPubKeys: this.nodeState ? this.nodeState.lndPubKeys : undefined,
+      raidenAddress: this.nodeState ? this.nodeState.raidenAddress : undefined,
     };
   }
 

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 import crypto from 'crypto';
 import secp256k1 from 'secp256k1';
 import stringify from 'json-stable-stringify';
-import { ReputationEvent, DisconnectionReason, NetworkMagic } from '../constants/enums';
+import { ReputationEvent, DisconnectionReason, NetworkMagic, SwapClient } from '../constants/enums';
 import Parser from './Parser';
 import * as packets from './packets/types';
 import Logger from '../Logger';
@@ -161,11 +161,17 @@ class Peer extends EventEmitter {
     return peer;
   }
 
-  public getLndPubKey(currency: string): string | undefined {
-    if (!this.nodeState || !this.nodeState.lndPubKeys) {
+  public getIdentifier(clientType: SwapClient, currency?: string): string | undefined {
+    if (!this.nodeState) {
       return undefined;
     }
-    return this.nodeState.lndPubKeys[currency];
+    if (clientType === SwapClient.Lnd && currency) {
+      return this.nodeState.lndPubKeys[currency];
+    }
+    if (clientType === SwapClient.Raiden) {
+      return this.nodeState.raidenAddress;
+    }
+    return;
   }
 
   public getStatus = (): string => {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1049,6 +1049,10 @@
           "type": "integer",
           "format": "int32",
           "description": "The time in seconds that we have been connected to this peer."
+        },
+        "raiden_address": {
+          "type": "string",
+          "title": "The raiden address for this peer"
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -826,6 +826,9 @@ export class Peer extends jspb.Message {
   getSecondsConnected(): number;
   setSecondsConnected(value: number): void;
 
+  getRaidenAddress(): string;
+  setRaidenAddress(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Peer.AsObject;
   static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
@@ -845,6 +848,7 @@ export namespace Peer {
     pairsList: Array<string>,
     xudVersion: string,
     secondsConnected: number,
+    raidenAddress: string,
   }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -5803,7 +5803,8 @@ proto.xudrpc.Peer.toObject = function(includeInstance, msg) {
     inbound: jspb.Message.getFieldWithDefault(msg, 4, false),
     pairsList: jspb.Message.getRepeatedField(msg, 5),
     xudVersion: jspb.Message.getFieldWithDefault(msg, 6, ""),
-    secondsConnected: jspb.Message.getFieldWithDefault(msg, 7, 0)
+    secondsConnected: jspb.Message.getFieldWithDefault(msg, 7, 0),
+    raidenAddress: jspb.Message.getFieldWithDefault(msg, 8, "")
   };
 
   if (includeInstance) {
@@ -5869,6 +5870,10 @@ proto.xudrpc.Peer.deserializeBinaryFromReader = function(msg, reader) {
     case 7:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setSecondsConnected(value);
+      break;
+    case 8:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setRaidenAddress(value);
       break;
     default:
       reader.skipField();
@@ -5942,6 +5947,13 @@ proto.xudrpc.Peer.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0) {
     writer.writeInt32(
       7,
+      f
+    );
+  }
+  f = message.getRaidenAddress();
+  if (f.length > 0) {
+    writer.writeString(
+      8,
       f
     );
   }
@@ -6069,6 +6081,21 @@ proto.xudrpc.Peer.prototype.getSecondsConnected = function() {
 /** @param {number} value */
 proto.xudrpc.Peer.prototype.setSecondsConnected = function(value) {
   jspb.Message.setField(this, 7, value);
+};
+
+
+/**
+ * optional string raiden_address = 8;
+ * @return {string}
+ */
+proto.xudrpc.Peer.prototype.getRaidenAddress = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 8, ""));
+};
+
+
+/** @param {string} value */
+proto.xudrpc.Peer.prototype.setRaidenAddress = function(value) {
+  jspb.Message.setField(this, 8, value);
 };
 
 

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -2,9 +2,9 @@ import http from 'http';
 import Logger from '../Logger';
 import BaseClient, { ClientStatus, ChannelBalance } from '../BaseClient';
 import errors from './errors';
-import { ms } from '../utils/utils';
 import { Order } from '../orderbook/types';
-import { SwapDeal } from 'lib/swaps/types';
+import { SwapDeal } from '../swaps/types';
+import { SwapClient } from '../constants/enums';
 
 /**
  * A utility function to parse the payload from an http response.
@@ -78,6 +78,7 @@ interface RaidenClient {
  * A class representing a client to interact with raiden.
  */
 class RaidenClient extends BaseClient {
+  public readonly type = SwapClient.Raiden;
   public readonly cltvDelta: number = 0;
   public address?: string;
   private port: number;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -6,7 +6,7 @@ import RaidenClient, { RaidenInfo } from '../raidenclient/RaidenClient';
 import Client from '../BaseClient';
 import { EventEmitter } from 'events';
 import errors from './errors';
-import { SwapClients, OrderSide, SwapRole } from '../constants/enums';
+import { SwapClient, OrderSide, SwapRole } from '../constants/enums';
 import { parseUri, toUri, UriParts } from '../utils/uriUtils';
 import * as lndrpc from '../proto/lndrpc_pb';
 import { Pair, Order, OrderPortion, PlaceOrderEvent } from '../orderbook/types';
@@ -59,7 +59,7 @@ const argChecks = {
     if (port < 1024 || port > 65535 || !Number.isInteger(port)) throw errors.INVALID_ARGUMENT('port must be an integer between 1024 and 65535');
   },
   VALID_SWAP_CLIENT: ({ swapClient }: { swapClient: number }) => {
-    if (!SwapClients[swapClient]) throw errors.INVALID_ARGUMENT('swap client is not recognized');
+    if (!SwapClient[swapClient]) throw errors.INVALID_ARGUMENT('swap client is not recognized');
   },
 };
 
@@ -88,7 +88,7 @@ class Service extends EventEmitter {
   }
 
   /** Adds a currency. */
-  public addCurrency = async (args: { currency: string, swapClient: SwapClients | number, decimalPlaces: number, tokenAddress?: string}) => {
+  public addCurrency = async (args: { currency: string, swapClient: SwapClient | number, decimalPlaces: number, tokenAddress?: string}) => {
     argChecks.VALID_CURRENCY(args);
     argChecks.VALID_SWAP_CLIENT(args);
     const { currency, swapClient, tokenAddress, decimalPlaces } = args;

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -453,6 +453,8 @@ message Peer {
   string xud_version = 6 [json_name = "xud_version"];
   // The time in seconds that we have been connected to this peer.
   int32 seconds_connected = 7 [json_name = "seconds_connected"];
+  // The raiden address for this peer
+  string raiden_address = 8 [json_name = "raiden_address"];
 }
 
 message PlaceOrderRequest {

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -5,7 +5,7 @@ import OrderBook from '../../lib/orderbook/OrderBook';
 import OrderBookRepository from '../../lib/orderbook/OrderBookRepository';
 import Logger, { Level } from '../../lib/Logger';
 import * as orders from '../../lib/orderbook/types';
-import { SwapClients } from '../../lib/constants/enums';
+import { SwapClient } from '../../lib/constants/enums';
 import { createOwnOrder } from '../utils';
 
 const PAIR_ID = 'LTC/BTC';
@@ -16,8 +16,8 @@ const initValues = async (db: DB) => {
   const orderBookRepository = new OrderBookRepository(loggers.orderbook, db.models);
 
   await orderBookRepository.addCurrencies([
-    { id: currencies[0], swapClient: SwapClients.Lnd, decimalPlaces: 8 },
-    { id: currencies[1], swapClient: SwapClients.Lnd, decimalPlaces: 8 },
+    { id: currencies[0], swapClient: SwapClient.Lnd, decimalPlaces: 8 },
+    { id: currencies[1], swapClient: SwapClient.Lnd, decimalPlaces: 8 },
   ]);
   await orderBookRepository.addPairs([
     { baseCurrency: currencies[0], quoteCurrency: currencies[1] },

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import Service from '../../lib/service/Service';
-import { SwapClients, OrderSide } from '../../lib/constants/enums';
+import { SwapClient, OrderSide } from '../../lib/constants/enums';
 
 chai.use(chaiAsPromised);
 
@@ -51,8 +51,8 @@ describe('API Service', () => {
   });
 
   it('should add two currencies', async () => {
-    const addCurrencyPromises = [service.addCurrency({ currency: 'LTC', swapClient: SwapClients.Lnd, decimalPlaces: 0 }),
-      service.addCurrency({ currency: 'BTC', swapClient: SwapClients.Lnd, decimalPlaces: 0 })];
+    const addCurrencyPromises = [service.addCurrency({ currency: 'LTC', swapClient: SwapClient.Lnd, decimalPlaces: 0 }),
+      service.addCurrency({ currency: 'BTC', swapClient: SwapClient.Lnd, decimalPlaces: 0 })];
     await expect(Promise.all(addCurrencyPromises)).to.be.fulfilled;
   });
 
@@ -108,12 +108,12 @@ describe('API Service', () => {
   });
 
   it('should fail adding a currency with a ticker that is not 2 to 5 characters long', async () => {
-    const tooLongAddCurrencyPromise = service.addCurrency({ currency: 'BITCOIN', swapClient: SwapClients.Lnd, decimalPlaces: 0 });
+    const tooLongAddCurrencyPromise = service.addCurrency({ currency: 'BITCOIN', swapClient: SwapClient.Lnd, decimalPlaces: 0 });
     await expect(tooLongAddCurrencyPromise).to.be.rejectedWith('currency must consist of 2 to 5 upper case English letters or numbers');
   });
 
   it('should fail adding a currency with an invalid letter in its ticker', async () => {
-    const invalidLetterAddCurrencyPromise = service.addCurrency({ currency: 'ÑEO', swapClient: SwapClients.Lnd, decimalPlaces: 0 });
+    const invalidLetterAddCurrencyPromise = service.addCurrency({ currency: 'ÑEO', swapClient: SwapClient.Lnd, decimalPlaces: 0 });
     await expect(invalidLetterAddCurrencyPromise).to.be.rejectedWith('currency must consist of 2 to 5 upper case English letters or numbers');
   });
 
@@ -123,7 +123,7 @@ describe('API Service', () => {
   });
 
   it('should fail adding a currency that already exists', async () => {
-    const addCurrencyPromise = service.addCurrency({ currency: 'LTC', swapClient: SwapClients.Lnd, decimalPlaces: 0 });
+    const addCurrencyPromise = service.addCurrency({ currency: 'LTC', swapClient: SwapClient.Lnd, decimalPlaces: 0 });
     await expect(addCurrencyPromise).to.be.rejectedWith('currency LTC already exists');
   });
 

--- a/test/integration/Swaps.spec.ts
+++ b/test/integration/Swaps.spec.ts
@@ -108,7 +108,7 @@ describe('Swaps.Integration', () => {
     // peer
     peer = sandbox.createStubInstance(Peer) as any;
     peer.sendPacket = async () => {};
-    peer.getLndPubKey = () => '1234567890';
+    peer.getIdentifier = () => '1234567890';
     // pool
     pool = sandbox.createStubInstance(Pool) as any;
     pool.addReputationEvent = () => Promise.resolve(true);
@@ -194,7 +194,7 @@ describe('Swaps.Integration', () => {
       swapClients.BTC!.getRoutes = rejectsWithUnknownError;
       swapClients.LTC!.getRoutes = rejectsWithUnknownError;
       await expect(swaps.executeSwap(validMakerOrder(), validTakerOrder()))
-        .to.eventually.be.rejected.and.equal(SwapFailureReason.UnexpectedLndError);
+        .to.eventually.be.rejected.and.equal(SwapFailureReason.UnexpectedClientError);
     });
 
   });

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import DB from '../../lib/db/DB';
 import OrderBookRepository from '../../lib/orderbook/OrderBookRepository';
 import Logger, { Level } from '../../lib/Logger';
-import { SwapClients, SwapRole, SwapState, SwapPhase } from '../../lib/constants/enums';
+import { SwapClient, SwapRole, SwapState, SwapPhase } from '../../lib/constants/enums';
 import SwapRepository from '../../lib/swaps/SwapRepository';
 import chaiAsPromised = require('chai-as-promised');
 import { SwapDeal } from '../../lib/swaps/types';
@@ -64,12 +64,12 @@ describe('Database', () => {
   it('should add two currencies', async () => {
     const btcPromise = orderBookRepo.addCurrency({
       id: 'BTC',
-      swapClient: SwapClients.Lnd,
+      swapClient: SwapClient.Lnd,
       decimalPlaces: 8,
     });
     const ltcPromise = orderBookRepo.addCurrency({
       id: 'LTC',
-      swapClient: SwapClients.Lnd,
+      swapClient: SwapClient.Lnd,
       decimalPlaces: 8,
     });
     await Promise.all([btcPromise, ltcPromise]);


### PR DESCRIPTION
This replaces the `Peer` `getLndPubKey` method with a generic `getIdentifier` method that will return either an lnd pubkey or a Raiden address. It also adds the raiden address to the `ListPeers` response.

This makes progress towards #797.