### PR TITLE
test: cache lnd & dependencies in travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ docker/xud/xud.db
 
 # xud-simulation execution temp directory
 test/simulation/temp
+test/simulation/go

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,12 @@ node_js:
 cache:
   directories:
     - "node_modules"
-    - $GOCACHE
-    - $GOPATH/pkg
-    - $GOPATH/bin
-    - $GOPATH/src/github.com/btcsuite
+    - "test/simulation/go" # lnd, btcd, and dependencies
+
+install:
+  - eval "$(GIMME_GO_VERSION=1.12 gimme)"
 
 script:
   - npm run lintNoFix
   - npm run test
-
-  # network simulation integration tests
-  - eval "$(GIMME_GO_VERSION=1.12 gimme)"
-  - go get -u github.com/golang/dep/cmd/dep
-  - go get -u github.com/btcsuite/btcd
-  - npm install
   - npm run test:sim

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:p2p": "mocha -r ts-node/register test/p2p/*",
     "test:p2p:watch": "mocha -r ts-node/register test/p2p/*  --watch --watch-extensions ts",
     "test:crypto": "mocha -r ts-node/register test/crypto/*",
-    "test:sim": "(npm run compile && cd test/simulation && GO111MODULE=on go test -v)",
+    "test:sim": "(npm run compile && cd test/simulation && export PATH=\"$PWD/go/bin:$PATH\" && GOPATH=$PWD/go GO111MODULE=on go test -v)",
     "typedoc": "typedoc --out typedoc --module commonjs --target es6 lib --readme none",
     "preversion": "npm run lintNoFix && npm test && npm run compile",
     "version": "npm run config && npm run changelog && git add sample-xud.conf CHANGELOG.md && npm run typedoc"

--- a/test/simulation/README.md
+++ b/test/simulation/README.md
@@ -15,7 +15,8 @@ Requirements:
 Installation & Usage:
 
 ```bash
-$ GO111MODULE=on go test -v
+$ export PATH=$PATH:$PWD/go/bin
+$ GOPATH=$PWD/go GO111MODULE=on go test -v
 ````
 
 ## Network Scenarios Tests

--- a/test/simulation/install.sh
+++ b/test/simulation/install.sh
@@ -8,12 +8,12 @@ delete_dir() {
 	return 0
 }
 
-temp_gopath=$PWD/temp/go
-temp_lndpath=${temp_gopath}/src/github.com/lightningnetwork/lnd
+GO_PATH=$PWD/go
+LND_PATH=${GO_PATH}/src/github.com/lightningnetwork/lnd
 LND_TAG="v0.6.1-beta"
-if [ -f ${temp_lndpath}/lnd-debug ]
+if [ -f ${LND_PATH}/lnd-debug ]
 then
-  LND_VERSION=$(${temp_lndpath}/lnd-debug --version)
+  LND_VERSION=$(${LND_PATH}/lnd-debug --version)
 else
   LND_VERSION=""
 fi
@@ -21,21 +21,24 @@ fi
 if [[ $LND_VERSION == *"$LND_TAG" ]]; then
     echo "lnd already installed"
 else
-    echo "deleting temporary gopath directory"
-    delete_dir ${temp_gopath}
+    echo "lnd version $LND_TAG not found"
+    if [ -d "$LND_PATH" ]; then
+      echo "deleting lnd directory"
+      delete_dir ${LND_PATH}
+    fi
 
     echo "getting btcd..."
-    GO111MODULE=off go get -u github.com/btcsuite/btcd
+    GOPATH=${GO_PATH} go get -u github.com/btcsuite/btcd
 
     echo "starting lnd clone..."
-    if ! git clone -b ${LND_TAG} --depth 1 https://github.com/lightningnetwork/lnd ${temp_lndpath} > /dev/null 2>&1; then
+    if ! git clone -b ${LND_TAG} --depth 1 https://github.com/lightningnetwork/lnd ${LND_PATH} > /dev/null 2>&1; then
        echo "unable to git clone lnd"
        exit 1
     fi
     echo "finished lnd clone"
 
     echo "starting lnd make..."
-    if ! (cd ${temp_lndpath} && GO111MODULE=off GOPATH=${temp_gopath} make tags="invoicesrpc"); then
+    if ! (cd ${LND_PATH} && GOPATH=${GO_PATH} make tags="invoicesrpc"); then
         echo "unable to make lnd"
         exit 1
     fi

--- a/test/simulation/lntest/node.go
+++ b/test/simulation/lntest/node.go
@@ -258,7 +258,7 @@ func (hn *HarnessNode) start(lndError chan<- error) error {
 
 	args := hn.Cfg.genArgs()
 	args = append(args, fmt.Sprintf("--profile=%d", 9000+hn.NodeID))
-	hn.cmd = exec.Command("./temp/go/src/github.com/lightningnetwork/lnd/lnd-debug", args...)
+	hn.cmd = exec.Command("./go/src/github.com/lightningnetwork/lnd/lnd-debug", args...)
 
 	// Redirect stderr output to buffer
 	var errb bytes.Buffer


### PR DESCRIPTION
This modifies our Travis CI configuration to cache the go folder that holds lnd and its dependencies, such that we won't need to install lnd for each build and will reduce test run time significantly. This also moves the `go` folder out of the `temp` folder since this folder need not change unless the version of lnd we're using changes, and in that case the tests will reinstall lnd automatically. Even locally, keeping the go folder in between test runs will save time.

The install and simulation test scripts are modified to use the go folder created for the simulation tests as the only GOPATH value. This means all dependency modules and btcd are put in this folder and separated from the local go environment, preventing the possibility for conflicts and inconsistencies due to the environment.

### Travis Results

Old build time: From 6:20 to 8:15
New build time: 4:07

Old cache size: ~675MB
New cache size: 395MB