### PR TITLE
fix: deprecation warnings from crypto dependency

### DIFF
--- a/lib/p2p/Framer.ts
+++ b/lib/p2p/Framer.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import crypto from 'crypto';
+import { createCipheriv, createDecipheriv } from 'crypto';
 import Network from './Network';
 import Packet from './packets/Packet';
 import errors from './errors';
@@ -172,7 +172,7 @@ class Framer {
 
   public encrypt = async (plaintext: Buffer, key: Buffer): Promise<Buffer> => {
     const iv = await randomBytes(Framer.ENCRYPTION_IV_LENGTH);
-    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+    const cipher = createCipheriv('aes-256-cbc', key, iv);
 
     return Buffer.concat([iv, cipher.update(plaintext), cipher.final()]);
   }
@@ -180,7 +180,7 @@ class Framer {
   public decrypt = (ciphertext: Buffer, key: Buffer): Buffer => {
     const iv = ciphertext.slice(0, Framer.ENCRYPTION_IV_LENGTH);
     const encrypted = ciphertext.slice(Framer.ENCRYPTION_IV_LENGTH);
-    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+    const decipher = createDecipheriv('aes-256-cbc', key, iv);
 
     return Buffer.concat([decipher.update(encrypted), decipher.final()]);
   }

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import net, { Socket } from 'net';
 import { EventEmitter } from 'events';
-import crypto from 'crypto';
+import { createHash, createECDH } from 'crypto';
 import secp256k1 from 'secp256k1';
 import stringify from 'json-stable-stringify';
 import { ReputationEvent, DisconnectionReason, SwapClientType } from '../constants/enums';
@@ -720,7 +720,7 @@ class Peer extends EventEmitter {
 
     // verify that the msg was signed by the peer
     const msg = stringify(bodyWithoutSign);
-    const msgHash = crypto.createHash('sha256').update(msg).digest();
+    const msgHash = createHash('sha256').update(msg).digest();
     const verified = secp256k1.verify(
       msgHash,
       Buffer.from(sign, 'hex'),
@@ -741,7 +741,7 @@ class Peer extends EventEmitter {
    * Sends a [[SessionInitPacket]] and waits for a [[SessionAckPacket]].
    */
   private initSession = async (ownNodeState: NodeState, nodeKey: NodeKey, expectedNodePubKey: string): Promise<void> => {
-    const ECDH = crypto.createECDH('secp256k1');
+    const ECDH = createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
     const packet = this.createSessionInitPacket(ephemeralPubKey, ownNodeState, expectedNodePubKey, nodeKey);
     await this.sendPacket(packet);
@@ -758,7 +758,7 @@ class Peer extends EventEmitter {
    * Sends a [[SessionAckPacket]] in response to a given [[SessionInitPacket]].
    */
   private ackSession = async (sessionInit: packets.SessionInitPacket): Promise<void> => {
-    const ECDH = crypto.createECDH('secp256k1');
+    const ECDH = createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
 
     await this.sendPacket(new packets.SessionAckPacket({ ephemeralPubKey }, sessionInit.header.id));
@@ -851,7 +851,7 @@ class Peer extends EventEmitter {
     };
 
     const msg = stringify(body);
-    const msgHash = crypto.createHash('sha256').update(msg).digest();
+    const msgHash = createHash('sha256').update(msg).digest();
     const { signature } = secp256k1.sign(msgHash, nodeKey.nodePrivKey);
 
     body = { ...body, sign: signature.toString('hex') };

--- a/lib/p2p/packets/Packet.ts
+++ b/lib/p2p/packets/Packet.ts
@@ -1,5 +1,5 @@
 import PacketType from './PacketType';
-import crypto from 'crypto';
+import { createHash } from 'crypto';
 import uuidv1 from 'uuid/v1';
 import stringify from 'json-stable-stringify';
 
@@ -107,8 +107,7 @@ abstract class Packet<T = any> implements PacketInterface {
    * Calculating the packet checksum using its JSON representation hash first 4 bytes.
    */
   public checksum = (): number => {
-    return crypto
-      .createHash('sha256')
+    return createHash('sha256')
       .update(this.toJSON())
       .digest()
       .readUInt32LE(0, true);

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import p2pErrors from '../p2p/errors';
 import { Pair, Order } from '../orderbook/types';
-import crypto, { createHash } from 'crypto';
+import { createHash, randomBytes as cryptoRandomBytes } from 'crypto';
 import { promisify } from 'util';
 import moment from 'moment';
 
@@ -147,7 +147,7 @@ export const isPlainObject = (obj: any) => {
 export const setTimeoutPromise = promisify(setTimeout);
 
 /** A promisified wrapper for the NodeJS `crypto.randomBytes` method. */
-export const randomBytes = promisify(crypto.randomBytes);
+export const randomBytes = promisify(cryptoRandomBytes);
 
 export const removeUndefinedProps = (obj: any) => {
   Object.keys(obj).forEach((key) => {

--- a/test/crypto/handshake.ts
+++ b/test/crypto/handshake.ts
@@ -1,14 +1,14 @@
-import crypto from 'crypto';
-import secp256k1 from 'secp256k1';
-import NodeKey from '../../lib/nodekey/NodeKey';
 import { expect } from 'chai';
+import secp256k1 from 'secp256k1';
+import { createECDH, randomBytes, createCipheriv, createDecipheriv, createHash } from 'crypto';
+import NodeKey from '../../lib/nodekey/NodeKey';
 
 describe('key exchange and symmetric encryption', () => {
   let secretKey: Buffer;
 
   it('alice and bob should successfully exchange shared secret key', async () => {
-    const alice = crypto.createECDH('secp256k1');
-    const bob = crypto.createECDH('secp256k1');
+    const alice = createECDH('secp256k1');
+    const bob = createECDH('secp256k1');
 
     // alice and bob create an ephemeral key pair for the key exchange
     const aliceEphemeralPubKey = alice.generateKeys();
@@ -25,13 +25,13 @@ describe('key exchange and symmetric encryption', () => {
   });
 
   it('alice should encrypt messages that bob can decrypt', async () => {
-    const msg = crypto.randomBytes(100);
+    const msg = randomBytes(100);
 
-    const iv = crypto.randomBytes(16);
-    const cipher = crypto.createCipheriv('aes-256-cbc', secretKey, iv);
+    const iv = randomBytes(16);
+    const cipher = createCipheriv('aes-256-cbc', secretKey, iv);
     const encrypted = Buffer.concat([iv, cipher.update(msg), cipher.final()]);
 
-    const decipher = crypto.createDecipheriv('aes-256-cbc', secretKey, encrypted.slice(0, 16));
+    const decipher = createDecipheriv('aes-256-cbc', secretKey, encrypted.slice(0, 16));
     const decrypted = Buffer.concat([decipher.update(encrypted.slice(16)), decipher.final()]);
 
     expect(msg.toString('hex')).to.be.equal(decrypted.toString('hex'));
@@ -44,7 +44,7 @@ describe('authentication', () => {
     const aliceNodePubKey = aliceNodeKey.nodePubKey;
     const aliceNodePrivKey = aliceNodeKey['privKey'];
 
-    const alice = crypto.createECDH('secp256k1');
+    const alice = createECDH('secp256k1');
     const aliceEphemeralPubKey = alice.generateKeys();
 
     const msg = {
@@ -52,8 +52,7 @@ describe('authentication', () => {
       ephemeralPubKey: aliceEphemeralPubKey,
     };
 
-    const msgHash = crypto
-      .createHash('sha256')
+    const msgHash = createHash('sha256')
       .update(JSON.stringify(msg))
       .digest();
 

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import crypto from 'crypto';
+import { randomBytes } from 'crypto';
 import Parser from '../../lib/p2p/Parser';
 import { Packet, PacketType } from '../../lib/p2p/packets';
 import * as packets from '../../lib/p2p/packets/types';
@@ -20,7 +20,7 @@ describe('Parser', () => {
   const timeoutError = 'timeout';
   const network = new Network(XuNetwork.SimNet);
   const framer = new Framer(network);
-  const encryptionKey = crypto.randomBytes(Framer.ENCRYPTION_KEY_LENGTH);
+  const encryptionKey = randomBytes(Framer.ENCRYPTION_KEY_LENGTH);
   const rHash = '62c8bbef4587cff4286246e63044dc3e454b5693fb5ebd0171b7e58644bfafe2';
   let parser: Parser;
 


### PR DESCRIPTION
When running XUD with Node `v10.16.0` (latest LTS) I got this deprecation warnings:

```
(node:7546) [DEP0091] DeprecationWarning: crypto.DEFAULT_ENCODING is deprecated.
(node:7546) [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead.
(node:7546) [DEP0011] DeprecationWarning: crypto.Credentials is deprecated. Use tls.SecureContext instead.
```

This PR removes them by not importing everything from `crypto` but just the functions that are needed.