### PR TITLE
refactor: make peer activePairs private

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -543,7 +543,7 @@ class Pool extends EventEmitter {
   public broadcastOrder = (order: OutgoingOrder) => {
     const orderPacket = new packets.OrderPacket(order);
     this.peers.forEach(async (peer) => {
-      if (peer.activePairs.has(order.pairId)) {
+      if (peer.isPairActive(order.pairId)) {
         await peer.sendPacket(orderPacket);
       }
     });
@@ -594,7 +594,7 @@ class Pool extends EventEmitter {
         this.logger.verbose(`received order from ${peer.nodePubKey}: ${JSON.stringify(receivedOrder)}`);
         const incomingOrder: IncomingOrder = { ...receivedOrder, peerPubKey: peer.nodePubKey! };
 
-        if (peer.activePairs.has(incomingOrder.pairId)) {
+        if (peer.isPairActive(incomingOrder.pairId)) {
           this.emit('packet.order', incomingOrder);
         } else {
           this.logger.debug(`received order ${incomingOrder.id} for deactivated trading pair`);
@@ -617,7 +617,7 @@ class Pool extends EventEmitter {
         const receivedOrders = (packet as packets.OrdersPacket).body!;
         this.logger.verbose(`received ${receivedOrders.length} orders from ${peer.nodePubKey}`);
         receivedOrders.forEach((order) => {
-          if (peer.activePairs.has(order.pairId)) {
+          if (peer.isPairActive(order.pairId)) {
             this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey! });
           } else {
             this.logger.debug(`received order ${order.id} for deactivated trading pair`);

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -38,15 +38,11 @@ jest.mock('../../lib/db/DB', () => {
     };
   });
 });
-const mockSendPacket = jest.fn();
-const mockAddPair = jest.fn();
+const mockActivatePair = jest.fn();
 jest.mock('../../lib/p2p/Peer', () => {
   return jest.fn().mockImplementation(() => {
     return {
-      activePairs: {
-        add: mockAddPair,
-      },
-      sendPacket: mockSendPacket,
+      activatePair: mockActivatePair,
     };
   });
 });
@@ -103,8 +99,7 @@ describe('OrderBook', () => {
     await orderbook.init();
     const pairIds = ['LTC/BTC', 'WETH/BTC'];
     await orderbook['verifyPeerPairs'](peer, pairIds);
-    expect(mockAddPair).toHaveBeenCalledTimes(2);
-    expect(mockSendPacket).toHaveBeenCalledTimes(1);
+    expect(mockActivatePair).toHaveBeenCalledTimes(2);
   });
 
   test('placeOrder insufficient outbound balance does throw when nosanitychecks disabled', async () => {


### PR DESCRIPTION
This commit adds an `activatePair` public method for the `Peer` class and makes the `activePairs` property private. `activatePair` will both add a pair to the set of active pairs as well as request existing orders for that pair from the peer.