### PR TITLE
test: use os-specific temp dir as xudir

### DIFF
--- a/test/integration/WebProxy.spec.ts
+++ b/test/integration/WebProxy.spec.ts
@@ -1,7 +1,7 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import Xud from '../../lib/Xud';
-import { getUnusedPort } from '../utils';
+import { getUnusedPort, getTempDir } from '../utils';
 
 describe('WebProxy', async () => {
   let xud: Xud;
@@ -11,6 +11,7 @@ describe('WebProxy', async () => {
 
   before(async () => {
     config = {
+      xudir: getTempDir(true),
       dbpath: ':memory:',
       initdb: false,
       webproxy: {

--- a/test/p2p/networks.spec.ts
+++ b/test/p2p/networks.spec.ts
@@ -11,8 +11,8 @@ chai.use(chaiAsPromised);
 describe('P2P Networks Tests', () => {
   function testConnectionFailure(srcNodeNetwork: XuNetwork, destNodeNetwork: XuNetwork) {
     it(`should fail to connect a node from ${srcNodeNetwork} to a node from ${destNodeNetwork}`, async () => {
-      const srcNodeConfig = createConfig(1, 0, srcNodeNetwork);
-      const destNodeConfig = createConfig(2, 0, destNodeNetwork);
+      const srcNodeConfig = createConfig(1, 0, false, srcNodeNetwork);
+      const destNodeConfig = createConfig(2, 0, false, destNodeNetwork);
       const srcNode = new Xud();
       const destNode = new Xud();
       await Promise.all([srcNode.start(srcNodeConfig), destNode.start(destNodeConfig)]);
@@ -33,8 +33,8 @@ describe('P2P Networks Tests', () => {
 
   function testConnectionSuccess(srcNodeNetwork: XuNetwork, destNodeNetwork: XuNetwork) {
     it(`should successfully connect a node from ${srcNodeNetwork} to a node from ${destNodeNetwork}`, async () => {
-      const srcNodeConfig = createConfig(1, 0, srcNodeNetwork);
-      const destNodeConfig = createConfig(2, 0, destNodeNetwork);
+      const srcNodeConfig = createConfig(1, 0, false, srcNodeNetwork);
+      const destNodeConfig = createConfig(2, 0, false, destNodeNetwork);
       const srcNode = new Xud();
       const destNode = new Xud();
       await Promise.all([srcNode.start(srcNodeConfig), destNode.start(destNodeConfig)]);

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -2,16 +2,17 @@ import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import { toUri } from '../../lib/utils/uriUtils';
-import { getUnusedPort } from '../utils';
+import { getUnusedPort, getTempDir } from '../utils';
 import { DisconnectionReason, XuNetwork } from '../../lib/constants/enums';
 import NodeKey from '../../lib/nodekey/NodeKey';
 
 chai.use(chaiAsPromised);
 
-export const createConfig = (instanceid: number, p2pPort: number, network = XuNetwork.SimNet) => ({
+export const createConfig = (instanceid: number, p2pPort: number, uniqueXudir = true, network = XuNetwork.SimNet) => ({
   instanceid,
   network,
   initdb: false,
+  xudir: getTempDir(uniqueXudir),
   dbpath: ':memory:',
   loglevel: 'error',
   logpath: '',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -47,7 +47,7 @@ export const waitForSpy = (spy: SinonSpy, property = 'called') => {
 /**
  * Creates and returns an os-specific directory for temp files.
  */
-export const getTempDir = (unique = false) => {
+export const getTempDir = (unique: boolean) => {
   let dir = path.join(os.tmpdir(), 'xud-test');
   if (unique) {
     dir = path.join(dir, uuidv1());

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,8 +1,11 @@
 import net from 'net';
 import { SinonSpy } from 'sinon';
+import uuidv1 from 'uuid';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
 import { ms } from '../lib/utils/utils';
 import { PeerOrder, OwnOrder } from '../lib/orderbook/types';
-import uuidv1 from 'uuid';
 
 /**
  * Discovers and returns a dynamically assigned, unused port available for testing.
@@ -39,6 +42,22 @@ export const waitForSpy = (spy: SinonSpy, property = 'called') => {
       reject(e);
     }
   });
+};
+
+/**
+ * Creates and returns an os-specific directory for temp files.
+ */
+export const getTempDir = (unique = false) => {
+  let dir = path.join(os.tmpdir(), 'xud-test');
+  if (unique) {
+    dir = path.join(dir, uuidv1());
+  }
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  return dir;
 };
 
 export const createOwnOrder = (price: number, quantity: number, isBuy: boolean, createdAt = ms(), pairId = 'LTC/BTC'): OwnOrder => ({


### PR DESCRIPTION
Closing #574.

Since avoid writing to disk isn't practical (it would require different code to be run for production and under test), a temp directory can be used instead.  