### PR TITLE
 chore: generate protobuf

### DIFF
--- a/lib/proto/xudp2p_pb.d.ts
+++ b/lib/proto/xudp2p_pb.d.ts
@@ -1,615 +1,644 @@
 // package: xudp2p
 // file: xudp2p.proto
 
+/* tslint:disable */
+
 import * as jspb from "google-protobuf";
 
-export class Address extends jspb.Message {
-  getHost(): string;
-  setHost(value: string): void;
+export class Address extends jspb.Message { 
+    getHost(): string;
+    setHost(value: string): void;
 
-  getPort(): number;
-  setPort(value: number): void;
+    getPort(): number;
+    setPort(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): Address.AsObject;
-  static toObject(includeInstance: boolean, msg: Address): Address.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: Address, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): Address;
-  static deserializeBinaryFromReader(message: Address, reader: jspb.BinaryReader): Address;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Address.AsObject;
+    static toObject(includeInstance: boolean, msg: Address): Address.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Address, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Address;
+    static deserializeBinaryFromReader(message: Address, reader: jspb.BinaryReader): Address;
 }
 
 export namespace Address {
-  export type AsObject = {
-    host: string,
-    port: number,
-  }
+    export type AsObject = {
+        host: string,
+        port: number,
+    }
 }
 
-export class Order extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class Order extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getPairId(): string;
-  setPairId(value: string): void;
+    getPairId(): string;
+    setPairId(value: string): void;
 
-  getPrice(): number;
-  setPrice(value: number): void;
+    getPrice(): number;
+    setPrice(value: number): void;
 
-  getQuantity(): number;
-  setQuantity(value: number): void;
+    getQuantity(): number;
+    setQuantity(value: number): void;
 
-  getIsBuy(): boolean;
-  setIsBuy(value: boolean): void;
+    getIsBuy(): boolean;
+    setIsBuy(value: boolean): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): Order.AsObject;
-  static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): Order;
-  static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Order.AsObject;
+    static toObject(includeInstance: boolean, msg: Order): Order.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Order, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Order;
+    static deserializeBinaryFromReader(message: Order, reader: jspb.BinaryReader): Order;
 }
 
 export namespace Order {
-  export type AsObject = {
-    id: string,
-    pairId: string,
-    price: number,
-    quantity: number,
-    isBuy: boolean,
-  }
+    export type AsObject = {
+        id: string,
+        pairId: string,
+        price: number,
+        quantity: number,
+        isBuy: boolean,
+    }
 }
 
-export class Node extends jspb.Message {
-  getNodePubKey(): string;
-  setNodePubKey(value: string): void;
+export class Node extends jspb.Message { 
+    getNodePubKey(): string;
+    setNodePubKey(value: string): void;
 
-  clearAddressesList(): void;
-  getAddressesList(): Array<Address>;
-  setAddressesList(value: Array<Address>): void;
-  addAddresses(value?: Address, index?: number): Address;
+    clearAddressesList(): void;
+    getAddressesList(): Array<Address>;
+    setAddressesList(value: Array<Address>): void;
+    addAddresses(value?: Address, index?: number): Address;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): Node.AsObject;
-  static toObject(includeInstance: boolean, msg: Node): Node.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: Node, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): Node;
-  static deserializeBinaryFromReader(message: Node, reader: jspb.BinaryReader): Node;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Node.AsObject;
+    static toObject(includeInstance: boolean, msg: Node): Node.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Node, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Node;
+    static deserializeBinaryFromReader(message: Node, reader: jspb.BinaryReader): Node;
 }
 
 export namespace Node {
-  export type AsObject = {
-    nodePubKey: string,
-    addressesList: Array<Address.AsObject>,
-  }
+    export type AsObject = {
+        nodePubKey: string,
+        addressesList: Array<Address.AsObject>,
+    }
 }
 
-export class NodeState extends jspb.Message {
-  getVersion(): string;
-  setVersion(value: string): void;
+export class NodeState extends jspb.Message { 
+    getVersion(): string;
+    setVersion(value: string): void;
 
-  getNodePubKey(): string;
-  setNodePubKey(value: string): void;
+    getNodePubKey(): string;
+    setNodePubKey(value: string): void;
 
-  clearAddressesList(): void;
-  getAddressesList(): Array<Address>;
-  setAddressesList(value: Array<Address>): void;
-  addAddresses(value?: Address, index?: number): Address;
+    clearAddressesList(): void;
+    getAddressesList(): Array<Address>;
+    setAddressesList(value: Array<Address>): void;
+    addAddresses(value?: Address, index?: number): Address;
 
-  clearPairsList(): void;
-  getPairsList(): Array<string>;
-  setPairsList(value: Array<string>): void;
-  addPairs(value: string, index?: number): string;
+    clearPairsList(): void;
+    getPairsList(): Array<string>;
+    setPairsList(value: Array<string>): void;
+    addPairs(value: string, index?: number): string;
 
-  getRaidenAddress(): string;
-  setRaidenAddress(value: string): void;
+    getRaidenAddress(): string;
+    setRaidenAddress(value: string): void;
 
-  getLndPubKeysMap(): jspb.Map<string, string>;
-  clearLndPubKeysMap(): void;
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): NodeState.AsObject;
-  static toObject(includeInstance: boolean, msg: NodeState): NodeState.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: NodeState, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): NodeState;
-  static deserializeBinaryFromReader(message: NodeState, reader: jspb.BinaryReader): NodeState;
+
+    getLndPubKeysMap(): jspb.Map<string, string>;
+    clearLndPubKeysMap(): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): NodeState.AsObject;
+    static toObject(includeInstance: boolean, msg: NodeState): NodeState.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: NodeState, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): NodeState;
+    static deserializeBinaryFromReader(message: NodeState, reader: jspb.BinaryReader): NodeState;
 }
 
 export namespace NodeState {
-  export type AsObject = {
-    version: string,
-    nodePubKey: string,
-    addressesList: Array<Address.AsObject>,
-    pairsList: Array<string>,
-    raidenAddress: string,
-    lndPubKeysMap: Array<[string, string]>,
-  }
+    export type AsObject = {
+        version: string,
+        nodePubKey: string,
+        addressesList: Array<Address.AsObject>,
+        pairsList: Array<string>,
+        raidenAddress: string,
+
+        lndPubKeysMap: Array<[string, string]>,
+    }
 }
 
-export class PingPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class PingPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): PingPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: PingPacket): PingPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: PingPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): PingPacket;
-  static deserializeBinaryFromReader(message: PingPacket, reader: jspb.BinaryReader): PingPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PingPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: PingPacket): PingPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PingPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PingPacket;
+    static deserializeBinaryFromReader(message: PingPacket, reader: jspb.BinaryReader): PingPacket;
 }
 
 export namespace PingPacket {
-  export type AsObject = {
-    id: string,
-  }
+    export type AsObject = {
+        id: string,
+    }
 }
 
-export class PongPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class PongPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): PongPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: PongPacket): PongPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: PongPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): PongPacket;
-  static deserializeBinaryFromReader(message: PongPacket, reader: jspb.BinaryReader): PongPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PongPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: PongPacket): PongPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PongPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PongPacket;
+    static deserializeBinaryFromReader(message: PongPacket, reader: jspb.BinaryReader): PongPacket;
 }
 
 export namespace PongPacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+    }
 }
 
-export class OrderPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class OrderPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  hasOrder(): boolean;
-  clearOrder(): void;
-  getOrder(): Order | undefined;
-  setOrder(value?: Order): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): OrderPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: OrderPacket): OrderPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: OrderPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): OrderPacket;
-  static deserializeBinaryFromReader(message: OrderPacket, reader: jspb.BinaryReader): OrderPacket;
+    hasOrder(): boolean;
+    clearOrder(): void;
+    getOrder(): Order | undefined;
+    setOrder(value?: Order): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): OrderPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: OrderPacket): OrderPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: OrderPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): OrderPacket;
+    static deserializeBinaryFromReader(message: OrderPacket, reader: jspb.BinaryReader): OrderPacket;
 }
 
 export namespace OrderPacket {
-  export type AsObject = {
-    id: string,
-    order?: Order.AsObject,
-  }
+    export type AsObject = {
+        id: string,
+        order?: Order.AsObject,
+    }
 }
 
-export class OrderInvalidationPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class OrderInvalidationPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getOrderId(): string;
-  setOrderId(value: string): void;
+    getOrderId(): string;
+    setOrderId(value: string): void;
 
-  getPairId(): string;
-  setPairId(value: string): void;
+    getPairId(): string;
+    setPairId(value: string): void;
 
-  getQuantity(): number;
-  setQuantity(value: number): void;
+    getQuantity(): number;
+    setQuantity(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): OrderInvalidationPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: OrderInvalidationPacket): OrderInvalidationPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: OrderInvalidationPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): OrderInvalidationPacket;
-  static deserializeBinaryFromReader(message: OrderInvalidationPacket, reader: jspb.BinaryReader): OrderInvalidationPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): OrderInvalidationPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: OrderInvalidationPacket): OrderInvalidationPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: OrderInvalidationPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): OrderInvalidationPacket;
+    static deserializeBinaryFromReader(message: OrderInvalidationPacket, reader: jspb.BinaryReader): OrderInvalidationPacket;
 }
 
 export namespace OrderInvalidationPacket {
-  export type AsObject = {
-    id: string,
-    orderId: string,
-    pairId: string,
-    quantity: number,
-  }
+    export type AsObject = {
+        id: string,
+        orderId: string,
+        pairId: string,
+        quantity: number,
+    }
 }
 
-export class GetOrdersPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class GetOrdersPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  clearPairIdsList(): void;
-  getPairIdsList(): Array<string>;
-  setPairIdsList(value: Array<string>): void;
-  addPairIds(value: string, index?: number): string;
+    clearPairIdsList(): void;
+    getPairIdsList(): Array<string>;
+    setPairIdsList(value: Array<string>): void;
+    addPairIds(value: string, index?: number): string;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetOrdersPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: GetOrdersPacket): GetOrdersPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetOrdersPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetOrdersPacket;
-  static deserializeBinaryFromReader(message: GetOrdersPacket, reader: jspb.BinaryReader): GetOrdersPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetOrdersPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: GetOrdersPacket): GetOrdersPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetOrdersPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetOrdersPacket;
+    static deserializeBinaryFromReader(message: GetOrdersPacket, reader: jspb.BinaryReader): GetOrdersPacket;
 }
 
 export namespace GetOrdersPacket {
-  export type AsObject = {
-    id: string,
-    pairIdsList: Array<string>,
-  }
+    export type AsObject = {
+        id: string,
+        pairIdsList: Array<string>,
+    }
 }
 
-export class OrdersPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class OrdersPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  clearOrdersList(): void;
-  getOrdersList(): Array<Order>;
-  setOrdersList(value: Array<Order>): void;
-  addOrders(value?: Order, index?: number): Order;
+    clearOrdersList(): void;
+    getOrdersList(): Array<Order>;
+    setOrdersList(value: Array<Order>): void;
+    addOrders(value?: Order, index?: number): Order;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): OrdersPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: OrdersPacket): OrdersPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: OrdersPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): OrdersPacket;
-  static deserializeBinaryFromReader(message: OrdersPacket, reader: jspb.BinaryReader): OrdersPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): OrdersPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: OrdersPacket): OrdersPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: OrdersPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): OrdersPacket;
+    static deserializeBinaryFromReader(message: OrdersPacket, reader: jspb.BinaryReader): OrdersPacket;
 }
 
 export namespace OrdersPacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-    ordersList: Array<Order.AsObject>,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+        ordersList: Array<Order.AsObject>,
+    }
 }
 
-export class NodeStateUpdatePacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class NodeStateUpdatePacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  clearAddressesList(): void;
-  getAddressesList(): Array<Address>;
-  setAddressesList(value: Array<Address>): void;
-  addAddresses(value?: Address, index?: number): Address;
+    clearAddressesList(): void;
+    getAddressesList(): Array<Address>;
+    setAddressesList(value: Array<Address>): void;
+    addAddresses(value?: Address, index?: number): Address;
 
-  clearPairsList(): void;
-  getPairsList(): Array<string>;
-  setPairsList(value: Array<string>): void;
-  addPairs(value: string, index?: number): string;
+    clearPairsList(): void;
+    getPairsList(): Array<string>;
+    setPairsList(value: Array<string>): void;
+    addPairs(value: string, index?: number): string;
 
-  getRaidenAddress(): string;
-  setRaidenAddress(value: string): void;
+    getRaidenAddress(): string;
+    setRaidenAddress(value: string): void;
 
-  getLndPubKeysMap(): jspb.Map<string, string>;
-  clearLndPubKeysMap(): void;
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): NodeStateUpdatePacket.AsObject;
-  static toObject(includeInstance: boolean, msg: NodeStateUpdatePacket): NodeStateUpdatePacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: NodeStateUpdatePacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): NodeStateUpdatePacket;
-  static deserializeBinaryFromReader(message: NodeStateUpdatePacket, reader: jspb.BinaryReader): NodeStateUpdatePacket;
+
+    getLndPubKeysMap(): jspb.Map<string, string>;
+    clearLndPubKeysMap(): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): NodeStateUpdatePacket.AsObject;
+    static toObject(includeInstance: boolean, msg: NodeStateUpdatePacket): NodeStateUpdatePacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: NodeStateUpdatePacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): NodeStateUpdatePacket;
+    static deserializeBinaryFromReader(message: NodeStateUpdatePacket, reader: jspb.BinaryReader): NodeStateUpdatePacket;
 }
 
 export namespace NodeStateUpdatePacket {
-  export type AsObject = {
-    id: string,
-    addressesList: Array<Address.AsObject>,
-    pairsList: Array<string>,
-    raidenAddress: string,
-    lndPubKeysMap: Array<[string, string]>,
-  }
+    export type AsObject = {
+        id: string,
+        addressesList: Array<Address.AsObject>,
+        pairsList: Array<string>,
+        raidenAddress: string,
+
+        lndPubKeysMap: Array<[string, string]>,
+    }
 }
 
-export class SessionInitPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class SessionInitPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getSign(): string;
-  setSign(value: string): void;
+    getSign(): string;
+    setSign(value: string): void;
 
-  getPeerPubKey(): string;
-  setPeerPubKey(value: string): void;
+    getPeerPubKey(): string;
+    setPeerPubKey(value: string): void;
 
-  getEphemeralPubKey(): string;
-  setEphemeralPubKey(value: string): void;
+    getEphemeralPubKey(): string;
+    setEphemeralPubKey(value: string): void;
 
-  hasNodeState(): boolean;
-  clearNodeState(): void;
-  getNodeState(): NodeState | undefined;
-  setNodeState(value?: NodeState): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SessionInitPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: SessionInitPacket): SessionInitPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SessionInitPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SessionInitPacket;
-  static deserializeBinaryFromReader(message: SessionInitPacket, reader: jspb.BinaryReader): SessionInitPacket;
+    hasNodeState(): boolean;
+    clearNodeState(): void;
+    getNodeState(): NodeState | undefined;
+    setNodeState(value?: NodeState): void;
+
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SessionInitPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: SessionInitPacket): SessionInitPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SessionInitPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SessionInitPacket;
+    static deserializeBinaryFromReader(message: SessionInitPacket, reader: jspb.BinaryReader): SessionInitPacket;
 }
 
 export namespace SessionInitPacket {
-  export type AsObject = {
-    id: string,
-    sign: string,
-    peerPubKey: string,
-    ephemeralPubKey: string,
-    nodeState?: NodeState.AsObject,
-  }
+    export type AsObject = {
+        id: string,
+        sign: string,
+        peerPubKey: string,
+        ephemeralPubKey: string,
+        nodeState?: NodeState.AsObject,
+    }
 }
 
-export class SessionAckPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class SessionAckPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  getEphemeralPubKey(): string;
-  setEphemeralPubKey(value: string): void;
+    getEphemeralPubKey(): string;
+    setEphemeralPubKey(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SessionAckPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: SessionAckPacket): SessionAckPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SessionAckPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SessionAckPacket;
-  static deserializeBinaryFromReader(message: SessionAckPacket, reader: jspb.BinaryReader): SessionAckPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SessionAckPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: SessionAckPacket): SessionAckPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SessionAckPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SessionAckPacket;
+    static deserializeBinaryFromReader(message: SessionAckPacket, reader: jspb.BinaryReader): SessionAckPacket;
 }
 
 export namespace SessionAckPacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-    ephemeralPubKey: string,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+        ephemeralPubKey: string,
+    }
 }
 
-export class DisconnectingPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class DisconnectingPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReason(): number;
-  setReason(value: number): void;
+    getReason(): number;
+    setReason(value: number): void;
 
-  getPayload(): string;
-  setPayload(value: string): void;
+    getPayload(): string;
+    setPayload(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): DisconnectingPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: DisconnectingPacket): DisconnectingPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: DisconnectingPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): DisconnectingPacket;
-  static deserializeBinaryFromReader(message: DisconnectingPacket, reader: jspb.BinaryReader): DisconnectingPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): DisconnectingPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: DisconnectingPacket): DisconnectingPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: DisconnectingPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): DisconnectingPacket;
+    static deserializeBinaryFromReader(message: DisconnectingPacket, reader: jspb.BinaryReader): DisconnectingPacket;
 }
 
 export namespace DisconnectingPacket {
-  export type AsObject = {
-    id: string,
-    reason: number,
-    payload: string,
-  }
+    export type AsObject = {
+        id: string,
+        reason: number,
+        payload: string,
+    }
 }
 
-export class GetNodesPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class GetNodesPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): GetNodesPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: GetNodesPacket): GetNodesPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: GetNodesPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): GetNodesPacket;
-  static deserializeBinaryFromReader(message: GetNodesPacket, reader: jspb.BinaryReader): GetNodesPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): GetNodesPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: GetNodesPacket): GetNodesPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: GetNodesPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): GetNodesPacket;
+    static deserializeBinaryFromReader(message: GetNodesPacket, reader: jspb.BinaryReader): GetNodesPacket;
 }
 
 export namespace GetNodesPacket {
-  export type AsObject = {
-    id: string,
-  }
+    export type AsObject = {
+        id: string,
+    }
 }
 
-export class NodesPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class NodesPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  clearNodesList(): void;
-  getNodesList(): Array<Node>;
-  setNodesList(value: Array<Node>): void;
-  addNodes(value?: Node, index?: number): Node;
+    clearNodesList(): void;
+    getNodesList(): Array<Node>;
+    setNodesList(value: Array<Node>): void;
+    addNodes(value?: Node, index?: number): Node;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): NodesPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: NodesPacket): NodesPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: NodesPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): NodesPacket;
-  static deserializeBinaryFromReader(message: NodesPacket, reader: jspb.BinaryReader): NodesPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): NodesPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: NodesPacket): NodesPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: NodesPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): NodesPacket;
+    static deserializeBinaryFromReader(message: NodesPacket, reader: jspb.BinaryReader): NodesPacket;
 }
 
 export namespace NodesPacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-    nodesList: Array<Node.AsObject>,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+        nodesList: Array<Node.AsObject>,
+    }
 }
 
-export class SwapRequestPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class SwapRequestPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getProposedQuantity(): number;
-  setProposedQuantity(value: number): void;
+    getProposedQuantity(): number;
+    setProposedQuantity(value: number): void;
 
-  getPairId(): string;
-  setPairId(value: string): void;
+    getPairId(): string;
+    setPairId(value: string): void;
 
-  getOrderId(): string;
-  setOrderId(value: string): void;
+    getOrderId(): string;
+    setOrderId(value: string): void;
 
-  getRHash(): string;
-  setRHash(value: string): void;
+    getRHash(): string;
+    setRHash(value: string): void;
 
-  getTakerCltvDelta(): number;
-  setTakerCltvDelta(value: number): void;
+    getTakerCltvDelta(): number;
+    setTakerCltvDelta(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SwapRequestPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: SwapRequestPacket): SwapRequestPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SwapRequestPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SwapRequestPacket;
-  static deserializeBinaryFromReader(message: SwapRequestPacket, reader: jspb.BinaryReader): SwapRequestPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SwapRequestPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: SwapRequestPacket): SwapRequestPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SwapRequestPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SwapRequestPacket;
+    static deserializeBinaryFromReader(message: SwapRequestPacket, reader: jspb.BinaryReader): SwapRequestPacket;
 }
 
 export namespace SwapRequestPacket {
-  export type AsObject = {
-    id: string,
-    proposedQuantity: number,
-    pairId: string,
-    orderId: string,
-    rHash: string,
-    takerCltvDelta: number,
-  }
+    export type AsObject = {
+        id: string,
+        proposedQuantity: number,
+        pairId: string,
+        orderId: string,
+        rHash: string,
+        takerCltvDelta: number,
+    }
 }
 
-export class SwapAcceptedPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class SwapAcceptedPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  getRHash(): string;
-  setRHash(value: string): void;
+    getRHash(): string;
+    setRHash(value: string): void;
 
-  getQuantity(): number;
-  setQuantity(value: number): void;
+    getQuantity(): number;
+    setQuantity(value: number): void;
 
-  getMakerCltvDelta(): number;
-  setMakerCltvDelta(value: number): void;
+    getMakerCltvDelta(): number;
+    setMakerCltvDelta(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SwapAcceptedPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: SwapAcceptedPacket): SwapAcceptedPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SwapAcceptedPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SwapAcceptedPacket;
-  static deserializeBinaryFromReader(message: SwapAcceptedPacket, reader: jspb.BinaryReader): SwapAcceptedPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SwapAcceptedPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: SwapAcceptedPacket): SwapAcceptedPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SwapAcceptedPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SwapAcceptedPacket;
+    static deserializeBinaryFromReader(message: SwapAcceptedPacket, reader: jspb.BinaryReader): SwapAcceptedPacket;
 }
 
 export namespace SwapAcceptedPacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-    rHash: string,
-    quantity: number,
-    makerCltvDelta: number,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+        rHash: string,
+        quantity: number,
+        makerCltvDelta: number,
+    }
 }
 
-export class SwapCompletePacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class SwapCompletePacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  getRHash(): string;
-  setRHash(value: string): void;
+    getRHash(): string;
+    setRHash(value: string): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SwapCompletePacket.AsObject;
-  static toObject(includeInstance: boolean, msg: SwapCompletePacket): SwapCompletePacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SwapCompletePacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SwapCompletePacket;
-  static deserializeBinaryFromReader(message: SwapCompletePacket, reader: jspb.BinaryReader): SwapCompletePacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SwapCompletePacket.AsObject;
+    static toObject(includeInstance: boolean, msg: SwapCompletePacket): SwapCompletePacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SwapCompletePacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SwapCompletePacket;
+    static deserializeBinaryFromReader(message: SwapCompletePacket, reader: jspb.BinaryReader): SwapCompletePacket;
 }
 
 export namespace SwapCompletePacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-    rHash: string,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+        rHash: string,
+    }
 }
 
-export class SwapFailedPacket extends jspb.Message {
-  getId(): string;
-  setId(value: string): void;
+export class SwapFailedPacket extends jspb.Message { 
+    getId(): string;
+    setId(value: string): void;
 
-  getReqId(): string;
-  setReqId(value: string): void;
+    getReqId(): string;
+    setReqId(value: string): void;
 
-  getRHash(): string;
-  setRHash(value: string): void;
+    getRHash(): string;
+    setRHash(value: string): void;
 
-  getErrorMessage(): string;
-  setErrorMessage(value: string): void;
+    getErrorMessage(): string;
+    setErrorMessage(value: string): void;
 
-  getFailureReason(): number;
-  setFailureReason(value: number): void;
+    getFailureReason(): number;
+    setFailureReason(value: number): void;
 
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SwapFailedPacket.AsObject;
-  static toObject(includeInstance: boolean, msg: SwapFailedPacket): SwapFailedPacket.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SwapFailedPacket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SwapFailedPacket;
-  static deserializeBinaryFromReader(message: SwapFailedPacket, reader: jspb.BinaryReader): SwapFailedPacket;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): SwapFailedPacket.AsObject;
+    static toObject(includeInstance: boolean, msg: SwapFailedPacket): SwapFailedPacket.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: SwapFailedPacket, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): SwapFailedPacket;
+    static deserializeBinaryFromReader(message: SwapFailedPacket, reader: jspb.BinaryReader): SwapFailedPacket;
 }
 
 export namespace SwapFailedPacket {
-  export type AsObject = {
-    id: string,
-    reqId: string,
-    rHash: string,
-    errorMessage: string,
-    failureReason: number,
-  }
+    export type AsObject = {
+        id: string,
+        reqId: string,
+        rHash: string,
+        errorMessage: string,
+        failureReason: number,
+    }
 }
-

--- a/lib/proto/xudp2p_pb.js
+++ b/lib/proto/xudp2p_pb.js
@@ -181,7 +181,7 @@ proto.xudp2p.Address.prototype.getHost = function() {
 
 /** @param {string} value */
 proto.xudp2p.Address.prototype.setHost = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -196,7 +196,7 @@ proto.xudp2p.Address.prototype.getPort = function() {
 
 /** @param {number} value */
 proto.xudp2p.Address.prototype.setPort = function(value) {
-  jspb.Message.setProto3IntField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -250,7 +250,7 @@ proto.xudp2p.Order.toObject = function(includeInstance, msg) {
     id: jspb.Message.getFieldWithDefault(msg, 1, ""),
     pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
     price: +jspb.Message.getFieldWithDefault(msg, 3, 0.0),
-    quantity: +jspb.Message.getFieldWithDefault(msg, 4, 0.0),
+    quantity: jspb.Message.getFieldWithDefault(msg, 4, 0),
     isBuy: jspb.Message.getFieldWithDefault(msg, 5, false)
   };
 
@@ -301,7 +301,7 @@ proto.xudp2p.Order.deserializeBinaryFromReader = function(msg, reader) {
       msg.setPrice(value);
       break;
     case 4:
-      var value = /** @type {number} */ (reader.readDouble());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setQuantity(value);
       break;
     case 5:
@@ -359,8 +359,8 @@ proto.xudp2p.Order.serializeBinaryToWriter = function(message, writer) {
     );
   }
   f = message.getQuantity();
-  if (f !== 0.0) {
-    writer.writeDouble(
+  if (f !== 0) {
+    writer.writeUint64(
       4,
       f
     );
@@ -386,7 +386,7 @@ proto.xudp2p.Order.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.Order.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -401,7 +401,7 @@ proto.xudp2p.Order.prototype.getPairId = function() {
 
 /** @param {string} value */
 proto.xudp2p.Order.prototype.setPairId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -416,22 +416,22 @@ proto.xudp2p.Order.prototype.getPrice = function() {
 
 /** @param {number} value */
 proto.xudp2p.Order.prototype.setPrice = function(value) {
-  jspb.Message.setProto3FloatField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
 /**
- * optional double quantity = 4;
+ * optional uint64 quantity = 4;
  * @return {number}
  */
 proto.xudp2p.Order.prototype.getQuantity = function() {
-  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 4, 0.0));
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
 };
 
 
 /** @param {number} value */
 proto.xudp2p.Order.prototype.setQuantity = function(value) {
-  jspb.Message.setProto3FloatField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -448,7 +448,7 @@ proto.xudp2p.Order.prototype.getIsBuy = function() {
 
 /** @param {boolean} value */
 proto.xudp2p.Order.prototype.setIsBuy = function(value) {
-  jspb.Message.setProto3BooleanField(this, 5, value);
+  jspb.Message.setField(this, 5, value);
 };
 
 
@@ -612,21 +612,21 @@ proto.xudp2p.Node.prototype.getNodePubKey = function() {
 
 /** @param {string} value */
 proto.xudp2p.Node.prototype.setNodePubKey = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
 /**
  * repeated Address addresses = 2;
- * @return {!Array<!proto.xudp2p.Address>}
+ * @return {!Array.<!proto.xudp2p.Address>}
  */
 proto.xudp2p.Node.prototype.getAddressesList = function() {
-  return /** @type{!Array<!proto.xudp2p.Address>} */ (
+  return /** @type{!Array.<!proto.xudp2p.Address>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.xudp2p.Address, 2));
 };
 
 
-/** @param {!Array<!proto.xudp2p.Address>} value */
+/** @param {!Array.<!proto.xudp2p.Address>} value */
 proto.xudp2p.Node.prototype.setAddressesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
@@ -768,7 +768,7 @@ proto.xudp2p.NodeState.deserializeBinaryFromReader = function(msg, reader) {
     case 6:
       var value = msg.getLndPubKeysMap();
       reader.readMessage(value, function(message, reader) {
-        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "");
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString);
          });
       break;
     default:
@@ -854,7 +854,7 @@ proto.xudp2p.NodeState.prototype.getVersion = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodeState.prototype.setVersion = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -869,21 +869,21 @@ proto.xudp2p.NodeState.prototype.getNodePubKey = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodeState.prototype.setNodePubKey = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
 /**
  * repeated Address addresses = 3;
- * @return {!Array<!proto.xudp2p.Address>}
+ * @return {!Array.<!proto.xudp2p.Address>}
  */
 proto.xudp2p.NodeState.prototype.getAddressesList = function() {
-  return /** @type{!Array<!proto.xudp2p.Address>} */ (
+  return /** @type{!Array.<!proto.xudp2p.Address>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.xudp2p.Address, 3));
 };
 
 
-/** @param {!Array<!proto.xudp2p.Address>} value */
+/** @param {!Array.<!proto.xudp2p.Address>} value */
 proto.xudp2p.NodeState.prototype.setAddressesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
@@ -906,21 +906,21 @@ proto.xudp2p.NodeState.prototype.clearAddressesList = function() {
 
 /**
  * repeated string pairs = 4;
- * @return {!Array<string>}
+ * @return {!Array.<string>}
  */
 proto.xudp2p.NodeState.prototype.getPairsList = function() {
-  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 4));
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 4));
 };
 
 
-/** @param {!Array<string>} value */
+/** @param {!Array.<string>} value */
 proto.xudp2p.NodeState.prototype.setPairsList = function(value) {
   jspb.Message.setField(this, 4, value || []);
 };
 
 
 /**
- * @param {string} value
+ * @param {!string} value
  * @param {number=} opt_index
  */
 proto.xudp2p.NodeState.prototype.addPairs = function(value, opt_index) {
@@ -944,7 +944,7 @@ proto.xudp2p.NodeState.prototype.getRaidenAddress = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodeState.prototype.setRaidenAddress = function(value) {
-  jspb.Message.setProto3StringField(this, 5, value);
+  jspb.Message.setField(this, 5, value);
 };
 
 
@@ -1104,7 +1104,7 @@ proto.xudp2p.PingPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.PingPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -1258,7 +1258,7 @@ proto.xudp2p.PongPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.PongPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -1273,7 +1273,7 @@ proto.xudp2p.PongPacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.PongPacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -1429,7 +1429,7 @@ proto.xudp2p.OrderPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.OrderPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -1456,7 +1456,7 @@ proto.xudp2p.OrderPacket.prototype.clearOrder = function() {
 
 /**
  * Returns whether this field is set.
- * @return {boolean}
+ * @return {!boolean}
  */
 proto.xudp2p.OrderPacket.prototype.hasOrder = function() {
   return jspb.Message.getField(this, 2) != null;
@@ -1513,7 +1513,7 @@ proto.xudp2p.OrderInvalidationPacket.toObject = function(includeInstance, msg) {
     id: jspb.Message.getFieldWithDefault(msg, 1, ""),
     orderId: jspb.Message.getFieldWithDefault(msg, 2, ""),
     pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    quantity: +jspb.Message.getFieldWithDefault(msg, 4, 0.0)
+    quantity: jspb.Message.getFieldWithDefault(msg, 4, 0)
   };
 
   if (includeInstance) {
@@ -1563,7 +1563,7 @@ proto.xudp2p.OrderInvalidationPacket.deserializeBinaryFromReader = function(msg,
       msg.setPairId(value);
       break;
     case 4:
-      var value = /** @type {number} */ (reader.readDouble());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setQuantity(value);
       break;
     default:
@@ -1617,8 +1617,8 @@ proto.xudp2p.OrderInvalidationPacket.serializeBinaryToWriter = function(message,
     );
   }
   f = message.getQuantity();
-  if (f !== 0.0) {
-    writer.writeDouble(
+  if (f !== 0) {
+    writer.writeUint64(
       4,
       f
     );
@@ -1637,7 +1637,7 @@ proto.xudp2p.OrderInvalidationPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.OrderInvalidationPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -1652,7 +1652,7 @@ proto.xudp2p.OrderInvalidationPacket.prototype.getOrderId = function() {
 
 /** @param {string} value */
 proto.xudp2p.OrderInvalidationPacket.prototype.setOrderId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -1667,22 +1667,22 @@ proto.xudp2p.OrderInvalidationPacket.prototype.getPairId = function() {
 
 /** @param {string} value */
 proto.xudp2p.OrderInvalidationPacket.prototype.setPairId = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
 /**
- * optional double quantity = 4;
+ * optional uint64 quantity = 4;
  * @return {number}
  */
 proto.xudp2p.OrderInvalidationPacket.prototype.getQuantity = function() {
-  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 4, 0.0));
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
 };
 
 
 /** @param {number} value */
 proto.xudp2p.OrderInvalidationPacket.prototype.setQuantity = function(value) {
-  jspb.Message.setProto3FloatField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -1843,27 +1843,27 @@ proto.xudp2p.GetOrdersPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.GetOrdersPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
 /**
  * repeated string pair_ids = 2;
- * @return {!Array<string>}
+ * @return {!Array.<string>}
  */
 proto.xudp2p.GetOrdersPacket.prototype.getPairIdsList = function() {
-  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 2));
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 2));
 };
 
 
-/** @param {!Array<string>} value */
+/** @param {!Array.<string>} value */
 proto.xudp2p.GetOrdersPacket.prototype.setPairIdsList = function(value) {
   jspb.Message.setField(this, 2, value || []);
 };
 
 
 /**
- * @param {string} value
+ * @param {!string} value
  * @param {number=} opt_index
  */
 proto.xudp2p.GetOrdersPacket.prototype.addPairIds = function(value, opt_index) {
@@ -2048,7 +2048,7 @@ proto.xudp2p.OrdersPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.OrdersPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -2063,21 +2063,21 @@ proto.xudp2p.OrdersPacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.OrdersPacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
 /**
  * repeated Order orders = 3;
- * @return {!Array<!proto.xudp2p.Order>}
+ * @return {!Array.<!proto.xudp2p.Order>}
  */
 proto.xudp2p.OrdersPacket.prototype.getOrdersList = function() {
-  return /** @type{!Array<!proto.xudp2p.Order>} */ (
+  return /** @type{!Array.<!proto.xudp2p.Order>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.xudp2p.Order, 3));
 };
 
 
-/** @param {!Array<!proto.xudp2p.Order>} value */
+/** @param {!Array.<!proto.xudp2p.Order>} value */
 proto.xudp2p.OrdersPacket.prototype.setOrdersList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
@@ -2214,7 +2214,7 @@ proto.xudp2p.NodeStateUpdatePacket.deserializeBinaryFromReader = function(msg, r
     case 6:
       var value = msg.getLndPubKeysMap();
       reader.readMessage(value, function(message, reader) {
-        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "");
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString);
          });
       break;
     default:
@@ -2293,21 +2293,21 @@ proto.xudp2p.NodeStateUpdatePacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodeStateUpdatePacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
 /**
  * repeated Address addresses = 2;
- * @return {!Array<!proto.xudp2p.Address>}
+ * @return {!Array.<!proto.xudp2p.Address>}
  */
 proto.xudp2p.NodeStateUpdatePacket.prototype.getAddressesList = function() {
-  return /** @type{!Array<!proto.xudp2p.Address>} */ (
+  return /** @type{!Array.<!proto.xudp2p.Address>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.xudp2p.Address, 2));
 };
 
 
-/** @param {!Array<!proto.xudp2p.Address>} value */
+/** @param {!Array.<!proto.xudp2p.Address>} value */
 proto.xudp2p.NodeStateUpdatePacket.prototype.setAddressesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
@@ -2330,21 +2330,21 @@ proto.xudp2p.NodeStateUpdatePacket.prototype.clearAddressesList = function() {
 
 /**
  * repeated string pairs = 3;
- * @return {!Array<string>}
+ * @return {!Array.<string>}
  */
 proto.xudp2p.NodeStateUpdatePacket.prototype.getPairsList = function() {
-  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 3));
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 3));
 };
 
 
-/** @param {!Array<string>} value */
+/** @param {!Array.<string>} value */
 proto.xudp2p.NodeStateUpdatePacket.prototype.setPairsList = function(value) {
   jspb.Message.setField(this, 3, value || []);
 };
 
 
 /**
- * @param {string} value
+ * @param {!string} value
  * @param {number=} opt_index
  */
 proto.xudp2p.NodeStateUpdatePacket.prototype.addPairs = function(value, opt_index) {
@@ -2368,7 +2368,7 @@ proto.xudp2p.NodeStateUpdatePacket.prototype.getRaidenAddress = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodeStateUpdatePacket.prototype.setRaidenAddress = function(value) {
-  jspb.Message.setProto3StringField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -2578,7 +2578,7 @@ proto.xudp2p.SessionInitPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionInitPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -2593,7 +2593,7 @@ proto.xudp2p.SessionInitPacket.prototype.getSign = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionInitPacket.prototype.setSign = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -2608,7 +2608,7 @@ proto.xudp2p.SessionInitPacket.prototype.getPeerPubKey = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionInitPacket.prototype.setPeerPubKey = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -2623,7 +2623,7 @@ proto.xudp2p.SessionInitPacket.prototype.getEphemeralPubKey = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionInitPacket.prototype.setEphemeralPubKey = function(value) {
-  jspb.Message.setProto3StringField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -2650,7 +2650,7 @@ proto.xudp2p.SessionInitPacket.prototype.clearNodeState = function() {
 
 /**
  * Returns whether this field is set.
- * @return {boolean}
+ * @return {!boolean}
  */
 proto.xudp2p.SessionInitPacket.prototype.hasNodeState = function() {
   return jspb.Message.getField(this, 5) != null;
@@ -2819,7 +2819,7 @@ proto.xudp2p.SessionAckPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionAckPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -2834,7 +2834,7 @@ proto.xudp2p.SessionAckPacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionAckPacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -2849,7 +2849,7 @@ proto.xudp2p.SessionAckPacket.prototype.getEphemeralPubKey = function() {
 
 /** @param {string} value */
 proto.xudp2p.SessionAckPacket.prototype.setEphemeralPubKey = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -3015,7 +3015,7 @@ proto.xudp2p.DisconnectingPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.DisconnectingPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -3030,7 +3030,7 @@ proto.xudp2p.DisconnectingPacket.prototype.getReason = function() {
 
 /** @param {number} value */
 proto.xudp2p.DisconnectingPacket.prototype.setReason = function(value) {
-  jspb.Message.setProto3IntField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -3045,7 +3045,7 @@ proto.xudp2p.DisconnectingPacket.prototype.getPayload = function() {
 
 /** @param {string} value */
 proto.xudp2p.DisconnectingPacket.prototype.setPayload = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -3187,7 +3187,7 @@ proto.xudp2p.GetNodesPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.GetNodesPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -3363,7 +3363,7 @@ proto.xudp2p.NodesPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodesPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -3378,21 +3378,21 @@ proto.xudp2p.NodesPacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.NodesPacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
 /**
  * repeated Node nodes = 3;
- * @return {!Array<!proto.xudp2p.Node>}
+ * @return {!Array.<!proto.xudp2p.Node>}
  */
 proto.xudp2p.NodesPacket.prototype.getNodesList = function() {
-  return /** @type{!Array<!proto.xudp2p.Node>} */ (
+  return /** @type{!Array.<!proto.xudp2p.Node>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.xudp2p.Node, 3));
 };
 
 
-/** @param {!Array<!proto.xudp2p.Node>} value */
+/** @param {!Array.<!proto.xudp2p.Node>} value */
 proto.xudp2p.NodesPacket.prototype.setNodesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
@@ -3461,7 +3461,7 @@ proto.xudp2p.SwapRequestPacket.prototype.toObject = function(opt_includeInstance
 proto.xudp2p.SwapRequestPacket.toObject = function(includeInstance, msg) {
   var f, obj = {
     id: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    proposedQuantity: +jspb.Message.getFieldWithDefault(msg, 2, 0.0),
+    proposedQuantity: jspb.Message.getFieldWithDefault(msg, 2, 0),
     pairId: jspb.Message.getFieldWithDefault(msg, 3, ""),
     orderId: jspb.Message.getFieldWithDefault(msg, 4, ""),
     rHash: jspb.Message.getFieldWithDefault(msg, 5, ""),
@@ -3507,7 +3507,7 @@ proto.xudp2p.SwapRequestPacket.deserializeBinaryFromReader = function(msg, reade
       msg.setId(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readDouble());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setProposedQuantity(value);
       break;
     case 3:
@@ -3563,8 +3563,8 @@ proto.xudp2p.SwapRequestPacket.serializeBinaryToWriter = function(message, write
     );
   }
   f = message.getProposedQuantity();
-  if (f !== 0.0) {
-    writer.writeDouble(
+  if (f !== 0) {
+    writer.writeUint64(
       2,
       f
     );
@@ -3611,22 +3611,22 @@ proto.xudp2p.SwapRequestPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapRequestPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
 /**
- * optional double proposed_quantity = 2;
+ * optional uint64 proposed_quantity = 2;
  * @return {number}
  */
 proto.xudp2p.SwapRequestPacket.prototype.getProposedQuantity = function() {
-  return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 2, 0.0));
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
 
 /** @param {number} value */
 proto.xudp2p.SwapRequestPacket.prototype.setProposedQuantity = function(value) {
-  jspb.Message.setProto3FloatField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -3641,7 +3641,7 @@ proto.xudp2p.SwapRequestPacket.prototype.getPairId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapRequestPacket.prototype.setPairId = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -3656,7 +3656,7 @@ proto.xudp2p.SwapRequestPacket.prototype.getOrderId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapRequestPacket.prototype.setOrderId = function(value) {
-  jspb.Message.setProto3StringField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -3671,7 +3671,7 @@ proto.xudp2p.SwapRequestPacket.prototype.getRHash = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapRequestPacket.prototype.setRHash = function(value) {
-  jspb.Message.setProto3StringField(this, 5, value);
+  jspb.Message.setField(this, 5, value);
 };
 
 
@@ -3686,7 +3686,7 @@ proto.xudp2p.SwapRequestPacket.prototype.getTakerCltvDelta = function() {
 
 /** @param {number} value */
 proto.xudp2p.SwapRequestPacket.prototype.setTakerCltvDelta = function(value) {
-  jspb.Message.setProto3IntField(this, 6, value);
+  jspb.Message.setField(this, 6, value);
 };
 
 
@@ -3876,7 +3876,7 @@ proto.xudp2p.SwapAcceptedPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapAcceptedPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -3891,7 +3891,7 @@ proto.xudp2p.SwapAcceptedPacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapAcceptedPacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -3906,7 +3906,7 @@ proto.xudp2p.SwapAcceptedPacket.prototype.getRHash = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapAcceptedPacket.prototype.setRHash = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -3921,7 +3921,7 @@ proto.xudp2p.SwapAcceptedPacket.prototype.getQuantity = function() {
 
 /** @param {number} value */
 proto.xudp2p.SwapAcceptedPacket.prototype.setQuantity = function(value) {
-  jspb.Message.setProto3FloatField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -3936,7 +3936,7 @@ proto.xudp2p.SwapAcceptedPacket.prototype.getMakerCltvDelta = function() {
 
 /** @param {number} value */
 proto.xudp2p.SwapAcceptedPacket.prototype.setMakerCltvDelta = function(value) {
-  jspb.Message.setProto3IntField(this, 5, value);
+  jspb.Message.setField(this, 5, value);
 };
 
 
@@ -4102,7 +4102,7 @@ proto.xudp2p.SwapCompletePacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapCompletePacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -4117,7 +4117,7 @@ proto.xudp2p.SwapCompletePacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapCompletePacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -4132,7 +4132,7 @@ proto.xudp2p.SwapCompletePacket.prototype.getRHash = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapCompletePacket.prototype.setRHash = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -4322,7 +4322,7 @@ proto.xudp2p.SwapFailedPacket.prototype.getId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapFailedPacket.prototype.setId = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+  jspb.Message.setField(this, 1, value);
 };
 
 
@@ -4337,7 +4337,7 @@ proto.xudp2p.SwapFailedPacket.prototype.getReqId = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapFailedPacket.prototype.setReqId = function(value) {
-  jspb.Message.setProto3StringField(this, 2, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -4352,7 +4352,7 @@ proto.xudp2p.SwapFailedPacket.prototype.getRHash = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapFailedPacket.prototype.setRHash = function(value) {
-  jspb.Message.setProto3StringField(this, 3, value);
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -4367,7 +4367,7 @@ proto.xudp2p.SwapFailedPacket.prototype.getErrorMessage = function() {
 
 /** @param {string} value */
 proto.xudp2p.SwapFailedPacket.prototype.setErrorMessage = function(value) {
-  jspb.Message.setProto3StringField(this, 4, value);
+  jspb.Message.setField(this, 4, value);
 };
 
 
@@ -4382,7 +4382,7 @@ proto.xudp2p.SwapFailedPacket.prototype.getFailureReason = function() {
 
 /** @param {number} value */
 proto.xudp2p.SwapFailedPacket.prototype.setFailureReason = function(value) {
-  jspb.Message.setProto3IntField(this, 5, value);
+  jspb.Message.setField(this, 5, value);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "nodemon:watch:inspect": "nodemon --inspect-brk --watch dist -e js dist/Xud.js",
     "prepublishOnly": "npm run compile",
     "proto": "cross-os proto && cross-os swagger && cross-os protodocs && cross-os protoFixDeprecation",
-    "proto:p2p": "cross-os proto:p2p",
     "start": "node dist/Xud.js",
     "stop": "cross-os stop",
     "test": "npm run test:unit && npm run test:crypto && npm run test:int && npm run test:p2p",
@@ -57,12 +56,7 @@
     "proto": {
       "linux": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/.bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",
       "darwin": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/.bin/protoc-gen-ts' -I='proto' proto/*.proto proto/google/api/*.proto proto/google/protobuf/*.proto",
-      "win32": "node_modules\\grpc-tools\\bin\\protoc --js_out=\"import_style=commonjs,binary:lib\\proto\" --ts_out=\"lib\\proto\" --grpc_out=\"lib\\proto\" --plugin=\"protoc-gen-grpc=node_modules\\.bin\\grpc_tools_node_protoc_plugin.cmd\" --plugin=\"protoc-gen-ts=node_modules\\.bin\\protoc-gen-ts.cmd\" -I=\"proto\" proto\\xudrpc.proto proto\\hash_resolver.proto proto\\lndrpc.proto proto\\annotations.proto proto\\google\\api\\http.proto proto\\google\\protobuf\\descriptor.proto"
-    },
-    "proto:p2p": {
-      "linux": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/.bin/protoc-gen-ts' -I='proto' proto/xudp2p.proto",
-      "darwin": "./node_modules/grpc-tools/bin/protoc --js_out='import_style=commonjs,binary:lib/proto' --ts_out='lib/proto' --grpc_out='lib/proto' --plugin='protoc-gen-grpc=node_modules/.bin/grpc_tools_node_protoc_plugin' --plugin='protoc-gen-ts=node_modules/.bin/protoc-gen-ts' -I='proto' proto/xudp2p.proto",
-      "win32": "node_modules\\grpc-tools\\bin\\protoc --js_out=\"import_style=commonjs,binary:lib\\proto\" --ts_out=\"lib\\proto\" --grpc_out=\"lib\\proto\" --plugin=\"protoc-gen-grpc=node_modules\\.bin\\grpc_tools_node_protoc_plugin.cmd\" --plugin=\"protoc-gen-ts=node_modules\\.bin\\protoc-gen-ts.cmd\" -I=\"proto\" proto\\xudp2p.proto"
+      "win32": "node_modules\\grpc-tools\\bin\\protoc --js_out=\"import_style=commonjs,binary:lib\\proto\" --ts_out=\"lib\\proto\" --grpc_out=\"lib\\proto\" --plugin=\"protoc-gen-grpc=node_modules\\.bin\\grpc_tools_node_protoc_plugin.cmd\" --plugin=\"protoc-gen-ts=node_modules\\.bin\\protoc-gen-ts.cmd\" -I=\"proto\" proto\\xudrpc.proto proto\\xudp2p.proto proto\\hash_resolver.proto proto\\lndrpc.proto proto\\annotations.proto proto\\google\\api\\http.proto proto\\google\\protobuf\\descriptor.proto"
     },
     "swagger": {
       "linux": "./node_modules/grpc-tools/bin/protoc --swagger_out='lib/proto' -I='proto' proto/xudrpc.proto",


### PR DESCRIPTION
This is the result of running the `proto` npm script, which brings the p2p protobuf files up to date with the changes introduced in #869. It also removes the `proto:p2p` npm script and modifies the `proto` script for windows to generate the `p2p` protobufs. In Linux & Mac, the `proto` script already generated the `p2p` protobufs, so this adds consistency between platforms.

I had overlooked generating the p2p proto files and I'm hoping that combining the two into a single script that only needs to be run once will make that less likely to happen in the future.