### PR TITLE
chore: disable current v12 node travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "node"
   - "lts/*"
 
 cache:


### PR DESCRIPTION
This disables the travis build for the current Node.js version (12.0.0) until all dependencies support it. See: https://github.com/grpc/grpc-node/issues/834