### PR TITLE
refactor(orderbook): pass object to constructor

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -80,7 +80,14 @@ class Xud extends EventEmitter {
       this.swaps = new Swaps(loggers.swaps, this.db.models, this.pool, this.swapClientManager);
       initPromises.push(this.swaps.init());
 
-      this.orderBook = new OrderBook(loggers.orderbook, this.db.models, this.config.nomatching, this.pool, this.swaps, this.config.nosanitychecks);
+      this.orderBook = new OrderBook({
+        logger: loggers.orderbook,
+        models: this.db.models,
+        nomatching: this.config.nomatching,
+        pool: this.pool,
+        swaps: this.swaps,
+        nosanitychecks: this.config.nosanitychecks,
+      });
       initPromises.push(this.orderBook.init());
 
       // wait for components to initialize in parallel

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -61,6 +61,8 @@ interface OrderBook {
 class OrderBook extends EventEmitter {
   /** A map between active trading pair ids and trading pair instances. */
   public tradingPairs = new Map<string, TradingPair>();
+  public nomatching: boolean;
+
   /** A map between own orders local id and their global id. */
   private localIdMap = new Map<string, OrderIdentifier>();
 
@@ -69,6 +71,10 @@ class OrderBook extends EventEmitter {
   /** A map of supported trading pair tickers and pair database instances. */
   private pairInstances = new Map<string, PairInstance>();
   private repository: OrderBookRepository;
+  private logger: Logger;
+  private nosanitychecks: boolean;
+  private pool: Pool;
+  private swaps: Swaps;
 
   /** Max time for placeOrder iterations (due to swaps failures retries). */
   private static readonly MAX_PLACEORDER_ITERATIONS_TIME = 10000; // 10 sec
@@ -84,9 +90,22 @@ class OrderBook extends EventEmitter {
     return this.currencyInstances.keys();
   }
 
-  constructor(private logger: Logger, models: Models, public nomatching = false,
-    private pool: Pool, private swaps: Swaps, private nosanitychecks = false) {
+  constructor({ logger, models, pool, swaps, nomatching = false, nosanitychecks = false }:
+  {
+    logger: Logger,
+    models: Models,
+    pool: Pool,
+    swaps: Swaps,
+    nomatching?: boolean,
+    nosanitychecks?: boolean,
+  }) {
     super();
+
+    this.logger = logger;
+    this.pool = pool;
+    this.swaps = swaps;
+    this.nomatching = nomatching;
+    this.nosanitychecks = nosanitychecks;
 
     this.repository = new OrderBookRepository(models);
 

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -73,7 +73,12 @@ describe('OrderBook', () => {
     await initValues(db);
 
     swaps = getMockSwaps(sandbox);
-    orderBook = new OrderBook(loggers.orderbook, db.models, false, pool, swaps);
+    orderBook = new OrderBook({
+      pool,
+      swaps,
+      logger: loggers.orderbook,
+      models: db.models,
+    });
     await orderBook.init();
   });
 
@@ -176,7 +181,13 @@ describe('nomatching OrderBook', () => {
   });
 
   beforeEach(async () => {
-    orderBook = new OrderBook(loggers.orderbook, db.models, true, pool, swaps);
+    orderBook = new OrderBook({
+      pool,
+      swaps,
+      logger: loggers.orderbook,
+      models: db.models,
+      nomatching: true,
+    });
     await orderBook.init();
   });
 

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -102,7 +102,14 @@ describe('OrderBook', () => {
 
   test('nosanitychecks enabled adds pairs and requests orders', async () => {
     config.nosanitychecks = true;
-    orderbook = new Orderbook(loggers.orderbook, db.models, config.nomatching, pool, swaps, config.nosanitychecks);
+    orderbook = new Orderbook({
+      pool,
+      swaps,
+      logger: loggers.orderbook,
+      models: db.models,
+      nomatching: config.nomatching,
+      nosanitychecks: config.nosanitychecks,
+    });
     await orderbook.init();
     const pairIds = ['LTC/BTC', 'WETH/BTC'];
     await orderbook['verifyPeerPairs'](peer, pairIds);
@@ -111,7 +118,14 @@ describe('OrderBook', () => {
 
   test('placeOrder insufficient outbound balance does throw when nosanitychecks disabled', async () => {
     config.nosanitychecks = false;
-    orderbook = new Orderbook(loggers.orderbook, db.models, config.nomatching, pool, swaps, config.nosanitychecks);
+    orderbook = new Orderbook({
+      pool,
+      swaps,
+      logger: loggers.orderbook,
+      models: db.models,
+      nomatching: config.nomatching,
+      nosanitychecks: config.nosanitychecks,
+    });
     await orderbook.init();
     const quantity = 500000000000;
     const order: OwnOrder = {


### PR DESCRIPTION
This refactors the constructor for `OrderBook` to accept a single object rather than 6 parameters. This brings the constructor in line with other recently changed constructors/methods that accept 4+ parameters.