### PR TITLE
fix: switch swap capacity check currency

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -332,16 +332,15 @@ class OrderBook extends EventEmitter {
       };
     }
 
-    if (!this.nosanitychecks) {
+    if (!this.nosanitychecks && this.swaps) {
       // check if sufficient outbound channel capacity exists
-      const { makerAmount } = Swaps.calculateSwapAmounts(order.quantity, order.price, order.isBuy, order.pairId);
-      const { makerCurrency } = Swaps.deriveCurrencies(order.pairId, order.isBuy);
-      const swapClient = this.swaps && this.swaps.swapClients.get(makerCurrency);
+      const { outboundCurrency, outboundAmount } = Swaps.calculateInboundOutboundAmounts(order.quantity, order.price, order.isBuy, order.pairId);
+      const swapClient = this.swaps.swapClients.get(outboundCurrency);
       if (!swapClient) {
-        throw errors.SWAP_CLIENT_NOT_FOUND(makerCurrency);
+        throw errors.SWAP_CLIENT_NOT_FOUND(outboundCurrency);
       }
-      if (makerAmount > swapClient.maximumOutboundCapacity) {
-        throw errors.INSUFFICIENT_OUTBOUND_BALANCE(makerCurrency, makerAmount, swapClient.maximumOutboundCapacity);
+      if (outboundAmount > swapClient.maximumOutboundCapacity) {
+        throw errors.INSUFFICIENT_OUTBOUND_BALANCE(outboundCurrency, outboundAmount, swapClient.maximumOutboundCapacity);
       }
     }
 

--- a/test/simulation/tests.go
+++ b/test/simulation/tests.go
@@ -158,8 +158,8 @@ func testOrderBroadcastAndInvalidation(net *xudtest.NetworkHarness, ht *harnessT
 	ht.act.verifyConnectivity(net.Alice, net.Bob)
 
 	req := &xudrpc.PlaceOrderRequest{
-		Price:    10,
-		Quantity: 100000000,
+		Price:    0.02,
+		Quantity: 10000000,
 		PairId:   "LTC/BTC",
 		OrderId:  "random_order_id",
 		Side:     xudrpc.OrderSide_BUY,
@@ -180,7 +180,7 @@ func testOrderMatchingAndSwap(net *xudtest.NetworkHarness, ht *harnessTest) {
 	// Place an order on Alice.
 	req := &xudrpc.PlaceOrderRequest{
 		OrderId:  "maker_order_id",
-		Price:    10,
+		Price:    0.02,
 		Quantity: 10000000,
 		PairId:   "LTC/BTC",
 		Side:     xudrpc.OrderSide_BUY,

--- a/test/unit/Swaps.spec.ts
+++ b/test/unit/Swaps.spec.ts
@@ -54,6 +54,14 @@ describe('Swaps', () => {
     makerAmount: buyDeal.takerAmount,
   };
 
+  const buyOrder = {
+    quantity,
+    price,
+    pairId,
+    isBuy: true,
+  };
+  const sellOrder = { ...buyOrder, isBuy: false };
+
   const swapRequest: SwapRequestPacketBody = {
     takerCltvDelta,
     orderId,
@@ -62,40 +70,52 @@ describe('Swaps', () => {
     pairId: 'LTC/BTC',
   };
 
-  it('should derive currencies for a buy order', () => {
-    const { makerCurrency, takerCurrency } = Swaps['deriveCurrencies'](buyDeal.pairId, buyDeal.isBuy);
-    expect(makerCurrency).to.equal(buyDeal.makerCurrency);
-    expect(takerCurrency).to.equal(buyDeal.takerCurrency);
-  });
-
-  it('should derive currencies for a sell order', () => {
-    const { makerCurrency, takerCurrency } = Swaps['deriveCurrencies'](sellDeal.pairId, sellDeal.isBuy);
-    expect(makerCurrency).to.equal(sellDeal.makerCurrency);
-    expect(takerCurrency).to.equal(sellDeal.takerCurrency);
-  });
-
-  it('should calculate swap amounts for a buy order', () => {
-    const { makerAmount, takerAmount } = Swaps['calculateSwapAmounts'](
+  it('should calculate swap amounts and currencies for a buy order', () => {
+    const { makerCurrency, makerAmount, takerCurrency, takerAmount } = Swaps['calculateMakerTakerAmounts'](
       buyDeal.quantity!, buyDeal.price, buyDeal.isBuy, buyDeal.pairId,
     );
     expect(makerAmount).to.equal(buyDeal.makerAmount);
     expect(takerAmount).to.equal(buyDeal.takerAmount);
+    expect(makerCurrency).to.equal(buyDeal.makerCurrency);
+    expect(takerCurrency).to.equal(buyDeal.takerCurrency);
   });
 
-  it('should calculate swap amounts for a sell order', () => {
-    const { makerAmount, takerAmount } = Swaps['calculateSwapAmounts'](
+  it('should calculate swap amounts and currencies for a sell order', () => {
+    const { makerCurrency, makerAmount, takerCurrency, takerAmount } = Swaps['calculateMakerTakerAmounts'](
       sellDeal.quantity!, sellDeal.price, sellDeal.isBuy, sellDeal.pairId,
     );
     expect(makerAmount).to.equal(sellDeal.makerAmount);
     expect(takerAmount).to.equal(sellDeal.takerAmount);
+    expect(makerCurrency).to.equal(sellDeal.makerCurrency);
+    expect(takerCurrency).to.equal(sellDeal.takerCurrency);
   });
 
-  it('should calculate swap amounts for a WETH buy order', () => {
-    const { makerAmount, takerAmount } = Swaps['calculateSwapAmounts'](
+  it('should calculate swap amounts and currencies for a WETH buy order', () => {
+    const { makerCurrency, makerAmount, takerCurrency, takerAmount } = Swaps['calculateMakerTakerAmounts'](
       buyDealEth.quantity!, buyDealEth.price, buyDealEth.isBuy, buyDealEth.pairId,
     );
     expect(makerAmount).to.equal(buyDealEth.makerAmount);
     expect(takerAmount).to.equal(buyDealEth.takerAmount);
+    expect(makerCurrency).to.equal(buyDealEth.makerCurrency);
+    expect(takerCurrency).to.equal(buyDealEth.takerCurrency);
+  });
+
+  it('should calculate inbound and outbound amounts and currencies for a buy order', () => {
+    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount } =
+      Swaps.calculateInboundOutboundAmounts(quantity, price, true, pairId);
+    expect(inboundCurrency).to.equal('LTC');
+    expect(inboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity);
+    expect(outboundCurrency).to.equal('BTC');
+    expect(outboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity * price);
+  });
+
+  it('should calculate inbound and outbound amounts and currencies for a sell order', () => {
+    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount } =
+      Swaps.calculateInboundOutboundAmounts(quantity, price, false, pairId);
+    expect(inboundCurrency).to.equal('BTC');
+    expect(inboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity * price);
+    expect(outboundCurrency).to.equal('LTC');
+    expect(outboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity);
   });
 
   it(`should validate a good swap request`, () => {


### PR DESCRIPTION
This fixes a bug where the outbound capacity sanity check was comparing against the inbound currency and amount rather than outbound. In addition, this commit refactors & renames the methods used to calculate the amounts and currencies involved in a swap to minimize potential confusion. It also adds tests to detect a regression in the calculation logic.

Fixes #932.