### PR TITLE
feat: add backup daemon

### DIFF
--- a/bin/xud-backup
+++ b/bin/xud-backup
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const Backup = require('../dist/backup/Backup').default;
+
+const { argv } = require('yargs')
+  .options({
+    backupdir: {
+      describe: 'Data directory for backups',
+      type: 'string',
+      alias: 'b',
+    },
+    xudir: {
+      describe: 'Data directory for xud',
+      type: 'string',
+      alias: 'x',
+    },
+    dbpath: {
+      describe: 'Path to the XUD database',
+      type: 'string',
+      alias: 'd',
+    },
+    loglevel: {
+      describe: 'Verbosity of the logger',
+      type: 'string',
+      alias: 'l',
+    },
+    logpath: {
+      describe: 'Path to the log file',
+      type: 'string',
+    },
+    logdateformat: {
+      describe: 'Format of the logger date',
+      type: 'string',
+    },
+    'lnd.[currency].certpath': {
+      describe: 'Path to the SSL certificate for lnd',
+      type: 'string',
+    },
+    'lnd.[currency].cltvdelta': {
+      describe: 'CLTV delta for the final timelock',
+      type: 'number',
+    },
+    'lnd.[currency].disable': {
+      describe: 'Disable lnd integration',
+      type: 'boolean',
+      default: undefined,
+    },
+    'lnd.[currency].host': {
+      describe: 'Host of the lnd gRPC interface',
+      type: 'string',
+    },
+    'lnd.[currency].macaroonpath': {
+      describe: 'Path of the admin macaroon for lnd',
+      type: 'string',
+    },
+    'lnd.[currency].nomacaroons': {
+      describe: 'Whether to disable macaroons for lnd',
+      type: 'boolean',
+      default: undefined,
+    },
+    'lnd.[currency].port': {
+      describe: 'Port for the lnd gRPC interface',
+      type: 'number',
+    },
+    'raiden.dbpath': {
+      describe: 'Path to the database of Raiden',
+      type: 'string',
+    },
+  });
+
+// delete non-config keys from argv
+delete argv._;
+delete argv.version;
+delete argv.help;
+delete argv.$0;
+
+const backup = new Backup();
+
+backup.start(argv);

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -31,6 +31,7 @@ export enum Context {
   Raiden = 'RAIDEN',
   Swaps = 'SWAPS',
   Http = 'HTTP',
+  Backup = 'BACKUP',
 }
 
 type Loggers = {

--- a/lib/backup/Backup.ts
+++ b/lib/backup/Backup.ts
@@ -1,0 +1,181 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import Config from '../Config';
+import Logger, { Context } from '../Logger';
+import LndClient from '../lndclient/LndClient';
+
+class Backup {
+  private logger!: Logger;
+  private config = new Config();
+
+  private backupDir!: string;
+
+  private fileWatchers: fs.FSWatcher[] = [];
+  private lndClients: LndClient[] = [];
+
+  public start = async (args: { [argName: string]: any }) => {
+    await this.config.load(args);
+
+    this.backupDir = args.backupdir || this.getDefaultBackupDir();
+
+    this.logger = new Logger({
+      context: Context.Backup,
+      level: this.config.loglevel,
+      filename: this.config.logpath,
+      instanceId: this.config.instanceid,
+      dateFormat: this.config.logdateformat,
+    });
+
+    if (!fs.existsSync(this.backupDir)) {
+      try {
+        fs.mkdirSync(this.backupDir);
+      } catch (error) {
+        this.logger.error(`Could not create backup directory: ${error}`);
+        return;
+      }
+    }
+
+    try {
+      await this.startLndSubscriptions();
+    } catch (error) {
+      this.logger.error(`Could not connect to LNDs: ${error}`);
+    }
+
+    // Start the Raiden database filewatcher
+    if (args.raiden) {
+      this.startFilewatcher('raiden', args.raiden.dbpath);
+    } else {
+      this.logger.warn('Raiden database file not specified');
+    }
+
+    // Start the XUD database filewatcher
+    this.startFilewatcher('xud', this.config.dbpath);
+
+    this.logger.info('Started backup daemon');
+  }
+
+  public stop = async () => {
+    this.fileWatchers.forEach((watcher) => {
+      watcher.close();
+    });
+
+    for (const lndClient of this.lndClients) {
+      await lndClient.close();
+    }
+  }
+
+  private startLndSubscriptions = async () => {
+    // Start the LND SCB subscriptions
+    for (const currency in this.config.lnd) {
+      const config = this.config.lnd[currency]!;
+
+      // Ignore the LND client if it is disabled or not configured
+      if (!config.disable && Object.entries(config).length !== 0) {
+        const lndClient = new LndClient({
+          config,
+          currency,
+          logger: Logger.DISABLED_LOGGER,
+        });
+
+        this.lndClients.push(lndClient);
+
+        await lndClient.init();
+
+        const backupPath = this.getBackupPath('lnd', lndClient.currency);
+
+        this.logger.verbose(`Writing initial ${lndClient.currency} LND channel backup to: ${backupPath}`);
+
+        const channelBackup = await lndClient.exportAllChannelBackup();
+        this.writeBackup(backupPath, channelBackup);
+
+        this.listenToChannelBackups(lndClient);
+
+        lndClient.subscribeChannelBackups();
+        this.logger.verbose(`Listening to ${currency} LND channel backups`);
+      }
+    }
+  }
+
+  private listenToChannelBackups = (lndClient: LndClient) => {
+    const backupPath = this.getBackupPath('lnd', lndClient.currency);
+
+    lndClient.on('channelBackup', (channelBackup) => {
+      this.logger.debug(`New ${lndClient.currency} channel backup`);
+      this.writeBackup(backupPath, channelBackup);
+    });
+  }
+
+  private startFilewatcher = (client: string, dbPath: string) => {
+    if (fs.existsSync(dbPath)) {
+      const backupPath = this.getBackupPath(client);
+
+      this.logger.verbose(`Writing initial ${client} database backup to: ${backupPath}`);
+      const { content, hash } = this.readDatabase(dbPath);
+
+      let previousDatabaseHash = hash;
+      this.writeBackup(backupPath, content);
+
+      this.fileWatchers.push(fs.watch(dbPath, { persistent: true, recursive: false }, (event: string) => {
+        if (event === 'change') {
+          const { content, hash } = this.readDatabase(dbPath);
+
+          // Compare the MD5 hash of the current content of the file with hash of the content when
+          // it was backed up the last time to ensure that the content of the file has changed
+          if (hash !== previousDatabaseHash) {
+            this.logger.debug(`${client} database changed`);
+
+            previousDatabaseHash = hash;
+            this.writeBackup(backupPath, content);
+          }
+        }
+      }));
+
+      this.logger.verbose(`Listening for changes to the ${client} database`);
+    } else {
+      this.logger.error(`Could not find database file of ${client}: ${dbPath}`);
+    }
+  }
+
+  private readDatabase = (path: string): { content: string, hash: string } => {
+    const content = fs.readFileSync(path, 'utf8');
+
+    return {
+      content,
+      hash: createHash('md5').update(content).digest('base64'),
+    };
+  }
+
+  private writeBackup = (backupPath: string, data: string) => {
+    try {
+      fs.writeFileSync(
+        backupPath,
+        data,
+      );
+    } catch (error) {
+      this.logger.error(`Could not write backup file: ${error}`);
+    }
+  }
+
+  private getBackupPath = (client: string, currency?: string) => {
+    let clientName = client;
+
+    if (currency) {
+      clientName += `-${currency}`;
+    }
+
+    return path.join(this.backupDir, clientName);
+  }
+
+  private getDefaultBackupDir = () => {
+    switch (os.platform()) {
+      case 'win32':
+        return path.join(process.env.LOCALAPPDATA!, 'Xud Backup');
+      default:
+        return path.join(process.env.HOME!, '.xud-backup');
+    }
+  }
+}
+
+export default Backup;

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -18,9 +18,12 @@ import path from 'path';
 interface LndClient {
   on(event: 'connectionVerified', listener: (swapClientInfo: SwapClientInfo) => void): this;
   on(event: 'htlcAccepted', listener: (rHash: string, amount: number) => void): this;
+  on(event: 'channelBackup', listener: (channelBackup: string) => void): this;
   on(event: 'locked', listener: () => void): this;
+
   emit(event: 'connectionVerified', swapClientInfo: SwapClientInfo): boolean;
   emit(event: 'htlcAccepted', rHash: string, amount: number): boolean;
+  emit(event: 'channelBackup', channelBackup: string): boolean;
   emit(event: 'locked'): boolean;
 }
 
@@ -45,6 +48,7 @@ class LndClient extends SwapClient {
   private urisList?: string[];
   /** The identifier for the chain this lnd instance is using in the format [chain]-[network] like "bitcoin-testnet" */
   private chainIdentifier?: string;
+  private channelBackupSubscription?: ClientReadableStream<lndrpc.ChanBackupSnapshot>;
   private invoiceSubscriptions = new Map<string, ClientReadableStream<lndrpc.Invoice>>();
   private maximumOutboundAmount = 0;
   private initWalletResolve?: (value: boolean) => void;
@@ -821,6 +825,13 @@ class LndClient extends SwapClient {
     return this.unaryCall<lndrpc.ListPaymentsRequest, lndrpc.ListPaymentsResponse>('listPayments', request);
   }
 
+  public exportAllChannelBackup = async () => {
+    const request = new lndrpc.ChanBackupExportRequest();
+    const response = await this.unaryCall<lndrpc.ChanBackupExportRequest, lndrpc.ChanBackupSnapshot>('exportAllChannelBackups', request);
+
+    return response.getMultiChanBackup()!.getMultiChanBackup_asB64();
+  }
+
   private addHoldInvoice = (request: lndinvoices.AddHoldInvoiceRequest): Promise<lndinvoices.AddHoldInvoiceResp> => {
     return this.unaryInvoiceCall<lndinvoices.AddHoldInvoiceRequest, lndinvoices.AddHoldInvoiceResp>('addHoldInvoice', request);
   }
@@ -852,6 +863,29 @@ class LndClient extends SwapClient {
       }
     }).on('end', deleteInvoiceSubscription).on('error', deleteInvoiceSubscription);
     this.invoiceSubscriptions.set(rHash, invoiceSubscription);
+  }
+
+  /**
+   * Subscribes to channel backups
+   */
+  public subscribeChannelBackups = () => {
+    if (!this.lightning) {
+      throw errors.UNAVAILABLE(this.currency, this.status);
+    }
+
+    if (this.channelBackupSubscription) {
+      return;
+    }
+
+    const deleteChannelBackupSubscription = () => {
+      this.channelBackupSubscription = undefined;
+    };
+
+    this.channelBackupSubscription = this.lightning.subscribeChannelBackups(new lndrpc.ChannelBackupSubscription(), this.meta)
+      .on('data', (backupSnapshot: lndrpc.ChanBackupSnapshot) => {
+        const multiBackup = backupSnapshot.getMultiChanBackup()!;
+        this.emit('channelBackup', multiBackup.getMultiChanBackup_asB64());
+      }).on('end', deleteChannelBackupSubscription).on('error', deleteChannelBackupSubscription);
   }
 
   /**


### PR DESCRIPTION
Closes #917 

This PR adds `xu-backup` that starts listening for new LND SCBs and writing them to the disk when executed.

I am not finished yet and have some things to do before this backup daemon can be used but please have a look at this PR nevertheless to acknowledge the concept and give me some feedback on what I have been doing in this branch. 

Todo:
- [x] Raiden database backup (just copying the file is the recommended way of the Raiden devs)
- [x] XUD database backup
- [x] write SCB of all LNDs and Raiden database backup to disk on startup
- [x] writing unit/integration tests
- [ ] intensive manual testing

@kilrau we agreed on not implementing a restoring feature for now, right?