### PR TITLE
feat(raiden): log error message for 409 responses

### DIFF
--- a/lib/raidenclient/errors.ts
+++ b/lib/raidenclient/errors.ts
@@ -24,10 +24,15 @@ const errors = {
     message: 'request timed out',
     code: errorCodes.TIMEOUT,
   },
-  INVALID: {
-    message: 'request is conflicting or otherwise invalid',
+  /**
+   * For HTTP 409 responses from Raiden. For token payments 409 means "the address
+   * or the amount is invalid, or there is no path to the target, or the identifier
+   * is already in use for a different payment."
+   */
+  INVALID: (message: string) => ({
+    message,
     code: errorCodes.INVALID,
-  },
+  }),
   SERVER_ERROR: {
     message: 'raiden server error',
     code: errorCodes.SERVER_ERROR,


### PR DESCRIPTION
This improves the logging when requests to raiden fail with an HTTP 409 response. Previously only a generic error message was logged, here we parse the error response body and set it as the `message` for the error.

Closes #957.