### PR TITLE
chore: incremental builds & typescript 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ typings/
 
 # Typescript compilation output
 dist/
+.tsbuildinfo
 
 # Optional npm cache directory
 .npm

--- a/lib/p2p/packets/types/SwapFailedPacket.ts
+++ b/lib/p2p/packets/types/SwapFailedPacket.ts
@@ -59,7 +59,7 @@ class SwapFailedPacket extends Packet<SwapFailedPacketBody> {
     msg.setReqId(this.header.reqId!);
     msg.setRHash(this.body!.rHash);
     if (this.body!.errorMessage) {
-      msg.setErrorMessage(this.body!.errorMessage!);
+      msg.setErrorMessage(this.body!.errorMessage);
     }
     msg.setFailureReason(this.body!.failureReason);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,9 +345,9 @@
       }
     },
     "@types/fs-extra": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
-      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
+      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -391,10 +391,13 @@
       }
     },
     "@types/handlebars": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
-      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "*"
+      }
     },
     "@types/highlight.js": {
       "version": "9.12.3",
@@ -488,9 +491,9 @@
       }
     },
     "@types/shelljs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
-      "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==",
       "dev": true,
       "requires": {
         "@types/glob": "*",
@@ -3387,9 +3390,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -4386,7 +4389,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -4490,7 +4493,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -4511,7 +4514,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
@@ -4580,7 +4583,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -4724,7 +4727,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4734,7 +4737,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -4742,7 +4745,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7952,9 +7955,9 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "protobufjs": {
@@ -8719,9 +8722,9 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -9704,9 +9707,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedoc": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.13.0.tgz",
-      "integrity": "sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
+      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^5.0.3",
@@ -9718,20 +9721,26 @@
         "@types/shelljs": "^0.8.0",
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
-        "highlight.js": "^9.0.0",
+        "highlight.js": "^9.13.1",
         "lodash": "^4.17.10",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",
         "shelljs": "^0.8.2",
         "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.1.x"
+        "typescript": "3.2.x"
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.117",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-          "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==",
+          "version": "4.14.123",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+          "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
           "dev": true
         }
       }
@@ -9763,9 +9772,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "config": "gulp config.create",
-    "compile": "cross-os precompile && tsc && cross-os postcompile",
+    "compile": "tsc && cross-os postcompile",
     "compile:watch": "tsc -w",
     "dev": "npm run compile && npm start",
     "dev:watch": "concurrently --kill-others \"npm run compile:watch\" \"npm run nodemon:watch\"",
@@ -42,11 +42,6 @@
       "linux": "rsync -am --include '*/' --include '*.js*' --exclude '*' lib/proto/ dist/proto",
       "darwin": "rsync -am --include '*/' --include '*.js*' --exclude '*' lib/proto/ dist/proto",
       "win32": "xcopy /s lib\\proto\\*.js* dist\\proto\\* >nul"
-    },
-    "precompile": {
-      "linux": "rm -rf ./dist",
-      "darwin": "rm -rf ./dist",
-      "win32": "rd /q /s dist || cd ."
     },
     "protoFixDeprecation": {
       "linux": "sed -i -- 's/new Buffer(/Buffer.from(/g' lib/proto/*.js",
@@ -175,8 +170,8 @@
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.10.0",
     "tslint-no-circular-imports": "^0.5.0",
-    "typedoc": "^0.13.0",
-    "typescript": "^3.1.6"
+    "typedoc": "^0.14.2",
+    "typescript": "^3.4.5"
   },
   "engines": {
     "node": ">=10.2.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
     "noEmitOnError": false,
     "lib": ["dom","ES2017"],
     "declaration": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
 
     /* Additional Checks */
     "noUnusedLocals": false,                  /* Report errors on unused locals. */


### PR DESCRIPTION
This upgrades typescript to 3.4 to use its incremental build feature. This will speed up build times both locally and on travis by caching the dist directory and .tsbuildinfo file which is necessary for incremental compilation. It also makes the precompile script which deleted the dist folder obsolete.