### PR TITLE
style: fix golint errors in simulation tests

### DIFF
--- a/test/simulation/actions.go
+++ b/test/simulation/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ExchangeUnion/xud-simulation/xudrpc"
 	"github.com/ExchangeUnion/xud-simulation/xudtest"
 	"github.com/stretchr/testify/require"
@@ -11,7 +12,7 @@ import (
 
 type actions struct{}
 
-func (a *actions) addPair(assert *require.Assertions, ctx context.Context, node *xudtest.HarnessNode, baseCurrency string, quoteCurrency string,
+func (a *actions) addPair(ctx context.Context, assert *require.Assertions, node *xudtest.HarnessNode, baseCurrency string, quoteCurrency string,
 	swapClient xudrpc.AddCurrencyRequest_SwapClient) {
 	// Check the current number of pairs.
 	resInfo, err := node.Client.GetInfo(context.Background(), &xudrpc.GetInfoRequest{})
@@ -39,14 +40,14 @@ func (a *actions) addPair(assert *require.Assertions, ctx context.Context, node 
 	assert.Equal(resGetInfo.NumPairs, prevNumPairs+1)
 }
 
-func (*actions) connect(assert *require.Assertions, ctx context.Context, srcNode, destNode *xudtest.HarnessNode) {
-	destNodeUri := fmt.Sprintf("%v@%v",
+func (*actions) connect(ctx context.Context, assert *require.Assertions, srcNode, destNode *xudtest.HarnessNode) {
+	destNodeURI := fmt.Sprintf("%v@%v",
 		destNode.PubKey(),
 		destNode.Cfg.P2PAddr(),
 	)
 
 	// connect srcNode to destNode.
-	reqConn := &xudrpc.ConnectRequest{NodeUri: destNodeUri}
+	reqConn := &xudrpc.ConnectRequest{NodeUri: destNodeURI}
 	_, err := srcNode.Client.Connect(ctx, reqConn)
 	assert.NoError(err)
 
@@ -67,7 +68,7 @@ func (*actions) connect(assert *require.Assertions, ctx context.Context, srcNode
 	assert.Equal(resListPeers.Peers[0].LndPubKeys["LTC"], srcNode.LndLtcNode.PubKeyStr)
 }
 
-func (*actions) placeOrderAndBroadcast(assert *require.Assertions, ctx context.Context, srcNode, destNode *xudtest.HarnessNode,
+func (*actions) placeOrderAndBroadcast(ctx context.Context, assert *require.Assertions, srcNode, destNode *xudtest.HarnessNode,
 	req *xudrpc.PlaceOrderRequest) *xudrpc.Order {
 	// 	Fetch nodes current order book state.
 	prevSrcNodeCount, prevDestNodeCount, err := getOrdersCount(ctx, srcNode, destNode)
@@ -117,7 +118,7 @@ func (*actions) placeOrderAndBroadcast(assert *require.Assertions, ctx context.C
 	return res.RemainingOrder
 }
 
-func (*actions) removeOrderAndInvalidate(assert *require.Assertions, ctx context.Context, srcNode, destNode *xudtest.HarnessNode, order *xudrpc.Order) {
+func (*actions) removeOrderAndInvalidate(ctx context.Context, assert *require.Assertions, srcNode, destNode *xudtest.HarnessNode, order *xudrpc.Order) {
 	// 	Fetch nodes current order book state.
 	prevSrcNodeCount, prevDestNodeCount, err := getOrdersCount(ctx, srcNode, destNode)
 	assert.NoError(err)
@@ -153,7 +154,7 @@ func (*actions) removeOrderAndInvalidate(assert *require.Assertions, ctx context
 	assert.Equal(destNodeCount.Peer, prevDestNodeCount.Peer-1)
 }
 
-func (*actions) placeOrderAndSwap(assert *require.Assertions, ctx context.Context, srcNode, destNode *xudtest.HarnessNode,
+func (*actions) placeOrderAndSwap(ctx context.Context, assert *require.Assertions, srcNode, destNode *xudtest.HarnessNode,
 	req *xudrpc.PlaceOrderRequest) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/test/simulation/go.mod
+++ b/test/simulation/go.mod
@@ -5,6 +5,7 @@ require (
 	dmitri.shuralyov.com/app/changes v0.0.0-20181114035150-5af16e21babb // indirect
 	dmitri.shuralyov.com/service/change v0.0.0-20190203163610-217368fe4577 // indirect
 	git.apache.org/thrift.git v0.12.0 // indirect
+	github.com/Roasbeef/btcutil v0.0.0-20180406014609-dfb640c57141 // indirect
 	github.com/Shopify/sarama v1.21.0 // indirect
 	github.com/btcsuite/btcd v0.0.0-20181013004428-67e573d211ac
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f

--- a/test/simulation/go.sum
+++ b/test/simulation/go.sum
@@ -24,6 +24,8 @@ github.com/Masterminds/vcs v1.12.0 h1:bt9Hb4XlfmEfLnVA0MVz2NO0GFuMN5vX8iOWW38Xde
 github.com/Masterminds/vcs v1.12.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/NebulousLabs/go-upnp v0.0.0-20181203152547-b32978b8ccbf h1:1UP+tqdgLAKwt6NpefYq/SdyFaelU8MXOThESt6Od1U=
 github.com/NebulousLabs/go-upnp v0.0.0-20181203152547-b32978b8ccbf/go.mod h1:GbuBk21JqF+driLX3XtJYNZjGa45YDoa9IqCTzNSfEc=
+github.com/Roasbeef/btcutil v0.0.0-20180406014609-dfb640c57141 h1:XzCtkSb4BOEfjc9jQFi3YJ0lB3eajRgyBOk70Imo6Ts=
+github.com/Roasbeef/btcutil v0.0.0-20180406014609-dfb640c57141/go.mod h1:Q8e/TakPIqMqkD/B5e1Cgu0xzH3J3/SX2h+aOMv1i2c=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.21.0/go.mod h1:yuqtN/pe8cXRWG5zPaO7hCfNJp5MwmkoJEoLjkm5tCQ=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=


### PR DESCRIPTION
This fixes errors reported by `golint` and `go vet` in the simulation test golang code.