### PR TITLE
 fix: swap client initialization

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -73,7 +73,7 @@ class Xud extends EventEmitter {
 
       this.db = new DB(loggers.db, this.config.dbpath);
       await this.db.init(this.config.network, this.config.initdb);
-      this.pool = new Pool(this.config.p2p, this.config.network, loggers.p2p, this.db.models);
+      this.pool = new Pool(this.config.p2p, this.config.network, loggers.p2p, this.db.models, version);
       this.swapClientManager = new SwapClientManager(this.config, loggers, this.pool);
       await this.swapClientManager.init(this.db.models);
 
@@ -89,13 +89,7 @@ class Xud extends EventEmitter {
       this.logger.info(`Local nodePubKey is ${this.nodeKey.nodePubKey}`);
 
       // initialize pool and start listening/connecting only once other components are initialized
-      await this.pool.init({
-        version,
-        lndPubKeys: this.swapClientManager.getLndPubKeys(),
-        pairs: this.orderBook.pairIds,
-        nodePubKey: this.nodeKey.nodePubKey,
-        raidenAddress: this.swapClientManager.raidenClient.address,
-      }, this.nodeKey);
+      await this.pool.init(this.nodeKey);
 
       this.service = new Service({
         version,

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -160,6 +160,8 @@ class OrderBook extends EventEmitter {
       this.pairInstances.set(pair.id, pair);
       this.tradingPairs.set(pair.id, new TradingPair(this.logger, pair.id, this.nomatching));
     });
+
+    this.pool.updatePairs(this.pairIds);
   }
 
   public getCurrencyAttributes(symbol: string) {

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -15,6 +15,7 @@ export type NodeConnectionInfo = {
 export type NodeState = {
   version: string;
   nodePubKey: string;
+  /** This node's listening external socket addresses to advertise to peers. */
   addresses: Address[];
   pairs: string[];
   raidenAddress: string;

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -80,6 +80,7 @@ class RaidenClient extends SwapClient {
     } catch (err) {
       this.logger.error(
         `could not verify connection to raiden at ${this.host}:${this.port}, retrying in ${RaidenClient.RECONNECT_TIMER} ms`,
+        err,
       );
       await this.setStatus(ClientStatus.Disconnected);
     }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -449,7 +449,6 @@ class Swaps extends EventEmitter {
       localId: orderToAccept.localId,
       phase: SwapPhase.SwapCreated,
       state: SwapState.Active,
-      rHash: requestBody.rHash,
       role: SwapRole.Maker,
       createTime: Date.now(),
     };

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -3,7 +3,6 @@ import {
   SwapPhase,
   SwapState,
   SwapFailureReason,
-  SwapClientType,
 } from '../constants/enums';
 
 export type SwapDeal = {
@@ -97,11 +96,3 @@ export type ResolveRequest = {
   amount: number,
   rHash: string,
 };
-
-export function isLndClient(swapClientType: SwapClientType): boolean {
-  return (swapClientType === SwapClientType.Lnd);
-}
-
-export function isRaidenClient(swapClientType: SwapClientType): boolean {
-  return (swapClientType === SwapClientType.Raiden);
-}

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -12,7 +12,7 @@ import Logger, { Level } from '../../lib/Logger';
 import * as orders from '../../lib/orderbook/types';
 import { SwapClientType } from '../../lib/constants/enums';
 import { createOwnOrder } from '../utils';
-import sinon, { SinonSandbox }  from 'sinon';
+import sinon  from 'sinon';
 
 const PAIR_ID = 'LTC/BTC';
 const currencies = PAIR_ID.split('/');
@@ -30,12 +30,16 @@ const initValues = async (db: DB) => {
   ]);
 };
 
+const sandbox = sinon.createSandbox();
+const pool = sandbox.createStubInstance(Pool) as any;
+pool.broadcastOrder = () => {};
+pool.broadcastOrderInvalidation = () => {};
+pool.updatePairs = () => {};
+
 describe('OrderBook', () => {
   let db: DB;
-  let pool: Pool;
   let swaps: Swaps;
   let orderBook: OrderBook;
-  let sandbox: SinonSandbox;
 
   before(async () => {
     db = new DB(loggers.db);
@@ -43,11 +47,7 @@ describe('OrderBook', () => {
 
     await initValues(db);
 
-    sandbox = sinon.createSandbox();
-    pool = sandbox.createStubInstance(Pool) as any;
-    pool.broadcastOrder = () => {};
-    pool.broadcastOrderInvalidation = () => {};
-    swaps = sandbox.createStubInstance(Swaps) as any;
+    swaps = sandbox.createStubInstance(Swaps) as any;;
     swaps.isPairSupported = () => true;
     const lndBTC = sandbox.createStubInstance(LndClient) as any;
     const lndLTC = sandbox.createStubInstance(LndClient) as any;
@@ -162,7 +162,7 @@ describe('nomatching OrderBook', () => {
   });
 
   beforeEach(async () => {
-    orderBook = new OrderBook(loggers.orderbook, db.models, true);
+    orderBook = new OrderBook(loggers.orderbook, db.models, true, pool);
     await orderBook.init();
   });
 

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -44,6 +44,7 @@ describe('P2P Pool Tests', async () => {
 
   before(async () => {
     nodeKeyOne = await NodeKey['generate']();
+    const nodeKeyTwo = await NodeKey['generate']();
 
     const config = new Config();
     config.p2p.listen = false;
@@ -51,15 +52,9 @@ describe('P2P Pool Tests', async () => {
     db = new DB(loggers.db);
     await db.init();
 
-    pool = new Pool(config.p2p, XuNetwork.SimNet, loggers.p2p, db.models);
+    pool = new Pool(config.p2p, XuNetwork.SimNet, loggers.p2p, db.models, '1.0.0');
 
-    await pool.init({
-      nodePubKey: 'test',
-      version: 'test',
-      pairs: [],
-      lndPubKeys: {},
-      raidenAddress: '',
-    }, nodeKeyOne);
+    await pool.init(nodeKeyTwo);
   });
 
   it('should open a connection with a peer', async () => {

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -46,7 +46,14 @@ jest.mock('../../lib/p2p/Peer', () => {
     };
   });
 });
-jest.mock('../../lib/p2p/Pool');
+jest.mock('../../lib/p2p/Pool', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      updatePairs: jest.fn(),
+      on: jest.fn(),
+    };
+  });
+});
 jest.mock('../../lib/Config');
 jest.mock('../../lib/swaps/Swaps');
 jest.mock('../../lib/swaps/SwapClientManager');
@@ -83,7 +90,7 @@ describe('OrderBook', () => {
       port: 9735,
     }, network);
     db = new DB(loggers.db, config.dbpath);
-    pool = new Pool(config.p2p, config.network, loggers.p2p, db.models);
+    pool = new Pool(config.p2p, config.network, loggers.p2p, db.models, '1.0.0');
     swapClientManager = new SwapClientManager(config, loggers, pool);
     swaps = new Swaps(loggers.swaps, db.models, pool, swapClientManager);
     swaps.swapClientManager = swapClientManager;

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -100,7 +100,7 @@ describe('Swaps.SwapClientManager', () => {
       port: 1234,
     };
     db = new DB(loggers.db, config.dbpath);
-    pool = new Pool(config.p2p, config.network, loggers.p2p, db.models);
+    pool = new Pool(config.p2p, config.network, loggers.p2p, db.models, '1.0.0');
   });
 
   afterEach(() => {

--- a/test/simulation/tests.go
+++ b/test/simulation/tests.go
@@ -34,8 +34,6 @@ func testNetworkInit(net *xudtest.NetworkHarness, ht *harnessTest) {
 				ht.assert.Equal(res.Lnd["LTC"].Chains[0].Network, "simnet")
 				// Set the node public key.
 				node.SetPubKey(res.NodePubKey)
-				// Set the node public key.
-				node.SetPubKey(res.NodePubKey)
 				// Add pair to the node.
 				ht.act.addPair(node, "LTC", "BTC", xudrpc.AddCurrencyRequest_LND)
 				break


### PR DESCRIPTION
This fixes a bug where the swap clients would fail on their first attempt to initialize because they would try to update `pool.nodeState` which is undefined. `pool.nodeState` is not assigned a value until `pool.init()` is called, which would not happen until after the first attempt to initialize swap clients.

This changes the initialization flow so that the node state is assigned a value in the `Pool` constructor. The properties of `Pool.nodeState` are then updated as the other components (swap clients, order book)
initialize.