### PR TITLE
refactor: NodeStateUpdate to include all fields

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -178,7 +178,7 @@ class Xud extends EventEmitter {
     }
     this.raidenClient.on('connectionVerified', (newAddress) => {
       if (newAddress) {
-        this.pool.updateNodeState({ raidenAddress: newAddress });
+        this.pool.updateRaidenAddress(newAddress);
       }
     });
   }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -195,7 +195,7 @@ class OrderBook extends EventEmitter {
     this.tradingPairs.set(pairInstance.id, new TradingPair(this.logger, pairInstance.id, this.nomatching));
 
     if (this.pool) {
-      this.pool.updateNodeState({ pairs: this.pairIds });
+      this.pool.updatePairs(this.pairIds);
     }
     return pairInstance;
   }
@@ -236,7 +236,7 @@ class OrderBook extends EventEmitter {
     this.tradingPairs.delete(pairId);
 
     if (this.pool) {
-      this.pool.updateNodeState({ pairs: this.pairIds });
+      this.pool.updatePairs(this.pairIds);
     }
     return pair.destroy();
   }

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -841,17 +841,15 @@ class Peer extends EventEmitter {
     const nodeStateUpdate = packet.body!;
     this.logger.verbose(`received node state update packet from ${this.label}: ${JSON.stringify(nodeStateUpdate)}`);
 
-    const prevNodeState = this.nodeState;
-    if (prevNodeState) {
-      prevNodeState.pairs.forEach((pairId) => {
-        if (!nodeStateUpdate.pairs || !nodeStateUpdate.pairs.includes(pairId)) {
-          // a trading pair was in the old node state but not in the updated one
-          this.emit('pairDropped', pairId);
-        }
-      });
-    }
+    const prevNodeState = this.nodeState!;
+    prevNodeState.pairs.forEach((pairId) => {
+      if (!nodeStateUpdate.pairs.includes(pairId)) {
+        // a trading pair was in the old node state but not in the updated one
+        this.emit('pairDropped', pairId);
+      }
+    });
 
-    this.nodeState = { ...prevNodeState, ...nodeStateUpdate as NodeState };
+    this.nodeState = { ...nodeStateUpdate, nodePubKey: prevNodeState.nodePubKey, version: prevNodeState.version };
     this.emit('nodeStateUpdate');
   }
 

--- a/lib/p2p/packets/types/SessionInitPacket.ts
+++ b/lib/p2p/packets/types/SessionInitPacket.ts
@@ -56,8 +56,8 @@ class SessionInitPacket extends Packet<SessionInitPacketBody> {
           nodePubKey: obj.nodeState!.nodePubKey,
           pairs: obj.nodeState!.pairsList,
           addresses: obj.nodeState!.addressesList,
-          raidenAddress: obj.nodeState!.raidenAddress || undefined,
-          lndPubKeys: obj.nodeState!.lndPubKeysMap ? convertKvpArrayToKvps(obj.nodeState!.lndPubKeysMap) : undefined,
+          raidenAddress: obj.nodeState!.raidenAddress,
+          lndPubKeys: convertKvpArrayToKvps(obj.nodeState!.lndPubKeysMap),
         }),
       },
     });
@@ -74,13 +74,13 @@ class SessionInitPacket extends Packet<SessionInitPacketBody> {
       pbNodeState.setVersion(this.body!.nodeState.version);
       pbNodeState.setNodePubKey(this.body!.nodeState.nodePubKey);
       pbNodeState.setPairsList(this.body!.nodeState.pairs);
-      pbNodeState.setAddressesList(this.body!.nodeState.addresses!.map((addr) => {
+      pbNodeState.setAddressesList(this.body!.nodeState.addresses.map((addr) => {
         const pbAddr = new pb.Address();
         pbAddr.setHost(addr.host);
         pbAddr.setPort(addr.port);
         return pbAddr;
       }));
-      pbNodeState.setRaidenAddress(this.body!.nodeState.raidenAddress!);
+      pbNodeState.setRaidenAddress(this.body!.nodeState.raidenAddress);
       if (this.body!.nodeState.lndPubKeys) {
         setObjectToMap(this.body!.nodeState.lndPubKeys, pbNodeState.getLndPubKeysMap());
       }

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -15,18 +15,13 @@ export type NodeConnectionInfo = {
 export type NodeState = {
   version: string;
   nodePubKey: string;
-  addresses?: Address[];
+  addresses: Address[];
   pairs: string[];
-  raidenAddress?: string;
+  raidenAddress: string;
   lndPubKeys: { [currency: string]: string | undefined };
 };
 
-export type NodeStateUpdate = {
-  addresses?: Address[];
-  pairs?: string[];
-  raidenAddress?: string;
-  lndPubKeys?: { [currency: string]: string | undefined };
-};
+export type NodeStateUpdate = Pick<NodeState, Exclude<keyof NodeState, 'version' | 'nodePubKey'>>;
 
 export type PoolConfig = {
   /** Whether or not to automatically detect and share current external ip address on startup. */

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -74,7 +74,7 @@ type ChannelEvent = {
 class RaidenClient extends BaseClient {
   public readonly type = SwapClient.Raiden;
   public readonly cltvDelta: number = 0;
-  public address?: string;
+  public address = '';
   private port: number;
   private host: string;
 
@@ -160,7 +160,7 @@ class RaidenClient extends BaseClient {
     } else {
       try {
         channels = (await this.getChannels()).length;
-        address = this.address!;
+        address = this.address;
       } catch (err) {
         error = err.message;
       }

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -58,6 +58,7 @@ describe('P2P Pool Tests', async () => {
       version: 'test',
       pairs: [],
       lndPubKeys: {},
+      raidenAddress: '',
     }, nodeKeyOne);
   });
 

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -73,6 +73,17 @@ describe('P2P Sanity Tests', () => {
     expect(listPeersResult[0].nodePubKey).to.equal(nodeTwo.nodePubKey);
   });
 
+  it('should update the node state', (done) => {
+    const raidenAddress = '0xbb9bc244d798123fde783fcc1c72d3bb8c189413';
+    const nodeTwoPeer = nodeOne['pool'].getPeer(nodeTwo.nodePubKey);
+    nodeTwoPeer.on('nodeStateUpdate', () => {
+      expect(nodeTwoPeer['nodeState']!.raidenAddress).to.equal(raidenAddress);
+      done();
+    });
+
+    nodeTwo['pool'].updateRaidenAddress(raidenAddress);
+  });
+
   it('should fail connecting to the same node', async () => {
     await expect(nodeOne.service.connect({ nodeUri: nodeTwoUri, retryConnecting: false }))
       .to.be.rejectedWith('already connected');

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -214,7 +214,6 @@ describe('Parser', () => {
     testValidPacket(new packets.SessionInitPacket(sessionInitPacketBody));
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: { ...nodeState, pairs: [] } }));
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: { ...nodeState, addresses: [] } }));
-    testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, raidenAddress: undefined }) }));
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, lndPubKeys: { ...nodeState.lndPubKeys, BTC: undefined } }) }));
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, lndPubKeys: { ...nodeState.lndPubKeys, LTC: undefined } }) }));
     testInvalidPacket(new packets.SessionInitPacket(sessionInitPacketBody, uuid()));
@@ -234,7 +233,6 @@ describe('Parser', () => {
     testValidPacket(new packets.NodeStateUpdatePacket(nodeStateUpdate));
     testValidPacket(new packets.NodeStateUpdatePacket({ ...nodeStateUpdate, pairs: [] }));
     testValidPacket(new packets.NodeStateUpdatePacket({ ...nodeStateUpdate, addresses: [] }));
-    testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeStateUpdate, raidenAddress: undefined })));
     testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeStateUpdate, lndPubKeys: { ...nodeStateUpdate.lndPubKeys, BTC: undefined } })));
     testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeStateUpdate, lndPubKeys: { ...nodeStateUpdate.lndPubKeys, LTC: undefined } })));
     testInvalidPacket(new packets.NodeStateUpdatePacket(nodeStateUpdate, uuid()));


### PR DESCRIPTION
This PR refactors the `NodeStateUpdate` type and the logic around it to include all the fields from the `NodeState` type except those which should not change, namely `version` and `nodePubKey`. This is a follow-up to the fix in #876.