### PR TITLE
fix(swaps): remove stalled sanity swap invoice

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -36,7 +36,7 @@ interface Pool {
   /** Adds a listener to be called when a previously active pair is dropped by the peer or deactivated. */
   on(event: 'peer.pairDropped', listener: (peerPubKey: string, pairId: string) => void): this;
   on(event: 'peer.nodeStateUpdate', listener: (peer: Peer) => void): this;
-  on(event: 'packet.sanitySwap', listener: (packet: packets.SanitySwapInitPacket, peer: Peer) => void): this;
+  on(event: 'packet.sanitySwapInit', listener: (packet: packets.SanitySwapInitPacket, peer: Peer) => void): this;
   on(event: 'packet.swapRequest', listener: (packet: packets.SwapRequestPacket, peer: Peer) => void): this;
   on(event: 'packet.swapAccepted', listener: (packet: packets.SwapAcceptedPacket, peer: Peer) => void): this;
   on(event: 'packet.swapComplete', listener: (packet: packets.SwapCompletePacket) => void): this;
@@ -50,7 +50,7 @@ interface Pool {
   /** Notifies listeners that a previously active pair was dropped by the peer or deactivated. */
   emit(event: 'peer.pairDropped', peerPubKey: string, pairId: string): boolean;
   emit(event: 'peer.nodeStateUpdate', peer: Peer): boolean;
-  emit(event: 'packet.sanitySwap', packet: packets.SanitySwapInitPacket, peer: Peer): boolean;
+  emit(event: 'packet.sanitySwapInit', packet: packets.SanitySwapInitPacket, peer: Peer): boolean;
   emit(event: 'packet.swapRequest', packet: packets.SwapRequestPacket, peer: Peer): boolean;
   emit(event: 'packet.swapAccepted', packet: packets.SwapAcceptedPacket, peer: Peer): boolean;
   emit(event: 'packet.swapComplete', packet: packets.SwapCompletePacket): boolean;
@@ -61,8 +61,6 @@ interface Pool {
 interface NodeConnectionIterator {
   forEach: (callback: (node: NodeConnectionInfo) => void) => void;
 }
-
-/** Represents a pool of peers that handles all  network activity. */
 
 /**
  * Represents a pool of peers that handles all p2p network activity. This tracks all active and
@@ -645,7 +643,7 @@ class Pool extends EventEmitter {
       }
       case PacketType.SanitySwap: {
         this.logger.debug(`received sanitySwap from ${peer.nodePubKey}: ${JSON.stringify(packet.body)}`);
-        this.emit('packet.sanitySwap', packet, peer);
+        this.emit('packet.sanitySwapInit', packet, peer);
         break;
       }
       case PacketType.SwapRequest: {


### PR DESCRIPTION
This adds a timeout for sanity that we have accepted and added an invoice for. If the time limit is exceeded, we remove the sanity swap and its corresponding invoice. This prevents invoices and sanity swaps that are stalled from accumulating, avoiding a potential memory leak.

Fixes #964.