### PR TITLE
 fix(lndclient): unknown service lnrpc.Lightning

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -48,7 +48,7 @@ const { argv } = require('yargs')
       default: undefined,
     },
     noencrypt: {
-      describe: 'Whether to disable xud nodekey encription',
+      describe: 'Whether to disable nodekey encryption',
       type: 'boolean',
       default: undefined,
     },

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -38,7 +38,7 @@ class Xud extends EventEmitter {
   private grpcAPIProxy?: GrpcWebProxyServer;
   private swaps!: Swaps;
   private shuttingDown = false;
-  private swapClientManager!: SwapClientManager;
+  private swapClientManager?: SwapClientManager;
 
   /**
    * Create an Exchange Union daemon.
@@ -184,10 +184,12 @@ class Xud extends EventEmitter {
     this.shuttingDown = true;
     this.logger.info('XUD is shutting down');
 
-    this.swapClientManager.close();
     // TODO: ensure we are not in the middle of executing any trades
     const closePromises: Promise<void>[] = [];
 
+    if (this.swapClientManager) {
+      closePromises.push(this.swapClientManager.close());
+    }
     if (this.httpServer) {
       closePromises.push(this.httpServer.close());
     }

--- a/lib/lndclient/errors.ts
+++ b/lib/lndclient/errors.ts
@@ -1,4 +1,5 @@
 import errorCodesPrefix from '../constants/errorCodesPrefix';
+import { ClientStatus } from '../swaps/SwapClient';
 
 const codesPrefix = errorCodesPrefix.LND;
 const errorCodes = {
@@ -11,10 +12,10 @@ const errors = {
     message: 'lnd is disabled',
     code: errorCodes.LND_IS_DISABLED,
   },
-  LND_IS_UNAVAILABLE: {
-    message: 'lnd is not available',
+  LND_IS_UNAVAILABLE: (status: ClientStatus) => ({
+    message: `lnd is ${ClientStatus[status]}`,
     code: errorCodes.LND_IS_UNAVAILABLE,
-  },
+  }),
 };
 
 export { errorCodes };

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -82,7 +82,7 @@ class RaidenClient extends SwapClient {
         `could not verify connection to raiden at ${this.host}:${this.port}, retrying in ${RaidenClient.RECONNECT_TIMER} ms`,
         err,
       );
-      await this.setStatus(ClientStatus.Disconnected);
+      await this.disconnect();
     }
   }
 
@@ -351,7 +351,9 @@ class RaidenClient extends SwapClient {
   }
 
   /** Raiden client specific cleanup. */
-  protected closeSpecific() {}
+  protected disconnect = async () => {
+    await this.setStatus(ClientStatus.Disconnected);
+  }
 }
 
 export default RaidenClient;

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -138,18 +138,21 @@ abstract class SwapClient extends EventEmitter {
   public isWaitingUnlock(): boolean {
     return this.status === ClientStatus.WaitingUnlock;
   }
+  public isNotInitialized(): boolean {
+    return this.status === ClientStatus.NotInitialized;
+  }
   /** Ends all connections, subscriptions, and timers for for this client. */
-  public close() {
+  public async close() {
+    await this.disconnect();
     if (this.reconnectionTimer) {
       clearTimeout(this.reconnectionTimer);
     }
     if (this.updateCapacityTimer) {
       clearInterval(this.updateCapacityTimer);
     }
-    this.closeSpecific();
     this.removeAllListeners();
   }
-  protected abstract closeSpecific(): void;
+  protected abstract async disconnect(): Promise<void>;
 }
 
 export default SwapClient;

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -133,7 +133,7 @@ describe('Swaps.SwapClientManager', () => {
     expect(onListenerMock).toHaveBeenCalledTimes(4);
     expect(swapClientManager.get('BTC')).not.toBeUndefined();
     expect(swapClientManager.get('LTC')).not.toBeUndefined();
-    swapClientManager.close();
+    await swapClientManager.close();
     expect(closeMock).toHaveBeenCalledTimes(2);
   });
 
@@ -146,7 +146,7 @@ describe('Swaps.SwapClientManager', () => {
     expect(swapClientManager['swapClients'].size).toEqual(1);
     expect(onListenerMock).toHaveBeenCalledTimes(2);
     expect(swapClientManager.get('BTC')).not.toBeUndefined();
-    swapClientManager.close();
+    await swapClientManager.close();
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
 
@@ -160,7 +160,7 @@ describe('Swaps.SwapClientManager', () => {
     expect(onListenerMock).toHaveBeenCalledTimes(0);
     expect(swapClientManager.get('BTC')).toBeUndefined();
     expect(swapClientManager.get('WETH')).toBeUndefined();
-    swapClientManager.close();
+    await swapClientManager.close();
     expect(closeMock).toHaveBeenCalledTimes(0);
   });
 
@@ -170,7 +170,7 @@ describe('Swaps.SwapClientManager', () => {
     swapClientManager = new SwapClientManager(config, loggers);
     await swapClientManager.init(db.models);
     expect(swapClientManager['swapClients'].size).toEqual(3);
-    swapClientManager.close();
+    await swapClientManager.close();
     expect(closeMock).toHaveBeenCalledTimes(3);
   });
 


### PR DESCRIPTION
This fixes an issue where attempting a `GetInfo` call to lnd while lnd is locked results in an `UNIMPLEMENTED` grpc error that persists even after lnd has been unlocked and the `GetInfo` call becomes available. We close grpc clients after connection verification attempts so that we have a fresh start for future attempts

Fixes #1039.