### PR TITLE
feat(raiden): detect raiden address change

### DIFF
--- a/lib/BaseClient.ts
+++ b/lib/BaseClient.ts
@@ -17,6 +17,11 @@ type ChannelBalance = {
   pendingOpenBalance: number,
 };
 
+interface BaseClient {
+  on(event: 'connectionVerified', listener: (newIdentifier?: string) => void): this;
+  emit(event: 'connectionVerified', newIdentifier?: string): boolean;
+}
+
 /**
  * A base class to represent an external swap client such as lnd or Raiden.
  */
@@ -100,6 +105,7 @@ abstract class BaseClient extends EventEmitter {
       clearInterval(this.updateCapacityTimer);
     }
     this.closeSpecific();
+    this.removeAllListeners();
   }
   protected abstract closeSpecific(): void;
 }

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -176,6 +176,11 @@ class Xud extends EventEmitter {
         }
       });
     }
+    this.raidenClient.on('connectionVerified', (newAddress) => {
+      if (newAddress) {
+        this.pool.updateNodeState({ raidenAddress: newAddress });
+      }
+    });
   }
 
   private shutdown = async () => {

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -41,11 +41,6 @@ interface LightningMethodIndex extends LightningClient {
   [methodName: string]: Function;
 }
 
-interface LndClient {
-  on(event: 'connectionVerified', listener: (newPubKey?: string) => void): this;
-  emit(event: 'connectionVerified', newPubKey?: string): boolean;
-}
-
 /** A class representing a client to interact with lnd. */
 class LndClient extends BaseClient {
   public readonly type = SwapClient.Lnd;

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -161,14 +161,19 @@ class Pool extends EventEmitter {
    */
   public updateNodeState = (nodeStateUpdate: NodeStateUpdate) => {
     this.nodeState = { ...this.nodeState, ...nodeStateUpdate };
-    const packet = new packets.NodeStateUpdatePacket(this.nodeState);
-    this.peers.forEach(async (peer) => {
-      await peer.sendPacket(packet);
-    });
+    this.sendNodeStateUpdate(nodeStateUpdate);
   }
 
   public updateLndPubKey = (currency: string, pubKey: string) => {
     this.nodeState.lndPubKeys[currency] = pubKey;
+    this.sendNodeStateUpdate(this.nodeState.lndPubKeys);
+  }
+
+  private sendNodeStateUpdate = (nodeStateUpdate: NodeStateUpdate) => {
+    const packet = new packets.NodeStateUpdatePacket(nodeStateUpdate);
+    this.peers.forEach(async (peer) => {
+      await peer.sendPacket(packet);
+    });
   }
 
   public disconnect = async (): Promise<void> => {


### PR DESCRIPTION
This detects if our raiden address changes between calls to `getAddress`. If so it updates peers of our new raiden address.