### PR TITLE
feat(p2p): blacklist and whitelist

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -68,6 +68,8 @@ class Config {
       detectexternalip: false,
       port: 8885, // X = 88, U = 85 in ASCII
       addresses: [],
+      blacklist: [],
+      whitelist: [],
     };
     this.rpc = {
       disable: false,

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -49,4 +49,15 @@ export type PoolConfig = {
    * It will be advertised with peers for them to try to connect to the server in the future.
    */
   addresses: string[];
+
+  /**
+   * An array of IP addresses or host names which can be used as a whitelist to limit connecting peers.
+   * Is will bypass all peers when it is empty.
+   */
+  whitelist: string[];
+
+  /**
+   * An array of IP addresses or host names which can be used as a blacklist to limit connecting peers.
+   */
+  blacklist: string[];
 };


### PR DESCRIPTION
This commit add a feature to block incoming connections according to the blacklist or whitelist IP addresses.

The following topics needs to be discussed

- [ ] Persistence for such blacklist or whitelist
- [ ] Add IP addresses into blacklist or whitelist dynamically through RPC calls
- [ ] Enhance `xucli ban <pubkey>` with `xucli ban <ip>` and persist that IP address in blacklist.

Resolve #458
Resolve #179