### PR TITLE
fix: blockheight prop of `undefined` in GetInfo

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -382,9 +382,9 @@ class GrpcService {
         return lnd;
       });
       const lndMap = response.getLndMap();
-      for (const currency in getInfoResponse.lnd) {
-        lndMap.set(currency, getLndInfo(getInfoResponse.lnd[currency]!));
-      }
+      getInfoResponse.lnd.forEach((lndInfo, currency) => {
+        lndMap.set(currency, getLndInfo(lndInfo));
+      });
 
       if (getInfoResponse.raiden) {
         const raiden = new xudrpc.RaidenInfo();

--- a/lib/lndclient/types.ts
+++ b/lib/lndclient/types.ts
@@ -39,5 +39,3 @@ export type LndLogger = {
   debug: Function,
   trace: Function,
 };
-
-export type LndInfos = { [currency: string]: LndInfo | undefined };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -35,7 +35,7 @@ type XudInfo = {
   numPeers: number;
   numPairs: number;
   orders: { peer: number, own: number};
-  lnd: { [currency: string]: LndInfo | undefined };
+  lnd: Map<string, LndInfo>;
   raiden?: RaidenInfo;
 };
 


### PR DESCRIPTION
This fixes a bug where xud tries to read a property of `undefined` when an instance of `LndClient` is disabled. This refactors the code to use a `Map` when retrieving a mapping of `LndInfo` objects, and also calls `GetInfo` in parallel on all `LndClient`s.

Fixes #1011.