### PR TITLE
secrethash and not secret_hash

### DIFF
--- a/lib/http/HttpService.ts
+++ b/lib/http/HttpService.ts
@@ -6,7 +6,7 @@ class HttpService {
 
   public resolveHashRaiden = async (resolveRequest: RaidenResolveRequest): Promise<RaidenResolveResponse> => {
     const secret = await this.service.resolveHash({
-      rHash: resolveRequest.secret_hash.slice(2),
+      rHash: resolveRequest.secrethash.slice(2),
       amount: resolveRequest.amount,
     });
     return { secret };

--- a/lib/raidenclient/types.ts
+++ b/lib/raidenclient/types.ts
@@ -63,8 +63,8 @@ export type TokenPaymentRequest = {
 export type RaidenResolveRequest = {
   /** The token address for the resolve request in hex. */
   token: string;
-  /** The payment hash in hex. */
-  secret_hash: string;
+  /** The payment hash in hex with 0x prefix. */
+  secrethash: string;
   /** The amount of the incoming payment pending resolution, in the smallest units supported by the token. */
   amount: number;
   // unused fields on the raiden request listed below, taken from raiden codebase

--- a/test/jest/HttpService.spec.ts
+++ b/test/jest/HttpService.spec.ts
@@ -7,7 +7,7 @@ const mockedService = <jest.Mock<Service>><any>Service;
 const secretHash = '2ea852a816e4390f1468b9b1389be14e3a965479beb2c97354a409993eb52e46';
 const resolveRequest = {
   token: '0x4c354c76d5f73a63a90be776897dc81fb6238772',
-  secret_hash: `0x${secretHash}`,
+  secrethash: `0x${secretHash}`,
   amount: 1,
 };
 
@@ -24,7 +24,7 @@ describe('HttpService', () => {
     jest.clearAllMocks();
   });
 
-  test('removes 0x from RaidenResolveRequest\'s secret_hash', async () => {
+  test('removes 0x from RaidenResolveRequest\'s secrethash', async () => {
     httpService = new HttpService(service);
     await httpService.resolveHashRaiden(resolveRequest);
     expect(service.resolveHash)

--- a/test/unit/HttpServer.spec.ts
+++ b/test/unit/HttpServer.spec.ts
@@ -21,7 +21,7 @@ describe('HttpServer', () => {
   let port: number;
 
   const amount = 10;
-  const secret_hash = 'rhash';
+  const secrethash = 'rhash';
   const token = 'contractaddress';
   const preimage = 'rpreimage';
 
@@ -40,7 +40,7 @@ describe('HttpServer', () => {
   it('should receive and parse a raiden resolve request', (done) => {
     chai.request(`http://localhost:${port}`)
       .post('/resolveraiden')
-      .send({ amount, secret_hash, token })
+      .send({ amount, secrethash, token })
       .then((res: ChaiHttp.Response) => {
         expect(res.status).to.equal(200);
         expect(res).to.be.json;
@@ -54,7 +54,7 @@ describe('HttpServer', () => {
   it('should return not found 404 when wrong secret hash provided', (done) => {
     chai.request(`http://localhost:${port}`)
       .post('/resolveraiden')
-      .send({ amount, token, secret_hash: '0xwronghash' })
+      .send({ amount, token, secrethash: '0xwronghash' })
       .then((res: ChaiHttp.Response) => {
         expect(res.status).to.equal(404);
         done();
@@ -90,7 +90,7 @@ describe('HttpServer', () => {
   it('should 404 if a bad path is used', (done) => {
     chai.request(`http://localhost:${port}`)
       .post('/badendpoint')
-      .send({ amount, secret_hash, token })
+      .send({ amount, secrethash, token })
       .then((res: ChaiHttp.Response) => {
         expect(res.status).to.equal(404);
         done();


### PR DESCRIPTION
raiden is using secrethash when invoking the resolver and not secret_hash

This is needed to resolve #986 