### PR TITLE
test: preserve xud log files from sim tests

### DIFF
--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -29,6 +29,7 @@ var (
 type nodeConfig struct {
 	DataDir     string
 	XUDPath     string
+	LogPath     string
 	TLSCertPath string
 
 	LndBtcHost     string
@@ -54,6 +55,7 @@ func (cfg nodeConfig) genArgs() []string {
 	args = append(args, "--loglevel=debug")
 
 	args = append(args, fmt.Sprintf("--xudir=%v", cfg.DataDir))
+	args = append(args, fmt.Sprintf("--logpath=%v", cfg.LogPath))
 
 	args = append(args, fmt.Sprintf("--rpc.port=%v", cfg.RPCPort))
 
@@ -110,7 +112,7 @@ func (cfg nodeConfig) P2PAddr() string {
 func newNode(name string) (*HarnessNode, error) {
 	nodeNum := int(atomic.AddInt32(&numActiveNodes, 1))
 
-	dataDir, err := filepath.Abs("./xuddatadir-" + name)
+	dataDir, err := filepath.Abs("./temp/xuddatadir-" + name)
 	if err != nil {
 		return nil, err
 	}
@@ -124,6 +126,8 @@ func newNode(name string) (*HarnessNode, error) {
 		DataDir: dataDir,
 		XUDPath: xudPath,
 	}
+	epoch := time.Now().Unix()
+	cfg.LogPath = fmt.Sprintf("./temp/logs/xud-%s-%d.log", name, epoch)
 
 	cfg.TLSCertPath = filepath.Join(cfg.DataDir, "tls.cert")
 	cfg.P2PPort = baseP2PPort + nodeNum


### PR DESCRIPTION
This preserves the log files generated from running the simulation tests within the simulation test temp folder. Data directories are also moved to the temp folder and are still cleaned up by default after each run, but separating and keeping the logs will help with diagnosing errors that arise during simulation test runs.