### PR TITLE
[WIP]: feat: track nodes that have banned us

### DIFF
--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -1,0 +1,13 @@
+import Sequelize from 'sequelize';
+
+/**
+ * An ordered array of functions that will migrate the database from one
+ * version to the next. The 1st element (index 0) will migrate from version
+ * 0 to 1, the 2nd element will migrate from version 1 to 2, and so on...
+ * Each migration must be called in order and allowed to complete before
+ * calling the next.
+ */
+const migrations: ((sequelize: Sequelize.Sequelize) => Promise<void>)[] = [];
+
+
+export default migrations;

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -9,5 +9,11 @@ import Sequelize from 'sequelize';
  */
 const migrations: ((sequelize: Sequelize.Sequelize) => Promise<void>)[] = [];
 
+migrations[0] = async (sequelize: Sequelize.Sequelize) => {
+  await sequelize.getQueryInterface().addColumn('nodes', 'bannedBy', {
+    type: Sequelize.BOOLEAN,
+    allowNull: true,
+  });
+};
 
 export default migrations;

--- a/lib/db/models/Node.ts
+++ b/lib/db/models/Node.ts
@@ -7,6 +7,7 @@ export default function Node(sequelize: Sequelize) {
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
     nodePubKey: { type: DataTypes.STRING, unique: true, allowNull: false },
     addressesText: { type: DataTypes.TEXT, allowNull: false },
+    bannedBy: { type: DataTypes.BOOLEAN, allowNull: true },
     addresses: {
       type: DataTypes.VIRTUAL,
       get(this: NodeInstance) {

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -80,6 +80,7 @@ export type NodeCreationAttributes = NodeConnectionInfo;
 export type NodeAttributes = NodeCreationAttributes & {
   id: number;
   banned: boolean;
+  bannedBy: boolean;
   addressesText: string;
   lastAddressText: string;
   lastAddress: Address;

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -559,7 +559,7 @@ class GrpcService {
       return;
     }
     try {
-      const { banned, reputationScore } = await this.service.getNodeInfo(call.request.toObject());
+      const { banned, reputationScore } = this.service.getNodeInfo(call.request.toObject());
       const response = new xudrpc.GetNodeInfoResponse();
       if (banned) {
         response.setBanned(banned);

--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -24,7 +24,7 @@ const getGrpcError = (err: any) => {
       code = status.INVALID_ARGUMENT;
       break;
     case orderErrorCodes.PAIR_DOES_NOT_EXIST:
-    case p2pErrorCodes.NODE_UNKNOWN:
+    case p2pErrorCodes.NODE_NOT_FOUND:
     case p2pErrorCodes.UNKNOWN_ALIAS:
     case orderErrorCodes.LOCAL_ID_DOES_NOT_EXIST:
     case orderErrorCodes.ORDER_NOT_FOUND:

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -25,7 +25,9 @@ export const reputationEventWeight = {
 
 interface NodeList {
   on(event: 'node.ban', listener: (nodePubKey: string, events: ReputationEvent[]) => void): this;
+  on(event: 'node.unban', listener: (nodePubKey: string) => void): this;
   emit(event: 'node.ban', nodePubKey: string, events: ReputationEvent[]): boolean;
+  emit(event: 'node.unban', nodePubKey: string): boolean;
 }
 
 /** A wrapper class with help methods that represents a list of known nodes. */
@@ -248,6 +250,7 @@ class NodeList extends EventEmitter {
         // If the reputationScore is not below the banThreshold but node.banned
         // is true that means that the node was unbanned
         promises.push(this.setBanned(node, false));
+        this.emit('node.unban', nodePubKey);
       }
 
       promises.push(this.repository.addReputationEvent({ event, nodeId: node.id }));

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -204,7 +204,7 @@ class NodeList extends EventEmitter {
         node.lastAddress = lastAddress;
       }
 
-      await node.save();
+      await this.save(node);
       return true;
     }
 
@@ -269,7 +269,7 @@ class NodeList extends EventEmitter {
       const index = node.addresses.findIndex(existingAddress => addressUtils.areEqual(address, existingAddress));
       if (index > -1) {
         node.addresses = [...node.addresses.slice(0, index), ...node.addresses.slice(index + 1)];
-        await node.save();
+        await this.save(node);
         return true;
       }
 
@@ -282,9 +282,14 @@ class NodeList extends EventEmitter {
     return false;
   }
 
+  private save = async (node: NodeInstance) => {
+    await node.save();
+    this.nodes.set(node.nodePubKey, node);
+  }
+
   private setBanned = async (node: NodeInstance, banned: boolean) => {
     node.banned = banned;
-    await node.save();
+    await this.save(node);
   }
 
   private addNode = (node: NodeInstance) => {

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -64,6 +64,26 @@ class NodeList extends EventEmitter {
   }
 
   /**
+   * Checks if we are banned by this node
+   */
+  public isBannedBy = (nodePubKey: string): boolean => {
+    return this.nodes.get(nodePubKey)?.bannedBy ?? false;
+  }
+
+  /**
+   * Adds or removes a node to the set of nodes that have banned us.
+   */
+  public setBannedBy = async (nodePubKey: string, bannedBy = true) => {
+    const node = this.nodes.get(nodePubKey);
+    if (!node) {
+      throw errors.NODE_NOT_FOUND(nodePubKey);
+    }
+    node.bannedBy = bannedBy;
+
+    await this.repository.updateBannedBy(nodePubKey, bannedBy);
+  }
+
+  /**
    * Check if a node with a given nodePubKey exists.
    */
   public has = (nodePubKey: string): boolean => {
@@ -72,6 +92,10 @@ class NodeList extends EventEmitter {
 
   public forEach = (callback: (node: NodeInstance) => void) => {
     this.nodes.forEach(callback);
+  }
+
+  public getNode(nodePubKey: string): NodeInstance | undefined {
+    return this.nodes.get(nodePubKey);
   }
 
   /**

--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -10,14 +10,6 @@ class P2PRepository {
     return this.models.Node.findAll();
   }
 
-  public getNode = async (nodePubKey: string): Promise<NodeInstance | null> => {
-    return this.models.Node.findOne({
-      where: {
-        nodePubKey,
-      },
-    });
-  }
-
   public getReputationEvents = async (node: NodeInstance): Promise<ReputationEventInstance[]> => {
     return this.models.ReputationEvent.findAll({
       where: {
@@ -50,14 +42,6 @@ class P2PRepository {
 
   public addNodes = async (nodes: NodeCreationAttributes[]) => {
     return this.models.Node.bulkCreate(<NodeAttributes[]>nodes);
-  }
-
-  public updateBannedBy = async (nodePubKey: string, bannedBy: boolean) => {
-    return this.models.Node.update({ bannedBy }, {
-      where: {
-        nodePubKey,
-      },
-    });
   }
 }
 

--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -51,6 +51,14 @@ class P2PRepository {
   public addNodes = async (nodes: NodeCreationAttributes[]) => {
     return this.models.Node.bulkCreate(<NodeAttributes[]>nodes);
   }
+
+  public updateBannedBy = async (nodePubKey: string, bannedBy: boolean) => {
+    return this.models.Node.update({ bannedBy }, {
+      where: {
+        nodePubKey,
+      },
+    });
+  }
 }
 
 export default P2PRepository;

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -53,6 +53,7 @@ interface Peer {
   /** Adds a listener to be called when a previously active pair is dropped by the peer or deactivated. */
   on(event: 'pairDropped', listener: (pairId: string) => void): this;
   on(event: 'nodeStateUpdate', listener: () => void): this;
+  on(event: 'bannedBy', listener: (nodePubKey: string) => void): this;
   once(event: 'close', listener: () => void): this;
   emit(event: 'connect'): boolean;
   emit(event: 'reputation', reputationEvent: ReputationEvent): boolean;
@@ -63,6 +64,7 @@ interface Peer {
   /** Notifies listeners that a previously active pair was dropped by the peer or deactivated. */
   emit(event: 'pairDropped', pairId: string): boolean;
   emit(event: 'nodeStateUpdate'): boolean;
+  emit(event: 'bannedBy', nodePubKey: string): boolean;
 }
 
 /** Represents a remote peer and manages a TCP socket and incoming/outgoing communication with that peer. */
@@ -1005,9 +1007,16 @@ class Peer extends EventEmitter {
   }
 
   private handleDisconnecting = (packet: packets.DisconnectingPacket): void => {
-    if (!this.recvDisconnectionReason && packet.body && packet.body.reason !== undefined) {
+    if (!this.recvDisconnectionReason && packet.body && packet.body.reason) {
       this.logger.debug(`received disconnecting packet from ${this.label} due to ${DisconnectionReason[packet.body.reason]}`);
       this.recvDisconnectionReason = packet.body.reason;
+      if (packet.body.reason === DisconnectionReason.Banned) {
+        // if we are banned by the peer set `bannedBy` in DB.
+        const nodePubKey = this._nodePubKey || this.expectedNodePubKey;
+        if (nodePubKey) {
+          this.emit('bannedBy', this.expectedNodePubKey!);
+        }
+      }
     } else {
       // protocol violation: packet should be sent once only, with body, with `reason` field
       // TODO: penalize peer

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -293,6 +293,9 @@ class Pool extends EventEmitter {
       }
       return;
     });
+    this.nodes.on('node.unban', (nodePubKey: string) => {
+      this.logger.info(`node ${nodePubKey} was unbanned`);
+    });
   }
 
   private verifyReachability = () => {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -278,6 +278,7 @@ class Pool extends EventEmitter {
       await this.loadingNodesPromise;
     }
     await Promise.all([this.unlisten(), this.closePendingConnections(), this.closePeers()]);
+    this.nodes.removeAllListeners();
     this.connected = false;
     this.disconnecting = false;
   }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -340,8 +340,11 @@ class Pool extends EventEmitter {
       // if allowKnown is false, allow nodes that we don't aware of
       const isAllowed = allowKnown || !this.nodes.has(node.nodePubKey);
 
+      // Check if we are banned by the node.
+      const notBannedBy = !this.nodes.isBannedBy(node.nodePubKey);
+
       // determine whether we should attempt to connect
-      if (isNotUs && hasAddresses && isAllowed) {
+      if (isNotUs && hasAddresses && isAllowed && notBannedBy) {
         connectionPromises.push(this.tryConnectNode(node, retryConnecting));
       }
     });
@@ -600,16 +603,25 @@ class Pool extends EventEmitter {
       }
     });
 
+    const peerPubKey = peer.nodePubKey!;
+
     // creating the node entry
-    if (!this.nodes.has(peer.nodePubKey!)) {
+    if (!this.nodes.has(peerPubKey)) {
       await this.nodes.createNode({
         addresses,
-        nodePubKey: peer.nodePubKey!,
+        nodePubKey: peerPubKey,
         lastAddress: peer.inbound ? undefined : peer.address,
       });
     } else {
       // the node is known, update its listening addresses
-      await this.nodes.updateAddresses(peer.nodePubKey!, addresses, peer.inbound ? undefined : peer.address);
+      await this.nodes.updateAddresses(peerPubKey, addresses, peer.inbound ? undefined : peer.address);
+    }
+
+    // Check if peer has previously banned us, if so set `bannedBy` to false
+    const node = this.nodes.getNode(peerPubKey);
+    if (node && node.bannedBy) {
+      await this.nodes.setBannedBy(peerPubKey, false);
+      this.logger.info(`Peer: ${peerPubKey} has unbanned us`);
     }
   }
 
@@ -943,6 +955,12 @@ class Pool extends EventEmitter {
 
     peer.once('close', () => this.handlePeerClose(peer));
 
+    peer.on('bannedBy', async (nodePubKey: string) => {
+      // set peer as banning us
+      await this.nodes.setBannedBy(nodePubKey);
+      this.logger.info(`Peer: ${nodePubKey} has banned us`);
+    });
+
     peer.on('reputation', async (event) => {
       if (peer.nodePubKey) {
         await this.addReputationEvent(peer.nodePubKey, event);
@@ -971,7 +989,7 @@ class Pool extends EventEmitter {
 
     if (!peer.inbound && peer.nodePubKey && shouldReconnect && (addresses.length || peer.address)) {
       this.logger.debug(`attempting to reconnect to a disconnected peer ${peer.label}`);
-      const node = { addresses, lastAddress: peer.address, nodePubKey: peer.nodePubKey };
+      const node = { addresses, bannedBy: false, lastAddress: peer.address, nodePubKey: peer.nodePubKey };
       await this.tryConnectNode(node, true);
     }
   }

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -13,7 +13,7 @@ const errorCodes = {
   CONNECTION_RETRIES_MAX_PERIOD_EXCEEDED: codesPrefix.concat('.6'),
   CONNECTION_RETRIES_REVOKED: codesPrefix.concat('.7'),
   COULD_NOT_CONNECT: codesPrefix.concat('.7'),
-  NODE_UNKNOWN: codesPrefix.concat('.8'),
+  NODE_NOT_FOUND: codesPrefix.concat('.8'),
   NODE_ALREADY_BANNED: codesPrefix.concat('.9'),
   NODE_NOT_BANNED: codesPrefix.concat('.10'),
   NODE_IS_BANNED: codesPrefix.concat('.11'),
@@ -83,7 +83,7 @@ const errors = {
   }),
   NODE_NOT_FOUND: (nodePubKey: string) => ({
     message: `node with pub key ${nodePubKey} not found`,
-    code: errorCodes.NODE_UNKNOWN,
+    code: errorCodes.NODE_NOT_FOUND,
   }),
   NODE_ALREADY_BANNED: (nodePubKey: string) => ({
     message: `node ${nodePubKey} has already been banned`,

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -1,7 +1,7 @@
+import { XuNetwork } from '../constants/enums';
 import errorCodesPrefix from '../constants/errorCodesPrefix';
 import addressUtils from '../utils/addressUtils';
 import { Address } from './types';
-import { XuNetwork } from '../constants/enums';
 
 const codesPrefix = errorCodesPrefix.P2P;
 const errorCodes = {
@@ -33,6 +33,7 @@ const errorCodes = {
   NODE_TOR_ADDRESS: codesPrefix.concat('.25'),
   ALIAS_CONFLICT: codesPrefix.concat('.26'),
   UNKNOWN_ALIAS: codesPrefix.concat('.27'),
+  BANNED_BY_NODE: codesPrefix.concat('.28'),
 };
 
 const errors = {
@@ -155,6 +156,10 @@ const errors = {
   ALIAS_NOT_FOUND: (alias: string) => ({
     message: `node with alias ${alias} not found`,
     code: errorCodes.UNKNOWN_ALIAS,
+  }),
+  BANNED_BY_NODE: (nodePubKey: string) => ({
+    message: `could not connect to node ${nodePubKey} because it has banned us`,
+    code: errorCodes.BANNED_BY_NODE,
   }),
 };
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -340,10 +340,10 @@ class Service {
   /**
    * Gets information about a specified node.
    */
-  public getNodeInfo = async (args: { nodeIdentifier: string }) => {
+  public getNodeInfo = (args: { nodeIdentifier: string }) => {
     argChecks.HAS_NODE_IDENTIFIER(args);
     const nodePubKey = isNodePubKey(args.nodeIdentifier) ? args.nodeIdentifier : this.pool.resolveAlias(args.nodeIdentifier);
-    const info = await this.pool.getNodeReputation(nodePubKey);
+    const info = this.pool.getNodeReputation(nodePubKey);
     return info;
   }
 

--- a/test/jest/Pool.spec.ts
+++ b/test/jest/Pool.spec.ts
@@ -230,4 +230,23 @@ describe('P2P Pool', () => {
     expect(pool.peerCount).toEqual(1);
   });
 
+  it('bans and unbans a peer', async () => {
+    await pool['nodes'].createNode({ nodePubKey: pool2nodeKey.pubKey, addresses: [] });
+    await pool.banNode(pool2nodeKey.pubKey);
+    const bannedNodeReputationPromise = pool.getNodeReputation(pool2nodeKey.pubKey);
+    expect(bannedNodeReputationPromise.banned).toEqual(true);
+
+    await pool.unbanNode(pool2nodeKey.pubKey, false);
+    const unbannedNodeReputationPromise = pool.getNodeReputation(pool2nodeKey.pubKey);
+    expect(unbannedNodeReputationPromise.banned).toEqual(false);
+  });
+
+  it('sets bannedBy to true if a node has banned us', async () => {
+    await pool['nodes'].createNode({ nodePubKey: pool2nodeKey.pubKey, addresses: [] });
+    const peer = await pool.addOutbound(pool2address, pool2nodeKey.pubKey, true, false);
+    peer.emit('bannedBy', pool2nodeKey.pubKey);
+
+    const node = pool['nodes']['nodes'].get(pool2nodeKey.pubKey)!;
+    expect(node.bannedBy).toEqual(true);
+  });
 });


### PR DESCRIPTION
closes #693 

@sangaman This PR will ban and disconnect from a peer if we receive a `DisconnectingPacket` before a `SessionInitPacket`.

The next step for this PR will be persisting the fact that the node has banned us in memory or in the DB, 
personally, I think we should persist it in the DB. What are you're opinions?