### PR TITLE
refactor(orderbook): throw error on non-swap fail

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -348,7 +348,7 @@ class LndClient extends BaseClient {
     request.setPubKey(destination);
     try {
       const routes = (await this.queryRoutes(request)).getRoutesList();
-      this.logger.debug(`got ${routes.length} route(s) to destination: ${routes}`);
+      this.logger.debug(`got ${routes.length} route(s) to destination ${destination}: ${routes}`);
       return routes;
     } catch (err) {
       if (typeof err.message === 'string' && (

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -374,27 +374,25 @@ class OrderBook extends EventEmitter {
           onUpdate && onUpdate({ type: PlaceOrderEventType.SwapSuccess, payload: swapResult });
         } catch (err) {
           const failMsg = `swap for ${portion.quantity} failed during order matching`;
-          let failureReason: SwapFailureReason;
-          if (typeof err === 'number') {
+          if (typeof err === 'number' && SwapFailureReason[err] !== undefined) {
             // treat the error as a SwapFailureReason
             this.logger.warn(`${failMsg} due to ${SwapFailureReason[err]}, will repeat matching routine for failed quantity`);
-            failureReason = err;
+
+            const swapFailure: SwapFailure = {
+              failureReason: err,
+              orderId: maker.id,
+              pairId: maker.pairId,
+              quantity: portion.quantity,
+              peerPubKey: maker.peerPubKey,
+            };
+            swapFailures.push(swapFailure);
+            onUpdate && onUpdate({ type: PlaceOrderEventType.SwapFailure, payload: swapFailure });
+            await retryFailedSwap(portion.quantity);
           } else {
-            this.logger.error(`${failMsg} due to unexpected error, will repeat matching routine for failed quantity`, err);
-            failureReason = SwapFailureReason.UnknownError;
+            // treat this as a critical error and abort matching, we only expect SwapFailureReasons to be thrown in the try block above
+            this.logger.error(`${failMsg} due to unexpected error`, err);
             throw err;
           }
-
-          const swapFailure: SwapFailure = {
-            failureReason,
-            orderId: maker.id,
-            pairId: maker.pairId,
-            quantity: portion.quantity,
-            peerPubKey: maker.peerPubKey,
-          };
-          swapFailures.push(swapFailure);
-          onUpdate && onUpdate({ type: PlaceOrderEventType.SwapFailure, payload: swapFailure });
-          await retryFailedSwap(portion.quantity);
         }
       }
     };


### PR DESCRIPTION
This tweaks the logic around handling exceptions that arise from swap execution to ensure that the exception is a valid `SwapFailureReason` and to clarify the log messages and intent of the code. If the exception is not a `SwapFailureReason` we abort the matching procedure instead of repeating it for the failed amount.