### PR TITLE
feat(logger): optional subcontext

### DIFF
--- a/lib/lndclient/types.ts
+++ b/lib/lndclient/types.ts
@@ -30,12 +30,3 @@ export type Chain = {
   network: string,
   chain: string,
 };
-
-export type LndLogger = {
-  error: Function,
-  warn: Function,
-  info: Function,
-  verbose: Function,
-  debug: Function,
-  trace: Function,
-};

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -1,9 +1,9 @@
 import Config from '../Config';
 import SwapClient from './SwapClient';
 import LndClient from '../lndclient/LndClient';
-import { LndLogger, LndInfo } from '../lndclient/types';
+import { LndInfo } from '../lndclient/types';
 import RaidenClient from '../raidenclient/RaidenClient';
-import Logger, { Loggers } from '../Logger';
+import { Loggers } from '../Logger';
 import { errors } from './errors';
 import { Currency } from '../orderbook/types';
 import { Models } from '../db/DB';
@@ -42,21 +42,6 @@ class SwapClientManager extends EventEmitter {
   }
 
   /**
-   * Wraps each lnd logger call with currency.
-   * @returns A wrapped lnd logger object.
-   */
-  private static wrapLndLogger = (logger: Logger, currency: string): LndLogger => {
-    return {
-      error: (msg: string) => logger.error(`${currency}: ${msg}`),
-      warn: (msg: string) => logger.warn(`${currency}: ${msg}`),
-      info: (msg: string) => logger.info(`${currency}: ${msg}`),
-      verbose: (msg: string) => logger.verbose(`${currency}: ${msg}`),
-      debug: (msg: string) => logger.debug(`${currency}: ${msg}`),
-      trace: (msg: string) => logger.trace(`${currency}: ${msg}`),
-    };
-  }
-
-  /**
    * Starts all swap clients, binds event listeners
    * and waits for the swap clients to initialize.
    * @returns A promise that resolves upon successful initialization, rejects otherwise.
@@ -70,7 +55,7 @@ class SwapClientManager extends EventEmitter {
         const lndClient = new LndClient(
           lndConfig,
           currency,
-          (SwapClientManager.wrapLndLogger(this.loggers.lnd, currency) as Logger),
+          this.loggers.lnd.createSubLogger(currency),
         );
         this.swapClients.set(currency, lndClient);
         initPromises.push(lndClient.init());

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -16,7 +16,13 @@ jest.mock('../../lib/db/DB', () => {
   });
 });
 jest.mock('../../lib/Config');
-jest.mock('../../lib/Logger');
+jest.mock('../../lib/Logger', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      createSubLogger: () => {},
+    };
+  });
+});
 jest.mock('../../lib/nodekey/NodeKey');
 const mockLndPubKey = 1;
 const lndInfoMock = jest.fn(() => Promise.resolve());


### PR DESCRIPTION
This adds an optional subcontext for loggers to print on every log statement. This is used in place of wrapping the log methods for the lnd loggers to display currency, but can also be reused in a generic fashion going forward.

Before:

```
19/06/2019 15:44:43.634 [LND] info: BTC: trying to verify connection...
```

After:

```
19/06/2019 15:44:43.634 [LND-BTC] info: trying to verify connection...
```

This is an offshoot of #1039.