### PR TITLE
fix(cli): quantity rounding

### DIFF
--- a/lib/cli/commands/executeswap.ts
+++ b/lib/cli/commands/executeswap.ts
@@ -1,7 +1,7 @@
 import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { ExecuteSwapRequest } from '../../proto/xudrpc_pb';
-import { SATOSHIS_PER_COIN } from '../utils';
+import { coinsToSats } from '../utils';
 
 export const command = 'executeswap <pair_id> <order_id> [quantity]';
 
@@ -24,6 +24,6 @@ export const handler = (argv: Arguments) => {
   const request = new ExecuteSwapRequest();
   request.setOrderId(argv.order_id);
   request.setPairId(argv.pair_id);
-  request.setQuantity(argv.quantity * SATOSHIS_PER_COIN);
+  request.setQuantity(coinsToSats(argv.quantity));
   loadXudClient(argv).executeSwap(request, callback(argv));
 };

--- a/lib/cli/commands/listorders.ts
+++ b/lib/cli/commands/listorders.ts
@@ -3,7 +3,7 @@ import { callback, loadXudClient } from '../command';
 import { ListOrdersRequest, ListOrdersResponse, Order } from '../../proto/xudrpc_pb';
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
-import { SATOSHIS_PER_COIN } from '../utils';
+import { satsToCoinsStr } from '../utils';
 
 type FormattedTradingPairOrders = {
   pairId: string,
@@ -30,7 +30,7 @@ const addSide = (orderSide: Order.AsObject[]): string[] => {
   if (order) {
     const isOwn = order.isOwnOrder ? 'X' : '';
     return [
-      (order.quantity / SATOSHIS_PER_COIN).toFixed(8),
+      satsToCoinsStr(order.quantity),
       order.price.toString(),
       isOwn,
     ].map(i => order.isOwnOrder ? colors.cyan(i) : i);

--- a/lib/cli/commands/removeorder.ts
+++ b/lib/cli/commands/removeorder.ts
@@ -1,7 +1,7 @@
 import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
 import { RemoveOrderRequest } from '../../proto/xudrpc_pb';
-import { SATOSHIS_PER_COIN } from '../utils';
+import { coinsToSats } from '../utils';
 
 export const command = 'removeorder <order_id> [quantity]';
 
@@ -21,7 +21,7 @@ export const handler = (argv: Arguments) => {
   const request = new RemoveOrderRequest();
   request.setOrderId(argv.order_id);
   if (argv.quantity) {
-    request.setQuantity(argv.quantity * SATOSHIS_PER_COIN);
+    request.setQuantity(coinsToSats(argv.quantity));
   }
   loadXudClient(argv).removeOrder(request, callback(argv));
 };

--- a/lib/cli/utils.ts
+++ b/lib/cli/utils.ts
@@ -2,7 +2,17 @@ import { Arguments, Argv } from 'yargs';
 import { callback, loadXudClient } from './command';
 import { PlaceOrderRequest, PlaceOrderEvent, OrderSide, PlaceOrderResponse, Order, SwapSuccess, SwapFailure } from '../proto/xudrpc_pb';
 
-export const SATOSHIS_PER_COIN = 10 ** 8;
+const SATOSHIS_PER_COIN = 10 ** 8;
+
+/** Returns a number of coins as an integer number of satoshis. */
+export const coinsToSats = (coinsQuantity: number) => {
+  return Math.round(coinsQuantity * SATOSHIS_PER_COIN);
+};
+
+/** Returns a number of satoshis as a string representation of coins with up to 8 decimal places. */
+export const satsToCoinsStr = (satsQuantity: number) => {
+  return (satsQuantity / SATOSHIS_PER_COIN).toFixed(8).replace(/\.?0+$/, '');
+};
 
 export const orderBuilder = (argv: Argv, command: string) => argv
   .option('quantity', {
@@ -35,7 +45,7 @@ export const orderHandler = (argv: Arguments, isSell = false) => {
   const numericPrice = Number(argv.price);
   const priceStr = argv.price.toLowerCase();
 
-  request.setQuantity(argv.quantity * SATOSHIS_PER_COIN);
+  request.setQuantity(coinsToSats(argv.quantity));
   request.setSide(isSell ? OrderSide.SELL : OrderSide.BUY);
   request.setPairId(argv.pair_id.toUpperCase());
 
@@ -97,22 +107,22 @@ const formatPlaceOrderOutput = (response: PlaceOrderResponse.AsObject) => {
 
 const formatInternalMatch = (order: Order.AsObject) => {
   const baseCurrency = getBaseCurrency(order.pairId);
-  console.log(`matched ${order.quantity / SATOSHIS_PER_COIN} ${baseCurrency} @ ${order.price} with own order ${order.id}`);
+  console.log(`matched ${satsToCoinsStr(order.quantity)} ${baseCurrency} @ ${order.price} with own order ${order.id}`);
 };
 
 const formatSwapSuccess = (swapSuccess: SwapSuccess.AsObject) => {
   const baseCurrency = getBaseCurrency(swapSuccess.pairId);
-  console.log(`swapped ${swapSuccess.quantity / SATOSHIS_PER_COIN} ${baseCurrency} with peer order ${swapSuccess.orderId}`);
+  console.log(`swapped ${satsToCoinsStr(swapSuccess.quantity)} ${baseCurrency} with peer order ${swapSuccess.orderId}`);
 };
 
 const formatSwapFailure = (swapFailure: SwapFailure.AsObject) => {
   const baseCurrency = getBaseCurrency(swapFailure.pairId);
-  console.log(`failed to swap ${swapFailure.quantity / SATOSHIS_PER_COIN} ${baseCurrency} with peer order ${swapFailure.orderId}`);
+  console.log(`failed to swap ${satsToCoinsStr(swapFailure.quantity)} ${baseCurrency} with peer order ${swapFailure.orderId}`);
 };
 
 const formatRemainingOrder = (order: Order.AsObject) => {
   const baseCurrency = getBaseCurrency(order.pairId);
-  console.log(`remaining ${order.quantity / SATOSHIS_PER_COIN} ${baseCurrency} entered the order book as ${order.id}`);
+  console.log(`remaining ${satsToCoinsStr(order.quantity)} ${baseCurrency} entered the order book as ${order.id}`);
 };
 
 const getBaseCurrency = (pairId: string) => pairId.substring(0, pairId.indexOf('/'));

--- a/test/unit/Command.spec.ts
+++ b/test/unit/Command.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { formatOrders } from '../../lib/cli/commands/listorders';
 import { ListOrdersResponse } from '../../lib/proto/xudrpc_pb';
+import { satsToCoinsStr, coinsToSats } from '../../lib/cli/utils';
 
 describe('Command.listorders.formatOrders', () => {
   it('should flatten and format orders', () => {
@@ -105,5 +106,23 @@ describe('Command.listorders.formatOrders', () => {
     expect(output.length).to.equal(1);
     expect(output[0].pairId).to.equal('LTC/BTC');
     expect(output[0].orders.length).to.equal(5);
+  });
+});
+
+describe('Satoshi/Coin conversion', () => {
+  it('should convert satoshis to coins as strings with up to 8 decimal places', () => {
+    expect(satsToCoinsStr(123456789)).to.deep.equal('1.23456789');
+    expect(satsToCoinsStr(1234567890000)).to.deep.equal('12345.6789');
+    expect(satsToCoinsStr(123456789.1234)).to.deep.equal('1.23456789');
+    expect(satsToCoinsStr(123450000)).to.deep.equal('1.2345');
+    expect(satsToCoinsStr(100000000)).to.deep.equal('1');
+  });
+
+  it('should convert coins to satoshis as integers', () => {
+    expect(coinsToSats(1.23456789)).to.deep.equal(123456789);
+    expect(coinsToSats(12345.6789)).to.deep.equal(1234567890000);
+    expect(coinsToSats(1.234567891234)).to.deep.equal(123456789);
+    expect(coinsToSats(1.2345)).to.deep.equal(123450000);
+    expect(coinsToSats(1)).to.deep.equal(100000000);
   });
 });


### PR DESCRIPTION
This fixes edge case rounding errors when converting cli arguments like `2.3 * 100000000 = 229999999.99999997`. It creates conversion methods between coins and satoshis as well as unit tests for those methods.

Fixes #1015.