### PR TITLE
fix(swaps): don't retry verified currency sanity

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -66,6 +66,8 @@ class Peer extends EventEmitter {
   public discoverTimer?: NodeJS.Timer;
   /** Trading pairs advertised by this peer which we have verified that we can swap. */
   public activePairs = new Set<string>();
+  /** Currencies that we have verified that we can swap with for this peer. */
+  public verifiedCurrencies = new Set<string>();
   /** Whether we have received and authenticated a [[SessionInitPacket]] from the peer. */
   private opened = false;
   private opening = false;
@@ -341,6 +343,9 @@ class Peer extends EventEmitter {
       throw new Error('cannot deactivate a trading pair before handshake is complete');
     }
     if (this.activePairs.delete(pairId)) {
+      const [baseCurrency, quoteCurrency] = pairId.split('/');
+      this.verifiedCurrencies.delete(baseCurrency);
+      this.verifiedCurrencies.delete(quoteCurrency);
       this.emit('pairDropped', pairId);
     }
     // TODO: notify peer that we have deactivated this pair?


### PR DESCRIPTION
This modifies the logic for determining which currencies to perform sanity swaps for. Previously, if a sanity swap failed for either currency in a trading pair, when that trading pair was retried we would retry sanity swaps for both currencies in the pair including the one that worked previously. This change tracks currencies for which we have had a successful sanity swap for and prevents retrying sanity swaps for that currency - until we encounter an error that deactivates a trading pair that includes that currency.

Fixes #946.