### PR TITLE
refactor: enable noUnusedLocals tsconfig option

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -123,7 +123,7 @@ class Xud extends EventEmitter {
         raidenAddress: this.raidenClient.address,
       }, this.nodeKey);
 
-      this.service = new Service(loggers.global, {
+      this.service = new Service({
         version,
         orderBook: this.orderBook,
         lndClients: this.lndClients,

--- a/lib/cli/commands/listorders.ts
+++ b/lib/cli/commands/listorders.ts
@@ -1,6 +1,6 @@
 import { Arguments } from 'yargs';
 import { callback, loadXudClient } from '../command';
-import { ListOrdersRequest, ListOrdersResponse, Order, OrderSide } from '../../proto/xudrpc_pb';
+import { ListOrdersRequest, ListOrdersResponse, Order } from '../../proto/xudrpc_pb';
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
 import { SATOSHIS_PER_COIN } from '../utils';

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -4,7 +4,7 @@ import Logger from '../Logger';
 import Service from '../service/Service';
 import * as xudrpc from '../proto/xudrpc_pb';
 import { ResolveRequest, ResolveResponse } from '../proto/lndrpc_pb';
-import { Order, isOwnOrder, OrderPortion, PeerOrder, PlaceOrderResult, PlaceOrderEvent, PlaceOrderEventType } from '../orderbook/types';
+import { Order, isOwnOrder, OrderPortion, PlaceOrderResult, PlaceOrderEvent, PlaceOrderEventType } from '../orderbook/types';
 import { errorCodes as orderErrorCodes } from '../orderbook/errors';
 import { errorCodes as serviceErrorCodes } from '../service/errors';
 import { errorCodes as p2pErrorCodes } from '../p2p/errors';

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -81,7 +81,7 @@ class OrderBook extends EventEmitter {
     private pool?: Pool, private swaps?: Swaps, private nosanitychecks = false) {
     super();
 
-    this.repository = new OrderBookRepository(logger, models);
+    this.repository = new OrderBookRepository(models);
 
     this.bindPool();
     this.bindSwaps();

--- a/lib/orderbook/OrderBookRepository.ts
+++ b/lib/orderbook/OrderBookRepository.ts
@@ -1,11 +1,10 @@
 import * as db from '../db/types';
-import Logger from '../Logger';
 import Bluebird from 'bluebird';
 import { Models } from '../db/DB';
 
 class OrderbookRepository {
 
-  constructor(private logger: Logger, private models: Models) {}
+  constructor(private models: Models) {}
 
   public getPairs = (): Bluebird<db.PairInstance[]> => {
     return this.models.Pair.findAll();

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -4,7 +4,6 @@ import { NodeInstance, NodeFactory, ReputationEventInstance } from '../db/types'
 import { Address } from './types';
 import addressUtils from '../utils/addressUtils';
 import { ReputationEvent } from '../constants/enums';
-import Network from './Network';
 
 export const reputationEventWeight = {
   [ReputationEvent.ManualBan]: Number.NEGATIVE_INFINITY,
@@ -37,7 +36,7 @@ class NodeList extends EventEmitter {
     return this.nodes.size;
   }
 
-  constructor(private repository: P2PRepository, private network: Network) {
+  constructor(private repository: P2PRepository) {
     super();
   }
 

--- a/lib/p2p/packets/types/PongPacket.ts
+++ b/lib/p2p/packets/types/PongPacket.ts
@@ -1,7 +1,6 @@
 import Packet, { PacketDirection, ResponseType } from '../Packet';
 import PacketType from '../PacketType';
 import * as pb from '../../../proto/xudp2p_pb';
-import PingPacket from './PingPacket';
 
 class PongPacket extends Packet<undefined> {
   public get type(): PacketType {

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -99,7 +99,7 @@ class RaidenClient extends BaseClient {
     this.host = host;
     this.disable = disable;
 
-    this.repository = new OrderBookRepository(logger, models);
+    this.repository = new OrderBookRepository(models);
   }
 
   /**
@@ -118,7 +118,7 @@ class RaidenClient extends BaseClient {
   private setCurrencies = async () => {
     try {
       const currencies = await this.repository.getCurrencies();
-      const raidenCurrencies = currencies.filter((currency) => {
+      currencies.filter((currency) => {
         const tokenAddress = currency.getDataValue('tokenAddress');
         if (tokenAddress) {
           this.tokenAddresses.set(currency.getDataValue('id'), tokenAddress);
@@ -287,7 +287,7 @@ class RaidenClient extends BaseClient {
   /**
    * Queries for events tied to a specific channel.
    */
-  private getChannelEvents = async (channel_address: string) => {
+  public getChannelEvents = async (channel_address: string) => {
     // TODO: specify a "from_block"  query argument to only get events since a specific block.
     const endpoint = `events/channels/${channel_address}`;
     const res = await this.sendRequest(endpoint, 'GET');
@@ -343,7 +343,7 @@ class RaidenClient extends BaseClient {
    */
   public closeChannel = async (channel_address: string): Promise<void> => {
     const endpoint = `channels/${channel_address}`;
-    const res = await this.sendRequest(endpoint, 'PATCH', { state: 'settled' });
+    await this.sendRequest(endpoint, 'PATCH', { state: 'settled' });
   }
 
   /**
@@ -386,7 +386,7 @@ class RaidenClient extends BaseClient {
    */
   public depositToChannel = async (channel_address: string, balance: number): Promise<void> => {
     const endpoint = `channels/${channel_address}`;
-    const res = await this.sendRequest(endpoint, 'PATCH', { balance });
+    await this.sendRequest(endpoint, 'PATCH', { balance });
   }
 
   /**

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1,4 +1,3 @@
-import Logger from '../Logger';
 import Pool from '../p2p/Pool';
 import OrderBook from '../orderbook/OrderBook';
 import LndClient, { LndInfo } from '../lndclient/LndClient';
@@ -9,7 +8,7 @@ import { SwapClient, OrderSide, SwapRole } from '../constants/enums';
 import { parseUri, toUri, UriParts } from '../utils/uriUtils';
 import { sortOrders } from '../utils/utils';
 import * as lndrpc from '../proto/lndrpc_pb';
-import { Pair, Order, OrderPortion, PlaceOrderEvent } from '../orderbook/types';
+import { Order, OrderPortion, PlaceOrderEvent } from '../orderbook/types';
 import Swaps from '../swaps/Swaps';
 import { OrderSidesArrays } from '../orderbook/TradingPair';
 import { SwapSuccess, SwapFailure } from '../swaps/types';
@@ -74,7 +73,7 @@ class Service extends EventEmitter {
   private swaps: Swaps;
 
   /** Create an instance of available RPC methods and bind all exposed functions. */
-  constructor(private logger: Logger, components: ServiceComponents) {
+  constructor(components: ServiceComponents) {
     super();
 
     this.shutdown = components.shutdown;
@@ -313,7 +312,6 @@ class Service extends EventEmitter {
    * @returns A list of supported currency ticker symbols
    */
   public listCurrencies = () => {
-    const pairs = new Map<string, Pair>();
     return Array.from(this.orderBook.currencies);
   }
 

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1,4 +1,4 @@
-import { SwapPhase, SwapRole, SwapState, SwapFailureReason, ReputationEvent, SwapClient } from '../constants/enums';
+import { SwapPhase, SwapRole, SwapState, SwapFailureReason, ReputationEvent } from '../constants/enums';
 import Peer from '../p2p/Peer';
 import { Models } from '../db/DB';
 import * as packets from '../p2p/packets/types';
@@ -513,8 +513,7 @@ class Swaps extends EventEmitter {
 
     try {
       this.setDealPhase(deal, SwapPhase.SendingAmount);
-      const rPreimage = await swapClient.sendPayment(deal);
-      // TODO: check preimage from payment response vs deal.preImage
+      await swapClient.sendPayment(deal);
 
       // swap succeeded!
       this.setDealPhase(deal, SwapPhase.SwapCompleted);

--- a/test/crypto/handshake.ts
+++ b/test/crypto/handshake.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import CryptoJS from 'crypto-js';
 import secp256k1 from 'secp256k1';
 import NodeKey from '../../lib/nodekey/NodeKey';
 import { expect } from 'chai';

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -18,7 +18,7 @@ const currencies = PAIR_ID.split('/');
 const loggers = Logger.createLoggers(Level.Warn);
 
 const initValues = async (db: DB) => {
-  const orderBookRepository = new OrderBookRepository(loggers.orderbook, db.models);
+  const orderBookRepository = new OrderBookRepository(db.models);
 
   await orderBookRepository.addCurrencies([
     { id: currencies[0], swapClient: SwapClient.Lnd, decimalPlaces: 8 },

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -56,7 +56,7 @@ describe('Database', () => {
 
   before(async () => {
     await db.init();
-    orderBookRepo = new OrderBookRepository(loggers.db, db.models);
+    orderBookRepo = new OrderBookRepository(db.models);
     p2pRepo = new P2PRepository(db.models);
     swapRepo = new SwapRepository(db.models);
   });

--- a/test/unit/Swaps.spec.ts
+++ b/test/unit/Swaps.spec.ts
@@ -54,14 +54,6 @@ describe('Swaps', () => {
     makerAmount: buyDeal.takerAmount,
   };
 
-  const buyOrder = {
-    quantity,
-    price,
-    pairId,
-    isBuy: true,
-  };
-  const sellOrder = { ...buyOrder, isBuy: false };
-
   const swapRequest: SwapRequestPacketBody = {
     takerCltvDelta,
     orderId,

--- a/test/unit/uriUtils.spec.ts
+++ b/test/unit/uriUtils.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { parseUri, toUri, UriParts } from '../../lib/utils/uriUtils';
+import { parseUri } from '../../lib/utils/uriUtils';
 
 describe('parseUri', () => {
   it('should parse a valid uri', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "declaration": true,
 
     /* Additional Checks */
-    "noUnusedLocals": false,                  /* Report errors on unused locals. */
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
     "noUnusedParameters": true,               /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
 


### PR DESCRIPTION
This enables the `noUnusedLocals` option for the typescript compiler and removes examples of unused local variables that violate the rule.

I've had a couple of times where I had to uncover bugs related to unused variables in testing that may have been caught earlier by this rule, and as the code base gets more mature I think this rule makes more sense. @erkarl expressed a similar sentiment I believe.

This drops the packet count and last sent/last received variables on `Peer`. We weren't using them, and I'm not sure there's much value in those any more (especially since the plans of the using the packet count for unique identifiers is long gone). Last sent & received I don't think tells us much useful information. I was thinking about maybe exposing the `bytesReceived` & `bytesSent` fields which exist on the TCP socket object as part of the `PeerInfo` type, as that does give some useful information like how much data we have communicated with certain peers and may be useful for detecting peers that are spamming us, but that's for a separate PR.