### PR TITLE
Readme documentation fix, xud-simulation readme addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Exchange Union Daemon (`xud`) powers [Exchange Union](https://www.exchangeun
 
 ## Install
 
-If you already have [Node.js](https://nodejs.org/en/download/) installed, you can install `xud` via npm by running
+If you already have [Node.js](https://nodejs.org/en/download/) (min 10.15.3) installed, you can install `xud` via npm by running
 
 ```bash
 sudo npm install xud -g --unsafe-perm
@@ -45,9 +45,9 @@ You can find more information on how to use `xud` in the wiki at [Running xud](h
 
 Note: If you installed `xud` globally via npm, you can run `xud` and `xucli` from anywhere. Otherwise you must run them from the `bin` folder.
 
-## Code Documentation
+## Documentation
 
-Read the [TypeDoc here](https://exchangeunion.github.io/xud-typedoc/).
+Read the `xud` API documentation [here](http://api.exchangeunion.com) and code documentation [here](http://typedoc.exchangeunion.com/).
 
 ## License
 

--- a/test/simulation/README.md
+++ b/test/simulation/README.md
@@ -38,7 +38,7 @@ $ GO111MODULE=on go test -v
 - [ ] Peer disconnection should trigger orders removal to all his orders.
 
 ### Node State
-- [ ] Removed pair or swap client (lnd/raiden) unavailable should trigger order removal for all the pair's orders, and removed from connected peers' order books.
+- [ ] Removed pair or swap client (lnd/raiden) disconnected (after timeout elapsed) should trigger order removal for all the pair's orders, and removed from connected peers' order books.
 - [ ] Updated `LND-BTC`/`LND-LTC` public keys should propagate over the network.
 
 ### Swaps

--- a/test/simulation/README.md
+++ b/test/simulation/README.md
@@ -38,7 +38,7 @@ $ GO111MODULE=on go test -v
 - [ ] Peer disconnection should trigger orders removal to all his orders.
 
 ### Node State
-- [ ] Removed pair should trigger order removal for all the pair's orders, and removed from connected peers' order books.
+- [ ] Removed pair or swap client (lnd/raiden) unavailable should trigger order removal for all the pair's orders, and removed from connected peers' order books.
 - [ ] Updated `LND-BTC`/`LND-LTC` public keys should propagate over the network.
 
 ### Swaps


### PR DESCRIPTION
`xud` Readme documentation fix:
* added slate
* updated typedoc link
* added node min version

`xud-simulation` readme fix:
* added `swap client (lnd/raiden) disconnected` case for order invalidation on network