### PR TITLE
fix(lndclient): set status disabled when disabled

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -79,6 +79,7 @@ class LndClient extends BaseClient {
       shouldDisable = true;
     }
     if (shouldDisable) {
+      this.setStatus(ClientStatus.Disabled);
       return;
     }
 


### PR DESCRIPTION
This fixes an oversight where we were leaving the `ClientStatus` for lnd as not initialized when it's actually disabled.