### PR TITLE
feat: token identifiers for currencies

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -35,8 +35,8 @@ interface Peer {
   on(event: 'packet', listener: (packet: Packet) => void): this;
   on(event: 'error', listener: (err: Error) => void): this;
   on(event: 'reputation', listener: (event: ReputationEvent) => void): this;
-  /** Adds a listener to be called when the peer has newly advertised pairs. */
-  on(event: 'pairsAdvertised', listener: (pairIds: string[]) => void): this;
+  /** Adds a listener to be called when the peer's advertised but inactive pairs should be verified. */
+  on(event: 'verifyPairs', listener: () => void): this;
   /** Adds a listener to be called when a previously active pair is dropped by the peer or deactivated. */
   on(event: 'pairDropped', listener: (pairId: string) => void): this;
   on(event: 'nodeStateUpdate', listener: () => void): this;
@@ -46,8 +46,8 @@ interface Peer {
   emit(event: 'close'): boolean;
   emit(event: 'error', err: Error): boolean;
   emit(event: 'packet', packet: Packet): boolean;
-  /** Notifies listeners that the peer has advertised pairs to verify. */
-  emit(event: 'pairsAdvertised', pairIds: string[]): boolean;
+  /** Notifies listeners that the peer's advertised but inactive pairs should be verified. */
+  emit(event: 'verifyPairs'): boolean;
   /** Notifies listeners that a previously active pair was dropped by the peer or deactivated. */
   emit(event: 'pairDropped', pairId: string): boolean;
   emit(event: 'nodeStateUpdate'): boolean;
@@ -64,8 +64,14 @@ class Peer extends EventEmitter {
   public active = false;
   /** Timer to periodically call getNodes #402 */
   public discoverTimer?: NodeJS.Timer;
-  /** Currencies that we have verified that we can swap with for this peer. */
+  /** Currencies that we have verified that we can swap for this peer. */
   public verifiedCurrencies = new Set<string>();
+  /**
+   * Currencies that we cannot swap because we are missing a swap client identifier or because our
+   * peer's token identifier for this currency does not match ours - for example this may happen
+   * because a peer is using a different raiden token contract address for a currency than we are.
+   */
+  public disabledCurrencies = new Set<string>();
   /** Trading pairs advertised by this peer which we have verified that we can swap. */
   private activePairs = new Set<string>();
   /** Whether we have received and authenticated a [[SessionInitPacket]] from the peer. */
@@ -82,6 +88,10 @@ class Peer extends EventEmitter {
   private readonly responseMap: Map<string, PendingResponseEntry> = new Map();
   private connectTime!: number;
   private connectionRetriesRevoked = false;
+  /** The version of xud this peer is using. */
+  private _version?: string;
+  /** The node pub key of this peer. */
+  private _nodePubKey?: string;
   private nodeState?: NodeState;
   private sessionInitPacket?: packets.SessionInitPacket;
   private outEncryptionKey?: Buffer;
@@ -102,13 +112,14 @@ class Peer extends EventEmitter {
   /** Connection retries max period. */
   private static readonly CONNECTION_RETRIES_MAX_PERIOD = 604800000;
 
-  public get version(): string {
-    return this.nodeState ? this.nodeState.version : '';
+  /** The version of xud this peer is using, or an empty string if it is still not known. */
+  public get version() {
+    return this._version || '';
   }
 
   /** The hex-encoded node public key for this peer, or undefined if it is still not known. */
   public get nodePubKey(): string | undefined {
-    return this.nodeState ? this.nodeState.nodePubKey : undefined;
+    return this._nodePubKey;
   }
 
   public get label(): string {
@@ -134,10 +145,10 @@ class Peer extends EventEmitter {
   public get info(): PeerInfo {
     return {
       address: addressUtils.toString(this.address),
-      nodePubKey: this.nodeState ? this.nodeState.nodePubKey : undefined,
+      nodePubKey: this.nodePubKey,
       inbound: this.inbound,
       pairs: Array.from(this.activePairs),
-      xudVersion: this.nodeState ? this.nodeState.version : undefined,
+      xudVersion: this.version,
       secondsConnected: Math.round((Date.now() - this.connectTime) / 1000),
       lndPubKeys: this.nodeState ? this.nodeState.lndPubKeys : undefined,
       raidenAddress: this.nodeState ? this.nodeState.raidenAddress : undefined,
@@ -169,7 +180,17 @@ class Peer extends EventEmitter {
     return peer;
   }
 
-  public getIdentifier(clientType: SwapClientType, currency?: string): string | undefined {
+  public getAdvertisedCurrencies = (): Set<string> => {
+    const advertisedCurrencies: Set<string> = new Set();
+    this.advertisedPairs.forEach((advertisedPair) => {
+      const [baseCurrency, quoteCurrency] = advertisedPair.split('/');
+      advertisedCurrencies.add(baseCurrency);
+      advertisedCurrencies.add(quoteCurrency);
+    });
+    return advertisedCurrencies;
+  }
+
+  public getIdentifier = (clientType: SwapClientType, currency?: string): string | undefined => {
     if (!this.nodeState) {
       return undefined;
     }
@@ -180,6 +201,14 @@ class Peer extends EventEmitter {
       return this.nodeState.raidenAddress;
     }
     return;
+  }
+
+  public getTokenIdentifier = (currency: string): string | undefined => {
+    if (!this.nodeState) {
+      return undefined;
+    }
+
+    return this.nodeState.tokenIdentifiers[currency];
   }
 
   public getStatus = (): string => {
@@ -196,13 +225,21 @@ class Peer extends EventEmitter {
 
   /**
    * Prepares a peer for use by establishing a socket connection and beginning the handshake.
-   * @param ownNodeState our node state data to send to the peer
-   * @param nodeKey our identity node key
-   * @param expectedNodePubKey the expected nodePubKey of the node we are opening a connection with
-   * @param retryConnecting whether to retry to connect upon failure
    * @returns the session init packet from beginning the handshake
    */
-  public beginOpen = async (ownNodeState: NodeState, nodeKey: NodeKey, expectedNodePubKey?: string, retryConnecting = false):
+  public beginOpen = async ({ ownNodeState, ownNodeKey, ownVersion, expectedNodePubKey, retryConnecting = false }:
+    {
+      /** Our node state data to send to the peer. */
+      ownNodeState: NodeState,
+      /** Our identity node key. */
+      ownNodeKey: NodeKey,
+      /** The version of xud we are running. */
+      ownVersion: string
+      /** The expected nodePubKey of the node we are opening a connection with. */
+      expectedNodePubKey?: string,
+      /** Whether to retry to connect upon failure. */
+      retryConnecting?: boolean,
+    }):
     Promise<packets.SessionInitPacket> => {
     assert(!this.opening);
     assert(!this.opened);
@@ -216,17 +253,18 @@ class Peer extends EventEmitter {
     await this.initConnection(retryConnecting);
     this.initStall();
 
-    return this.beginHandshake(ownNodeState, nodeKey);
+    return this.beginHandshake(ownNodeState, ownNodeKey, ownVersion);
   }
 
   /**
    * Finishes opening a peer for use by marking the peer as opened, completing the handshake,
    * and setting up the ping packet timer.
    * @param ownNodeState our node state data to send to the peer
-   * @param nodeKey our identity node key
+   * @param ownNodeKey our identity node key
+   * @param ownVersion the version of xud we are running
    * @param sessionInit the session init packet we received when beginning the handshake
    */
-  public completeOpen = async (ownNodeState: NodeState, nodeKey: NodeKey, sessionInit: packets.SessionInitPacket) => {
+  public completeOpen = async (ownNodeState: NodeState, ownNodeKey: NodeKey, ownVersion: string, sessionInit: packets.SessionInitPacket) => {
     assert(this.opening);
     assert(!this.opened);
     assert(!this.closed);
@@ -234,13 +272,13 @@ class Peer extends EventEmitter {
     this.opening = false;
     this.opened = true;
 
-    await this.completeHandshake(ownNodeState, nodeKey, sessionInit);
+    await this.completeHandshake(ownNodeState, ownNodeKey, ownVersion, sessionInit);
 
     // Setup the ping interval
     this.pingTimer = setInterval(this.sendPing, Peer.PING_INTERVAL);
 
     // Setup a timer to periodicially check if we can swap inactive pairs
-    this.checkPairsTimer = setInterval(this.checkPairs, Peer.CHECK_PAIRS_INTERVAL);
+    this.checkPairsTimer = setInterval(() => this.emit('verifyPairs'), Peer.CHECK_PAIRS_INTERVAL);
   }
 
   /**
@@ -335,6 +373,26 @@ class Peer extends EventEmitter {
     await this.sendPacket(packet);
   }
 
+  public disableCurrency = (currency: string) => {
+    if (!this.disabledCurrencies.has(currency)) {
+      this.disabledCurrencies.add(currency);
+      this.verifiedCurrencies.delete(currency);
+      this.activePairs.forEach((activePairId) => {
+        const [baseCurrency, quoteCurrency] = activePairId.split('/');
+        if (baseCurrency === currency || quoteCurrency === currency) {
+          this.deactivatePair(activePairId);
+        }
+      });
+      this.logger.debug(`disabled ${currency} for peer ${this.label}`);
+    }
+  }
+
+  public enableCurrency = (currency: string) => {
+    if (this.disabledCurrencies.delete(currency)) {
+      this.logger.debug(`enabled ${currency} for peer ${this.label}`);
+    }
+  }
+
   /**
    * Deactivates a trading pair with this peer.
    */
@@ -343,9 +401,6 @@ class Peer extends EventEmitter {
       throw new Error('cannot deactivate a trading pair before handshake is complete');
     }
     if (this.activePairs.delete(pairId)) {
-      const [baseCurrency, quoteCurrency] = pairId.split('/');
-      this.verifiedCurrencies.delete(baseCurrency);
-      this.verifiedCurrencies.delete(quoteCurrency);
       this.emit('pairDropped', pairId);
     }
     // TODO: notify peer that we have deactivated this pair?
@@ -364,9 +419,6 @@ class Peer extends EventEmitter {
   }
 
   public isPairActive = (pairId: string) => this.activePairs.has(pairId);
-
-// tslint:disable-next-line: member-ordering
-  public forEachActivePair = this.activePairs.forEach.bind(this.activePairs);
 
   private sendRaw = (data: Buffer) => {
     if (this.socket && !this.socket.destroyed) {
@@ -701,7 +753,7 @@ class Peer extends EventEmitter {
     const body = packet.body!;
     const { sign, ...bodyWithoutSign } = body;
     /** The pub key of the node that sent the init packet. */
-    const sourceNodePubKey = body.nodeState.nodePubKey;
+    const sourceNodePubKey = body.nodePubKey;
     /** The pub key of the node that the init packet is intended for. */
     const targetNodePubKey = body.peerPubKey;
 
@@ -735,15 +787,23 @@ class Peer extends EventEmitter {
 
     // finally set this peer's node state to the node state in the init packet body
     this.nodeState = body.nodeState;
+    this._nodePubKey = body.nodePubKey;
+    this._version = body.version;
   }
 
   /**
    * Sends a [[SessionInitPacket]] and waits for a [[SessionAckPacket]].
    */
-  private initSession = async (ownNodeState: NodeState, nodeKey: NodeKey, expectedNodePubKey: string): Promise<void> => {
+  private initSession = async (ownNodeState: NodeState, ownNodeKey: NodeKey, ownVersion: string, expectedNodePubKey: string): Promise<void> => {
     const ECDH = createECDH('secp256k1');
     const ephemeralPubKey = ECDH.generateKeys().toString('hex');
-    const packet = this.createSessionInitPacket(ephemeralPubKey, ownNodeState, expectedNodePubKey, nodeKey);
+    const packet = this.createSessionInitPacket({
+      ephemeralPubKey,
+      ownNodeState,
+      ownNodeKey,
+      ownVersion,
+      expectedNodePubKey,
+    });
     await this.sendPacket(packet);
     await this.wait(packet.header.id, packet.responseType, Peer.RESPONSE_TIMEOUT, (packet: Packet) => {
       // enabling in-encryption synchronously,
@@ -774,18 +834,18 @@ class Peer extends EventEmitter {
    * [[SessionInitPacket]] first if we are the outbound peer.
    * @returns the session init packet we receive
    */
-  private beginHandshake = async (ownNodeState: NodeState, nodeKey: NodeKey) => {
+  private beginHandshake = async (ownNodeState: NodeState, ownNodeKey: NodeKey, ownVersion: string) => {
     let sessionInit: packets.SessionInitPacket;
     if (!this.inbound) {
       // outbound handshake
       assert(this.expectedNodePubKey);
-      await this.initSession(ownNodeState, nodeKey, this.expectedNodePubKey!);
+      await this.initSession(ownNodeState, ownNodeKey, ownVersion, this.expectedNodePubKey!);
       sessionInit = await this.waitSessionInit();
-      await this.authenticateSessionInit(sessionInit, nodeKey.pubKey, this.expectedNodePubKey);
+      await this.authenticateSessionInit(sessionInit, ownNodeKey.pubKey, this.expectedNodePubKey);
     } else {
       // inbound handshake
       sessionInit = await this.waitSessionInit();
-      await this.authenticateSessionInit(sessionInit, nodeKey.pubKey);
+      await this.authenticateSessionInit(sessionInit, ownNodeKey.pubKey);
     }
     return sessionInit;
   }
@@ -794,21 +854,14 @@ class Peer extends EventEmitter {
    * Completes the handshake by sending the [[SessionAckPacket]] and our [[SessionInitPacket]] if it
    * has not been sent already, as is the case with inbound peers.
    */
-  private completeHandshake = async (ownNodeState: NodeState, nodeKey: NodeKey, sessionInit: packets.SessionInitPacket) => {
+  private completeHandshake = async (ownNodeState: NodeState, ownNodeKey: NodeKey, ownVersion: string, sessionInit: packets.SessionInitPacket) => {
     if (!this.inbound) {
       // outbound handshake
       await this.ackSession(sessionInit);
     } else {
       // inbound handshake
       await this.ackSession(sessionInit);
-      await this.initSession(ownNodeState, nodeKey, sessionInit.body!.nodeState.nodePubKey);
-    }
-  }
-
-  private checkPairs = () => {
-    const inactivePairs = this.advertisedPairs.filter(pair => !this.activePairs.has(pair));
-    if (inactivePairs.length) {
-      this.emit('pairsAdvertised', inactivePairs);
+      await this.initSession(ownNodeState, ownNodeKey, ownVersion, sessionInit.body!.nodePubKey);
     }
   }
 
@@ -838,21 +891,24 @@ class Peer extends EventEmitter {
     await this.sendPong(packet.header.id);
   }
 
-  private createSessionInitPacket = (
+  private createSessionInitPacket = ({ ephemeralPubKey, ownNodeState, ownNodeKey, ownVersion, expectedNodePubKey }: {
     ephemeralPubKey: string,
     ownNodeState: NodeState,
+    ownNodeKey: NodeKey,
+    ownVersion: string,
     expectedNodePubKey: string,
-    nodeKey: NodeKey,
-  ): packets.SessionInitPacket => {
+  }): packets.SessionInitPacket => {
     let body: any = {
       ephemeralPubKey,
+      version: ownVersion,
       peerPubKey: expectedNodePubKey,
+      nodePubKey: ownNodeKey.pubKey,
       nodeState: ownNodeState,
     };
 
     const msg = stringify(body);
     const msgHash = createHash('sha256').update(msg).digest();
-    const { signature } = secp256k1.sign(msgHash, nodeKey.privKey);
+    const { signature } = secp256k1.sign(msgHash, ownNodeKey.privKey);
 
     body = { ...body, sign: signature.toString('hex') };
 
@@ -883,28 +939,16 @@ class Peer extends EventEmitter {
     const nodeStateUpdate = packet.body!;
     this.logger.verbose(`received node state update packet from ${this.label}: ${JSON.stringify(nodeStateUpdate)}`);
 
-    const prevNodeState = this.nodeState!;
-    /** A list of trading pairs that are advertised in this node state update that weren't advertised before. */
-    const addedPairs: string[] = [];
-
     this.activePairs.forEach((pairId) => {
       if (!nodeStateUpdate.pairs.includes(pairId)) {
         // a trading pair was previously active but is not in the updated node state
-        this.activePairs.delete(pairId);
-        this.emit('pairDropped', pairId);
+        this.deactivatePair(pairId);
       }
     });
 
-    nodeStateUpdate.pairs.forEach((pairId) => {
-      if (!prevNodeState.pairs.includes(pairId)) {
-        // a trading pair in the updated node state was not in the old one
-        addedPairs.push(pairId);
-      }
-    });
-
-    this.nodeState = { ...nodeStateUpdate, nodePubKey: prevNodeState.nodePubKey, version: prevNodeState.version };
-    this.emit('pairsAdvertised', addedPairs);
+    this.nodeState = nodeStateUpdate;
     this.emit('nodeStateUpdate');
+    this.emit('verifyPairs');
   }
 
   private setOutEncryption = (key: Buffer) => {

--- a/lib/p2p/packets/types/SessionInitPacket.ts
+++ b/lib/p2p/packets/types/SessionInitPacket.ts
@@ -2,13 +2,19 @@ import Packet, { PacketDirection, ResponseType } from '../Packet';
 import PacketType from '../PacketType';
 import { NodeState } from '../../types';
 import * as pb from '../../../proto/xudp2p_pb';
-import { removeUndefinedProps, setObjectToMap, convertKvpArrayToKvps } from '../../../utils/utils';
+import { validateNodeState, convertNodeState, serializeNodeState } from '../utils';
 
 export type SessionInitPacketBody = {
   sign: string;
   ephemeralPubKey: string;
+  /** The node pub key of the peer we are connecting to. */
   peerPubKey: string;
+  /** Our local node state. */
   nodeState: NodeState;
+  /** The version of xud we are running. */
+  version: string;
+  /** Our local node pub key. */
+  nodePubKey: string;
 };
 
 class SessionInitPacket extends Packet<SessionInitPacketBody> {
@@ -34,11 +40,9 @@ class SessionInitPacket extends Packet<SessionInitPacketBody> {
       && obj.sign
       && obj.ephemeralPubKey
       && obj.peerPubKey
-      && obj.nodeState
-      && obj.nodeState.version
-      && obj.nodeState.nodePubKey
-      && obj.nodeState.pairsList
-      && obj.nodeState.addressesList.every(addr => !!addr.host)
+      && obj.version
+      && obj.nodePubKey
+      && validateNodeState(obj.nodeState)
     );
   }
 
@@ -51,14 +55,9 @@ class SessionInitPacket extends Packet<SessionInitPacketBody> {
         sign: obj.sign,
         peerPubKey: obj.peerPubKey,
         ephemeralPubKey: obj.ephemeralPubKey,
-        nodeState: removeUndefinedProps({
-          version: obj.nodeState!.version,
-          nodePubKey: obj.nodeState!.nodePubKey,
-          pairs: obj.nodeState!.pairsList,
-          addresses: obj.nodeState!.addressesList,
-          raidenAddress: obj.nodeState!.raidenAddress,
-          lndPubKeys: convertKvpArrayToKvps(obj.nodeState!.lndPubKeysMap),
-        }),
+        version: obj.version,
+        nodePubKey: obj.nodePubKey,
+        nodeState: convertNodeState(obj.nodeState!),
       },
     });
   }
@@ -69,23 +68,9 @@ class SessionInitPacket extends Packet<SessionInitPacketBody> {
     msg.setSign(this.body!.sign);
     msg.setPeerPubKey(this.body!.peerPubKey);
     msg.setEphemeralPubKey(this.body!.ephemeralPubKey);
-    msg.setNodeState((() => {
-      const pbNodeState = new pb.NodeState();
-      pbNodeState.setVersion(this.body!.nodeState.version);
-      pbNodeState.setNodePubKey(this.body!.nodeState.nodePubKey);
-      pbNodeState.setPairsList(this.body!.nodeState.pairs);
-      pbNodeState.setAddressesList(this.body!.nodeState.addresses.map((addr) => {
-        const pbAddr = new pb.Address();
-        pbAddr.setHost(addr.host);
-        pbAddr.setPort(addr.port);
-        return pbAddr;
-      }));
-      pbNodeState.setRaidenAddress(this.body!.nodeState.raidenAddress);
-      if (this.body!.nodeState.lndPubKeys) {
-        setObjectToMap(this.body!.nodeState.lndPubKeys, pbNodeState.getLndPubKeysMap());
-      }
-      return pbNodeState;
-    })());
+    msg.setVersion(this.body!.version);
+    msg.setNodePubKey(this.body!.nodePubKey);
+    msg.setNodeState(serializeNodeState(this.body!.nodeState));
 
     return msg.serializeBinary();
   }

--- a/lib/p2p/packets/utils.ts
+++ b/lib/p2p/packets/utils.ts
@@ -1,0 +1,42 @@
+import * as pb from '../../proto/xudp2p_pb';
+import { removeUndefinedProps, convertKvpArrayToKvps, setObjectToMap } from '../../utils/utils';
+import { NodeState } from '../types';
+
+export const validateNodeState = (nodeState?: pb.NodeState.AsObject) => {
+  // TODO: validate that pairsList does not contain duplicates
+  return !!(nodeState
+    && nodeState.pairsList
+    && nodeState.lndPubKeysMap
+    && nodeState.tokenIdentifiersMap
+    && nodeState.addressesList.every(addr => !!addr.host)
+  );
+};
+
+export const convertNodeState = (nodeState: pb.NodeState.AsObject) => {
+  return removeUndefinedProps({
+    pairs: nodeState.pairsList,
+    addresses: nodeState.addressesList,
+    raidenAddress: nodeState.raidenAddress,
+    lndPubKeys: convertKvpArrayToKvps(nodeState.lndPubKeysMap),
+    tokenIdentifiers: convertKvpArrayToKvps(nodeState.tokenIdentifiersMap),
+  });
+};
+
+export const serializeNodeState = (nodeState: NodeState): pb.NodeState => {
+  const pbNodeState = new pb.NodeState();
+  pbNodeState.setPairsList(nodeState.pairs);
+  pbNodeState.setAddressesList(nodeState.addresses.map((addr) => {
+    const pbAddr = new pb.Address();
+    pbAddr.setHost(addr.host);
+    pbAddr.setPort(addr.port);
+    return pbAddr;
+  }));
+  pbNodeState.setRaidenAddress(nodeState.raidenAddress);
+  if (nodeState.lndPubKeys) {
+    setObjectToMap(nodeState.lndPubKeys, pbNodeState.getLndPubKeysMap());
+  }
+  if (nodeState.tokenIdentifiers) {
+    setObjectToMap(nodeState.tokenIdentifiers, pbNodeState.getTokenIdentifiersMap());
+  }
+  return pbNodeState;
+};

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -13,16 +13,15 @@ export type NodeConnectionInfo = {
 };
 
 export type NodeState = {
-  version: string;
-  nodePubKey: string;
   /** This node's listening external socket addresses to advertise to peers. */
   addresses: Address[];
   pairs: string[];
   raidenAddress: string;
+  /** An object mapping currency symbols to lnd pub keys. */
   lndPubKeys: { [currency: string]: string | undefined };
+  /** An object mapping currency symbols to token identifiers such as lnd chains or raiden token contract addresses. */
+  tokenIdentifiers: { [currency: string]: string | undefined };
 };
-
-export type NodeStateUpdate = Pick<NodeState, Exclude<keyof NodeState, 'version' | 'nodePubKey'>>;
 
 export type PoolConfig = {
   /** Whether or not to automatically detect and share current external ip address on startup. */

--- a/lib/proto/xudp2p_pb.d.ts
+++ b/lib/proto/xudp2p_pb.d.ts
@@ -95,12 +95,6 @@ export namespace Node {
 }
 
 export class NodeState extends jspb.Message { 
-    getVersion(): string;
-    setVersion(value: string): void;
-
-    getNodePubKey(): string;
-    setNodePubKey(value: string): void;
-
     clearAddressesList(): void;
     getAddressesList(): Array<Address>;
     setAddressesList(value: Array<Address>): void;
@@ -119,6 +113,10 @@ export class NodeState extends jspb.Message {
     clearLndPubKeysMap(): void;
 
 
+    getTokenIdentifiersMap(): jspb.Map<string, string>;
+    clearTokenIdentifiersMap(): void;
+
+
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): NodeState.AsObject;
     static toObject(includeInstance: boolean, msg: NodeState): NodeState.AsObject;
@@ -131,13 +129,13 @@ export class NodeState extends jspb.Message {
 
 export namespace NodeState {
     export type AsObject = {
-        version: string,
-        nodePubKey: string,
         addressesList: Array<Address.AsObject>,
         pairsList: Array<string>,
         raidenAddress: string,
 
         lndPubKeysMap: Array<[string, string]>,
+
+        tokenIdentifiersMap: Array<[string, string]>,
     }
 }
 
@@ -310,22 +308,11 @@ export class NodeStateUpdatePacket extends jspb.Message {
     getId(): string;
     setId(value: string): void;
 
-    clearAddressesList(): void;
-    getAddressesList(): Array<Address>;
-    setAddressesList(value: Array<Address>): void;
-    addAddresses(value?: Address, index?: number): Address;
 
-    clearPairsList(): void;
-    getPairsList(): Array<string>;
-    setPairsList(value: Array<string>): void;
-    addPairs(value: string, index?: number): string;
-
-    getRaidenAddress(): string;
-    setRaidenAddress(value: string): void;
-
-
-    getLndPubKeysMap(): jspb.Map<string, string>;
-    clearLndPubKeysMap(): void;
+    hasNodeState(): boolean;
+    clearNodeState(): void;
+    getNodeState(): NodeState | undefined;
+    setNodeState(value?: NodeState): void;
 
 
     serializeBinary(): Uint8Array;
@@ -341,11 +328,7 @@ export class NodeStateUpdatePacket extends jspb.Message {
 export namespace NodeStateUpdatePacket {
     export type AsObject = {
         id: string,
-        addressesList: Array<Address.AsObject>,
-        pairsList: Array<string>,
-        raidenAddress: string,
-
-        lndPubKeysMap: Array<[string, string]>,
+        nodeState?: NodeState.AsObject,
     }
 }
 
@@ -368,6 +351,12 @@ export class SessionInitPacket extends jspb.Message {
     getNodeState(): NodeState | undefined;
     setNodeState(value?: NodeState): void;
 
+    getVersion(): string;
+    setVersion(value: string): void;
+
+    getNodePubKey(): string;
+    setNodePubKey(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SessionInitPacket.AsObject;
@@ -386,6 +375,8 @@ export namespace SessionInitPacket {
         peerPubKey: string,
         ephemeralPubKey: string,
         nodeState?: NodeState.AsObject,
+        version: string,
+        nodePubKey: string,
     }
 }
 

--- a/lib/proto/xudp2p_pb.js
+++ b/lib/proto/xudp2p_pb.js
@@ -703,13 +703,12 @@ proto.xudp2p.NodeState.prototype.toObject = function(opt_includeInstance) {
  */
 proto.xudp2p.NodeState.toObject = function(includeInstance, msg) {
   var f, obj = {
-    version: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    nodePubKey: jspb.Message.getFieldWithDefault(msg, 2, ""),
     addressesList: jspb.Message.toObjectList(msg.getAddressesList(),
     proto.xudp2p.Address.toObject, includeInstance),
     pairsList: jspb.Message.getRepeatedField(msg, 4),
     raidenAddress: jspb.Message.getFieldWithDefault(msg, 5, ""),
-    lndPubKeysMap: (f = msg.getLndPubKeysMap()) ? f.toObject(includeInstance, undefined) : []
+    lndPubKeysMap: (f = msg.getLndPubKeysMap()) ? f.toObject(includeInstance, undefined) : [],
+    tokenIdentifiersMap: (f = msg.getTokenIdentifiersMap()) ? f.toObject(includeInstance, undefined) : []
   };
 
   if (includeInstance) {
@@ -746,14 +745,6 @@ proto.xudp2p.NodeState.deserializeBinaryFromReader = function(msg, reader) {
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setVersion(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setNodePubKey(value);
-      break;
     case 3:
       var value = new proto.xudp2p.Address;
       reader.readMessage(value,proto.xudp2p.Address.deserializeBinaryFromReader);
@@ -769,6 +760,12 @@ proto.xudp2p.NodeState.deserializeBinaryFromReader = function(msg, reader) {
       break;
     case 6:
       var value = msg.getLndPubKeysMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString);
+         });
+      break;
+    case 7:
+      var value = msg.getTokenIdentifiersMap();
       reader.readMessage(value, function(message, reader) {
         jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString);
          });
@@ -802,20 +799,6 @@ proto.xudp2p.NodeState.prototype.serializeBinary = function() {
  */
 proto.xudp2p.NodeState.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getVersion();
-  if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
-  }
-  f = message.getNodePubKey();
-  if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
-  }
   f = message.getAddressesList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
@@ -842,36 +825,10 @@ proto.xudp2p.NodeState.serializeBinaryToWriter = function(message, writer) {
   if (f && f.getLength() > 0) {
     f.serializeBinary(6, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
   }
-};
-
-
-/**
- * optional string version = 1;
- * @return {string}
- */
-proto.xudp2p.NodeState.prototype.getVersion = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
-};
-
-
-/** @param {string} value */
-proto.xudp2p.NodeState.prototype.setVersion = function(value) {
-  jspb.Message.setField(this, 1, value);
-};
-
-
-/**
- * optional string node_pub_key = 2;
- * @return {string}
- */
-proto.xudp2p.NodeState.prototype.getNodePubKey = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
-};
-
-
-/** @param {string} value */
-proto.xudp2p.NodeState.prototype.setNodePubKey = function(value) {
-  jspb.Message.setField(this, 2, value);
+  f = message.getTokenIdentifiersMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(7, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
+  }
 };
 
 
@@ -965,6 +922,24 @@ proto.xudp2p.NodeState.prototype.getLndPubKeysMap = function(opt_noLazyCreate) {
 
 proto.xudp2p.NodeState.prototype.clearLndPubKeysMap = function() {
   this.getLndPubKeysMap().clear();
+};
+
+
+/**
+ * map<string, string> token_identifiers = 7;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,string>}
+ */
+proto.xudp2p.NodeState.prototype.getTokenIdentifiersMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,string>} */ (
+      jspb.Message.getMapField(this, 7, opt_noLazyCreate,
+      null));
+};
+
+
+proto.xudp2p.NodeState.prototype.clearTokenIdentifiersMap = function() {
+  this.getTokenIdentifiersMap().clear();
 };
 
 
@@ -2112,19 +2087,12 @@ proto.xudp2p.OrdersPacket.prototype.clearOrdersList = function() {
  * @constructor
  */
 proto.xudp2p.NodeStateUpdatePacket = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, proto.xudp2p.NodeStateUpdatePacket.repeatedFields_, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
 goog.inherits(proto.xudp2p.NodeStateUpdatePacket, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
   proto.xudp2p.NodeStateUpdatePacket.displayName = 'proto.xudp2p.NodeStateUpdatePacket';
 }
-/**
- * List of repeated fields within this message type.
- * @private {!Array<number>}
- * @const
- */
-proto.xudp2p.NodeStateUpdatePacket.repeatedFields_ = [2,3];
-
 
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
@@ -2155,11 +2123,7 @@ proto.xudp2p.NodeStateUpdatePacket.prototype.toObject = function(opt_includeInst
 proto.xudp2p.NodeStateUpdatePacket.toObject = function(includeInstance, msg) {
   var f, obj = {
     id: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    addressesList: jspb.Message.toObjectList(msg.getAddressesList(),
-    proto.xudp2p.Address.toObject, includeInstance),
-    pairsList: jspb.Message.getRepeatedField(msg, 3),
-    raidenAddress: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    lndPubKeysMap: (f = msg.getLndPubKeysMap()) ? f.toObject(includeInstance, undefined) : []
+    nodeState: (f = msg.getNodeState()) && proto.xudp2p.NodeState.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -2200,24 +2164,10 @@ proto.xudp2p.NodeStateUpdatePacket.deserializeBinaryFromReader = function(msg, r
       var value = /** @type {string} */ (reader.readString());
       msg.setId(value);
       break;
-    case 2:
-      var value = new proto.xudp2p.Address;
-      reader.readMessage(value,proto.xudp2p.Address.deserializeBinaryFromReader);
-      msg.addAddresses(value);
-      break;
-    case 3:
-      var value = /** @type {string} */ (reader.readString());
-      msg.addPairs(value);
-      break;
-    case 4:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setRaidenAddress(value);
-      break;
-    case 6:
-      var value = msg.getLndPubKeysMap();
-      reader.readMessage(value, function(message, reader) {
-        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString);
-         });
+    case 5:
+      var value = new proto.xudp2p.NodeState;
+      reader.readMessage(value,proto.xudp2p.NodeState.deserializeBinaryFromReader);
+      msg.setNodeState(value);
       break;
     default:
       reader.skipField();
@@ -2255,31 +2205,13 @@ proto.xudp2p.NodeStateUpdatePacket.serializeBinaryToWriter = function(message, w
       f
     );
   }
-  f = message.getAddressesList();
-  if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      2,
+  f = message.getNodeState();
+  if (f != null) {
+    writer.writeMessage(
+      5,
       f,
-      proto.xudp2p.Address.serializeBinaryToWriter
+      proto.xudp2p.NodeState.serializeBinaryToWriter
     );
-  }
-  f = message.getPairsList();
-  if (f.length > 0) {
-    writer.writeRepeatedString(
-      3,
-      f
-    );
-  }
-  f = message.getRaidenAddress();
-  if (f.length > 0) {
-    writer.writeString(
-      4,
-      f
-    );
-  }
-  f = message.getLndPubKeysMap(true);
-  if (f && f.getLength() > 0) {
-    f.serializeBinary(6, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
   }
 };
 
@@ -2300,95 +2232,32 @@ proto.xudp2p.NodeStateUpdatePacket.prototype.setId = function(value) {
 
 
 /**
- * repeated Address addresses = 2;
- * @return {!Array.<!proto.xudp2p.Address>}
+ * optional NodeState node_state = 5;
+ * @return {?proto.xudp2p.NodeState}
  */
-proto.xudp2p.NodeStateUpdatePacket.prototype.getAddressesList = function() {
-  return /** @type{!Array.<!proto.xudp2p.Address>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.xudp2p.Address, 2));
+proto.xudp2p.NodeStateUpdatePacket.prototype.getNodeState = function() {
+  return /** @type{?proto.xudp2p.NodeState} */ (
+    jspb.Message.getWrapperField(this, proto.xudp2p.NodeState, 5));
 };
 
 
-/** @param {!Array.<!proto.xudp2p.Address>} value */
-proto.xudp2p.NodeStateUpdatePacket.prototype.setAddressesList = function(value) {
-  jspb.Message.setRepeatedWrapperField(this, 2, value);
+/** @param {?proto.xudp2p.NodeState|undefined} value */
+proto.xudp2p.NodeStateUpdatePacket.prototype.setNodeState = function(value) {
+  jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+proto.xudp2p.NodeStateUpdatePacket.prototype.clearNodeState = function() {
+  this.setNodeState(undefined);
 };
 
 
 /**
- * @param {!proto.xudp2p.Address=} opt_value
- * @param {number=} opt_index
- * @return {!proto.xudp2p.Address}
+ * Returns whether this field is set.
+ * @return {!boolean}
  */
-proto.xudp2p.NodeStateUpdatePacket.prototype.addAddresses = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.xudp2p.Address, opt_index);
-};
-
-
-proto.xudp2p.NodeStateUpdatePacket.prototype.clearAddressesList = function() {
-  this.setAddressesList([]);
-};
-
-
-/**
- * repeated string pairs = 3;
- * @return {!Array.<string>}
- */
-proto.xudp2p.NodeStateUpdatePacket.prototype.getPairsList = function() {
-  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 3));
-};
-
-
-/** @param {!Array.<string>} value */
-proto.xudp2p.NodeStateUpdatePacket.prototype.setPairsList = function(value) {
-  jspb.Message.setField(this, 3, value || []);
-};
-
-
-/**
- * @param {!string} value
- * @param {number=} opt_index
- */
-proto.xudp2p.NodeStateUpdatePacket.prototype.addPairs = function(value, opt_index) {
-  jspb.Message.addToRepeatedField(this, 3, value, opt_index);
-};
-
-
-proto.xudp2p.NodeStateUpdatePacket.prototype.clearPairsList = function() {
-  this.setPairsList([]);
-};
-
-
-/**
- * optional string raiden_address = 4;
- * @return {string}
- */
-proto.xudp2p.NodeStateUpdatePacket.prototype.getRaidenAddress = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
-};
-
-
-/** @param {string} value */
-proto.xudp2p.NodeStateUpdatePacket.prototype.setRaidenAddress = function(value) {
-  jspb.Message.setField(this, 4, value);
-};
-
-
-/**
- * map<string, string> lnd_pub_keys = 6;
- * @param {boolean=} opt_noLazyCreate Do not create the map if
- * empty, instead returning `undefined`
- * @return {!jspb.Map<string,string>}
- */
-proto.xudp2p.NodeStateUpdatePacket.prototype.getLndPubKeysMap = function(opt_noLazyCreate) {
-  return /** @type {!jspb.Map<string,string>} */ (
-      jspb.Message.getMapField(this, 6, opt_noLazyCreate,
-      null));
-};
-
-
-proto.xudp2p.NodeStateUpdatePacket.prototype.clearLndPubKeysMap = function() {
-  this.getLndPubKeysMap().clear();
+proto.xudp2p.NodeStateUpdatePacket.prototype.hasNodeState = function() {
+  return jspb.Message.getField(this, 5) != null;
 };
 
 
@@ -2443,7 +2312,9 @@ proto.xudp2p.SessionInitPacket.toObject = function(includeInstance, msg) {
     sign: jspb.Message.getFieldWithDefault(msg, 2, ""),
     peerPubKey: jspb.Message.getFieldWithDefault(msg, 3, ""),
     ephemeralPubKey: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    nodeState: (f = msg.getNodeState()) && proto.xudp2p.NodeState.toObject(includeInstance, f)
+    nodeState: (f = msg.getNodeState()) && proto.xudp2p.NodeState.toObject(includeInstance, f),
+    version: jspb.Message.getFieldWithDefault(msg, 6, ""),
+    nodePubKey: jspb.Message.getFieldWithDefault(msg, 7, "")
   };
 
   if (includeInstance) {
@@ -2500,6 +2371,14 @@ proto.xudp2p.SessionInitPacket.deserializeBinaryFromReader = function(msg, reade
       var value = new proto.xudp2p.NodeState;
       reader.readMessage(value,proto.xudp2p.NodeState.deserializeBinaryFromReader);
       msg.setNodeState(value);
+      break;
+    case 6:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setVersion(value);
+      break;
+    case 7:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setNodePubKey(value);
       break;
     default:
       reader.skipField();
@@ -2564,6 +2443,20 @@ proto.xudp2p.SessionInitPacket.serializeBinaryToWriter = function(message, write
       5,
       f,
       proto.xudp2p.NodeState.serializeBinaryToWriter
+    );
+  }
+  f = message.getVersion();
+  if (f.length > 0) {
+    writer.writeString(
+      6,
+      f
+    );
+  }
+  f = message.getNodePubKey();
+  if (f.length > 0) {
+    writer.writeString(
+      7,
+      f
     );
   }
 };
@@ -2656,6 +2549,36 @@ proto.xudp2p.SessionInitPacket.prototype.clearNodeState = function() {
  */
 proto.xudp2p.SessionInitPacket.prototype.hasNodeState = function() {
   return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * optional string version = 6;
+ * @return {string}
+ */
+proto.xudp2p.SessionInitPacket.prototype.getVersion = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/** @param {string} value */
+proto.xudp2p.SessionInitPacket.prototype.setVersion = function(value) {
+  jspb.Message.setField(this, 6, value);
+};
+
+
+/**
+ * optional string node_pub_key = 7;
+ * @return {string}
+ */
+proto.xudp2p.SessionInitPacket.prototype.getNodePubKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 7, ""));
+};
+
+
+/** @param {string} value */
+proto.xudp2p.SessionInitPacket.prototype.setNodePubKey = function(value) {
+  jspb.Message.setField(this, 7, value);
 };
 
 

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -72,6 +72,7 @@ class RaidenClient extends SwapClient {
       /** The new raiden address value if different from the one we had previously. */
       let newAddress: string | undefined;
       if (this.address !== address) {
+        this.logger.debug(`address is ${newAddress}`);
         newAddress = address;
         this.address = newAddress;
       }

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -211,7 +211,7 @@ class Service {
    * Get general information about this Exchange Union node.
    */
   public getInfo = async (): Promise<XudInfo> => {
-    const { nodePubKey, addresses } = this.pool.nodeState;
+    const { nodePubKey, addresses } = this.pool;
 
     const uris: string[] = [];
 

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -19,11 +19,11 @@ function isLndClient(swapClient: SwapClient): swapClient is LndClient {
 }
 
 interface SwapClientManager {
-  on(event: 'lndUpdate', listener: (currency: string, newPubKey: string) => void): this;
-  on(event: 'raidenUpdate', listener: (newAddress: string) => void): this;
+  on(event: 'lndUpdate', listener: (currency: string, pubKey: string, chain?: string) => void): this;
+  on(event: 'raidenUpdate', listener: (tokenAddresses: Map<string, string>, address?: string) => void): this;
   on(event: 'htlcAccepted', listener: (swapClient: SwapClient, rHash: string, amount: number, currency: string) => void): this;
-  emit(event: 'lndUpdate', currency: string, newPubKey: string): boolean;
-  emit(event: 'raidenUpdate', newAddress: string): boolean;
+  emit(event: 'lndUpdate', currency: string, pubKey: string, chain?: string): boolean;
+  emit(event: 'raidenUpdate', tokenAddresses: Map<string, string>, address?: string): boolean;
   emit(event: 'htlcAccepted', swapClient: SwapClient, rHash: string, amount: number, currency: string): boolean;
 }
 
@@ -48,7 +48,7 @@ class SwapClientManager extends EventEmitter {
    */
   public init = async (models: Models): Promise<void> => {
     const initPromises = [];
-    // setup LND clients and initialize
+    // setup configured LND clients and initialize them
     for (const currency in this.config.lnd) {
       const lndConfig = this.config.lnd[currency]!;
       if (!lndConfig.disable) {
@@ -163,17 +163,19 @@ class SwapClientManager extends EventEmitter {
     if (currency.swapClient === SwapClientType.Raiden && currency.tokenAddress) {
       this.swapClients.set(currency.id, this.raidenClient);
       this.raidenClient.tokenAddresses.set(currency.id, currency.tokenAddress);
+      this.emit('raidenUpdate', this.raidenClient.tokenAddresses, this.raidenClient.address);
     } else if (currency.swapClient === SwapClientType.Lnd) {
       // in case of lnd we check if the configuration includes swap client
       // for the specified currency
-      let hasCurrency = false;
+      let isCurrencyConfigured = false;
       for (const lndCurrency in this.config.lnd) {
         if (lndCurrency === currency.id) {
-          hasCurrency = true;
+          isCurrencyConfigured = true;
+          break;
         }
       }
       // adding a new lnd client at runtime is currently not supported
-      if (!hasCurrency) {
+      if (!isCurrencyConfigured) {
         throw errors.SWAP_CLIENT_NOT_CONFIGURED(currency.id);
       }
     }
@@ -193,17 +195,17 @@ class SwapClientManager extends EventEmitter {
   }
 
   /**
-   * Gets all lnd clients' pubKeys.
-   * @returns An object containing lnd public keys.
+   * Gets a map of all lnd clients.
+   * @returns A map of currencies to lnd clients.
    */
-  public getLndPubKeysMap = () => {
-    const lndPubKeys = new Map<string, string>();
-    for (const [currency, swapClient] of this.swapClients.entries()) {
-      if (isLndClient(swapClient) && swapClient.pubKey) {
-        lndPubKeys.set(currency, swapClient.pubKey);
+  public getLndClientsMap = () => {
+    const lndClients: Map<string, LndClient> = new Map();
+    this.swapClients.forEach((swapClient, currency) => {
+      if (isLndClient(swapClient)) {
+        lndClients.set(currency, swapClient);
       }
-    }
-    return lndPubKeys;
+    });
+    return lndClients;
   }
 
   /**
@@ -255,7 +257,7 @@ class SwapClientManager extends EventEmitter {
       if (isLndClient(swapClient)) {
         swapClient.on('connectionVerified', (newPubKey) => {
           if (newPubKey) {
-            this.emit('lndUpdate', currency, newPubKey);
+            this.emit('lndUpdate', currency, newPubKey, swapClient.chain);
           }
         });
         // lnd clients emit htlcAccepted evented we must handle
@@ -270,7 +272,7 @@ class SwapClientManager extends EventEmitter {
     if (!this.raidenClient.isDisabled()) {
       this.raidenClient.on('connectionVerified', (newAddress) => {
         if (newAddress) {
-          this.emit('raidenUpdate', newAddress);
+          this.emit('raidenUpdate', this.raidenClient.tokenAddresses, newAddress);
         }
       });
     }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -116,11 +116,13 @@ class Swaps extends EventEmitter {
 
   public init = async () => {
     // update pool with lnd pubkeys and raiden address
-    this.swapClientManager.getLndPubKeysMap().forEach((pubKey, currency) => {
-      this.pool.updateLndPubKey(currency, pubKey);
+    this.swapClientManager.getLndClientsMap().forEach((lndClient) => {
+      if (lndClient.pubKey && lndClient.chain) {
+        this.pool.updateLndState(lndClient.currency, lndClient.pubKey, lndClient.chain);
+      }
     });
     if (this.swapClientManager.raidenClient.address) {
-      this.pool.updateRaidenAddress(this.swapClientManager.raidenClient.address);
+      this.pool.updateRaidenState(this.swapClientManager.raidenClient.tokenAddresses, this.swapClientManager.raidenClient.address);
     }
 
     // Load Swaps from database
@@ -167,8 +169,8 @@ class Swaps extends EventEmitter {
         this.logger.error('could not settle invoice', err);
       }
     });
-    this.swapClientManager.on('lndUpdate', this.pool.updateLndPubKey);
-    this.swapClientManager.on('raidenUpdate', this.pool.updateRaidenAddress);
+    this.swapClientManager.on('lndUpdate', this.pool.updateLndState);
+    this.swapClientManager.on('raidenUpdate', this.pool.updateRaidenState);
   }
 
   /**
@@ -849,6 +851,7 @@ class Swaps extends EventEmitter {
       case SwapFailureReason.SwapClientNotSetup:
         // something is wrong with swaps for this trading pair and peer, drop this pair
         try {
+          // TODO: disable the currency that caused this error
           this.pool.getPeer(deal.peerPubKey).deactivatePair(deal.pairId);
         } catch (err) {
           this.logger.debug(`could not drop trading pair ${deal.pairId} for peer ${deal.peerPubKey}`);

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -149,7 +149,8 @@ export const setTimeoutPromise = promisify(setTimeout);
 /** A promisified wrapper for the NodeJS `crypto.randomBytes` method. */
 export const randomBytes = promisify(cryptoRandomBytes);
 
-export const removeUndefinedProps = (obj: any) => {
+export const removeUndefinedProps = <T>(typedObj: T): T => {
+  const obj = typedObj as any;
   Object.keys(obj).forEach((key) => {
     if (obj[key] === undefined) {
       delete obj[key];

--- a/proto/xudp2p.proto
+++ b/proto/xudp2p.proto
@@ -21,12 +21,11 @@ message Node {
 }
 
 message NodeState {
-    string version = 1;
-    string node_pub_key = 2;
     repeated Address addresses = 3;
     repeated string pairs = 4;
     string raiden_address = 5;
     map<string, string> lnd_pub_keys = 6;
+    map<string, string> token_identifiers = 7;
 }
 
 message PingPacket {
@@ -63,18 +62,20 @@ message OrdersPacket {
 
 message NodeStateUpdatePacket {
     string id = 1;
-    repeated Address addresses = 2;
-    repeated string pairs = 3;
-    string raiden_address = 4;
-    map<string, string> lnd_pub_keys = 6;
+    NodeState node_state = 5;
 }
 
 message SessionInitPacket {
     string id = 1;
     string sign = 2;
+    // The node pub key of the peer we are connecting to.
     string peer_pub_key = 3;
     string ephemeral_pub_key = 4;
     NodeState node_state = 5;
+    // The version of xud we are running.
+    string version = 6;
+    // Our local node pub key.
+    string node_pub_key = 7;
 }
 
 message SessionAckPacket {

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -24,10 +24,10 @@ describe('P2P Pool Tests', async () => {
     peer.beginOpen = () => {
       peer.nodeState = {
         addresses,
-        nodePubKey,
-        version: '100.0.0',
         pairs: ['LTC/BTC'],
       };
+      peer['_nodePubKey'] = nodePubKey;
+      peer['_version'] = '100.0.0';
       peer.address = addresses[0];
     };
     peer.completeOpen = () => {};

--- a/test/jest/Pool.spec.ts
+++ b/test/jest/Pool.spec.ts
@@ -1,0 +1,69 @@
+import Pool from '../../lib/p2p/Pool';
+import Logger, { Level } from '../../lib/Logger';
+import Config from '../../lib/Config';
+import DB from '../../lib/db/DB';
+import { XuNetwork } from '../../lib/constants/enums';
+import NodeKey from '../../lib/nodekey/NodeKey';
+
+jest.mock('../../lib/db/DB', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      models: {
+        Node: {
+          findAll: jest.fn(() => []),
+        },
+      },
+    };
+  });
+});
+
+describe('P2P Pool', () => {
+  let db: DB;
+  let pool: Pool;
+  const logger = Logger.createLoggers(Level.Warn).p2p;
+
+  beforeAll(async () => {
+    const nodeKeyTwo = await NodeKey['generate']();
+
+    const config = new Config();
+    config.p2p.listen = false;
+    config.p2p.discover = false;
+    db = new DB(logger);
+
+    pool = new Pool({
+      logger,
+      config: config.p2p,
+      xuNetwork: XuNetwork.SimNet,
+      models: db.models,
+      nodeKey: nodeKeyTwo,
+      version: '1.0.0',
+    });
+
+    await pool.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('updateLndState sets lnd pub key and token identifier', async () => {
+    const lndPubKey = 'lndPubKey';
+    const chain = 'bitcoin-regtest';
+    pool.updateLndState('BTC', lndPubKey, chain);
+    expect(pool.getTokenIdentifier('BTC')).toEqual(chain);
+    expect(pool['nodeState'].lndPubKeys['BTC']).toEqual(lndPubKey);
+  });
+
+  test('updateRaidenState sets Raiden address and token identifiers', async () => {
+    const tokenAddresses = new Map();
+    const raidenAddress = 'raidenAddress';
+    const wethTokenAddress = 'wethtokenaddress';
+    const daiTokenAddress = 'daitokenaddress';
+    tokenAddresses.set('WETH', wethTokenAddress);
+    tokenAddresses.set('DAI', daiTokenAddress);
+    pool.updateRaidenState(tokenAddresses, raidenAddress);
+    expect(pool.getTokenIdentifier('WETH')).toEqual(wethTokenAddress);
+    expect(pool.getTokenIdentifier('DAI')).toEqual(daiTokenAddress);
+    expect(pool['nodeState'].raidenAddress).toEqual(raidenAddress);
+  });
+});

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -122,10 +122,10 @@ describe('Swaps.SwapClientManager', () => {
     expect(swapClientManager.raidenClient.tokenAddresses.get('WETH')).not.toBeUndefined();
     swapClientManager.remove('WETH');
     expect(swapClientManager['swapClients'].size).toEqual(2);
-    const lndPubKeysMap = swapClientManager.getLndPubKeysMap();
-    expect(lndPubKeysMap.size).toEqual(2);
-    expect(lndPubKeysMap.get('BTC')).toEqual(1);
-    expect(lndPubKeysMap.get('LTC')).toEqual(1);
+    const lndClients = swapClientManager.getLndClientsMap();
+    expect(lndClients.size).toEqual(2);
+    expect(lndClients.get('BTC')!.pubKey).toEqual(1);
+    expect(lndClients.get('LTC')!.pubKey).toEqual(1);
     await swapClientManager.getLndClientsInfo();
     expect(lndInfoMock).toHaveBeenCalledTimes(2);
   });

--- a/test/p2p/networks.spec.ts
+++ b/test/p2p/networks.spec.ts
@@ -19,7 +19,7 @@ describe('P2P Networks Tests', () => {
 
       const host = 'localhost';
       const port = destNode['pool']['listenPort']!;
-      const nodeTwoUri = toUri({ host, port, nodePubKey: destNode['pool'].nodeState.nodePubKey });
+      const nodeTwoUri = toUri({ host, port, nodePubKey: destNode['pool'].nodePubKey });
 
       const rejectionMsg = `Peer (${host}:${port}) closed due to WireProtocolErr framer: incompatible msg origin network (expected: ${srcNodeNetwork}, found: ${destNodeNetwork})`;
       await expect(srcNode.service.connect({ nodeUri: nodeTwoUri, retryConnecting: false })).to.be.rejectedWith(rejectionMsg);
@@ -38,8 +38,8 @@ describe('P2P Networks Tests', () => {
       const srcNode = new Xud();
       const destNode = new Xud();
       await Promise.all([srcNode.start(srcNodeConfig), destNode.start(destNodeConfig)]);
-      const srcNodePubKey = srcNode['pool'].nodeState.nodePubKey;
-      const destNodePubKey = destNode['pool'].nodeState.nodePubKey;
+      const srcNodePubKey = srcNode['pool'].nodePubKey;
+      const destNodePubKey = destNode['pool'].nodePubKey;
 
       const host = 'localhost';
       const port = destNode['pool']['listenPort']!;

--- a/test/p2p/sanity.spec.ts
+++ b/test/p2p/sanity.spec.ts
@@ -60,8 +60,8 @@ describe('P2P Sanity Tests', () => {
 
     await Promise.all([nodeOne.start(nodeOneConfig), nodeTwo.start(nodeTwoConfig)]);
 
-    nodeOnePubKey = nodeOne['pool'].nodeState.nodePubKey;
-    nodeTwoPubKey = nodeTwo['pool'].nodeState.nodePubKey;
+    nodeOnePubKey = nodeOne['pool'].nodePubKey;
+    nodeTwoPubKey = nodeTwo['pool'].nodePubKey;
 
     nodeTwoPort = nodeTwo['pool']['listenPort']!;
     nodeOneUri = toUri({ nodePubKey: nodeOnePubKey, host: 'localhost', port: nodeOne['pool']['listenPort']! });
@@ -87,7 +87,7 @@ describe('P2P Sanity Tests', () => {
       done();
     });
 
-    nodeTwo['pool'].updateRaidenAddress(raidenAddress);
+    nodeTwo['pool'].updateRaidenState(new Map(), raidenAddress);
   });
 
   it('should fail connecting to the same node', async () => {

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto';
 import Parser from '../../lib/p2p/Parser';
 import { Packet, PacketType } from '../../lib/p2p/packets';
 import * as packets from '../../lib/p2p/packets/types';
-import { removeUndefinedProps } from '../../lib/utils/utils';
+import { removeUndefinedProps as removeUndefinedPropsTyped } from '../../lib/utils/utils';
 import { DisconnectionReason, SwapFailureReason, XuNetwork } from '../../lib/constants/enums';
 import uuid = require('uuid');
 import { Address, NodeState } from '../../lib/p2p/types';
@@ -13,6 +13,8 @@ import Network from '../../lib/p2p/Network';
 import Framer from '../../lib/p2p/Framer';
 import { errorCodes } from '../../lib/p2p/errors';
 import stringify = require('json-stable-stringify');
+
+const removeUndefinedProps = (obj: any): any => { return removeUndefinedPropsTyped(obj); };
 
 chai.use(chaiAsPromised);
 
@@ -188,16 +190,17 @@ describe('Parser', () => {
   }
 
   const nodeState: NodeState = {
-    version: '1.0.0',
-    nodePubKey: uuid(),
     addresses: [{ host: '1.1.1.1', port: 8885 }, { host: '2.2.2.2', port: 8885 }],
     pairs: [uuid()],
     raidenAddress: uuid(),
     lndPubKeys: { BTC: uuid(), LTC: uuid() },
+    tokenIdentifiers: { BTC: 'bitcoin-testnet', LTC: 'litecoin-testnet' },
   };
 
   const sessionInitPacketBody: SessionInitPacketBody = {
     nodeState,
+    version: '1.0.0',
+    nodePubKey: uuid(),
     sign: uuid(),
     peerPubKey: uuid(),
     ephemeralPubKey: uuid(),
@@ -217,12 +220,11 @@ describe('Parser', () => {
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: { ...nodeState, addresses: [] } }));
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, lndPubKeys: { ...nodeState.lndPubKeys, BTC: undefined } }) }));
     testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, lndPubKeys: { ...nodeState.lndPubKeys, LTC: undefined } }) }));
+    testValidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, tokenIdentifiers: { ...nodeState.tokenIdentifiers, BTC: undefined } }) }));
     testInvalidPacket(new packets.SessionInitPacket(sessionInitPacketBody, uuid()));
     testInvalidPacket(new packets.SessionInitPacket(removeUndefinedProps({ ...sessionInitPacketBody, sign: undefined })));
     testInvalidPacket(new packets.SessionInitPacket(removeUndefinedProps({ ...sessionInitPacketBody, ephemeralPubKey: undefined })));
     testInvalidPacket(new packets.SessionInitPacket(removeUndefinedProps({ ...sessionInitPacketBody, peerPubKey: undefined })));
-    testInvalidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, nodePubKey: undefined }) }));
-    testInvalidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: removeUndefinedProps({ ...nodeState, version: undefined }) }));
     testInvalidPacket(new packets.SessionInitPacket({ ...sessionInitPacketBody, nodeState: { ...nodeState, addresses: [{} as Address] } }));
 
     const sessionAckPacketBody = { ephemeralPubKey: sessionInitPacketBody.ephemeralPubKey };
@@ -230,14 +232,14 @@ describe('Parser', () => {
     testInvalidPacket(new packets.SessionAckPacket(sessionAckPacketBody));
     testInvalidPacket(new packets.SessionAckPacket(removeUndefinedProps({ ...sessionAckPacketBody, ephemeralPubKey: undefined }), uuid()));
 
-    const { version, nodePubKey, ...nodeStateUpdate } = nodeState;
-    testValidPacket(new packets.NodeStateUpdatePacket(nodeStateUpdate));
-    testValidPacket(new packets.NodeStateUpdatePacket({ ...nodeStateUpdate, pairs: [] }));
-    testValidPacket(new packets.NodeStateUpdatePacket({ ...nodeStateUpdate, addresses: [] }));
-    testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeStateUpdate, lndPubKeys: { ...nodeStateUpdate.lndPubKeys, BTC: undefined } })));
-    testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeStateUpdate, lndPubKeys: { ...nodeStateUpdate.lndPubKeys, LTC: undefined } })));
-    testInvalidPacket(new packets.NodeStateUpdatePacket(nodeStateUpdate, uuid()));
-    testInvalidPacket(new packets.NodeStateUpdatePacket({ ...nodeStateUpdate, addresses: [{} as Address] }));
+    testValidPacket(new packets.NodeStateUpdatePacket(nodeState));
+    testValidPacket(new packets.NodeStateUpdatePacket({ ...nodeState, pairs: [] }));
+    testValidPacket(new packets.NodeStateUpdatePacket({ ...nodeState, addresses: [] }));
+    testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeState, lndPubKeys: { ...nodeState.lndPubKeys, BTC: undefined } })));
+    testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeState, lndPubKeys: { ...nodeState.lndPubKeys, LTC: undefined } })));
+    testValidPacket(new packets.NodeStateUpdatePacket(removeUndefinedProps({ ...nodeState, tokenIdentifiers: { ...nodeState.tokenIdentifiers, LTC: undefined } })));
+    testInvalidPacket(new packets.NodeStateUpdatePacket(nodeState, uuid()));
+    testInvalidPacket(new packets.NodeStateUpdatePacket({ ...nodeState, addresses: [{} as Address] }));
 
     const disconnectingPacketBody = {
       reason: DisconnectionReason.IncompatibleProtocolVersion,
@@ -294,8 +296,8 @@ describe('Parser', () => {
     };
     testValidPacket(new packets.GetOrdersPacket(getOrdersPacketBody));
     testInvalidPacket(new packets.GetOrdersPacket(getOrdersPacketBody, uuid()));
-    testInvalidPacket(new packets.OrderInvalidationPacket(removeUndefinedProps({ ...getOrdersPacketBody, pairIds: undefined })));
-    testInvalidPacket(new packets.OrderInvalidationPacket(removeUndefinedProps({ ...getOrdersPacketBody, pairIds: [] })));
+    testInvalidPacket(new packets.GetOrdersPacket(removeUndefinedProps({ ...getOrdersPacketBody, pairIds: undefined })));
+    testInvalidPacket(new packets.GetOrdersPacket(removeUndefinedProps({ ...getOrdersPacketBody, pairIds: [] })));
 
     const ordersPacketBody = [
       orderPacketBody,


### PR DESCRIPTION
At a high level, this adds a concept of a token identifier for each currency supported by xud that is consistent across the entire network.

NOTE: Although this is a breaking change in terms of the p2p messaging, I wound up implementing this without any changes to the database. We already store token addresses in the database, and the lnd chain is determined dynamically after we call `GetInfo`, so no db changes are made and there's no need to drop existing databases after this PR is merged.

"BTC" can mean mainnet tokens or testnet tokens (or simnet, etc...) and can even be misconfigured to point to the LTC lightning network. Meanwhile, Raiden ERC20 tokens refer to a particular token contract, and there's no guarantee that peers won't be using different (and therefore incompatible) contracts for the same currency such as WETH.

Here, we use an identifier to ensure peers are referring to the same token as we are. For currencies that use lnd, the token identifier is determined dynamically using the `chain` and `network` returned by lnd on a `GetInfo` call. For example, BTC mainnet would be "bitcoin-mainnet" and LTC testnet would be "litecoin-testnet". For currencies that use Raiden, we use the token contract address as the identifier.

These token identifiers are shared with peers during the handshake and on any subsequent node state updates. The p2p messaging format is changed to accommodate this. This also drops static node values like the `nodePubKey` and `version` from the node state p2p message, as these values can not change mid-session for a peer.

A future improvement may be to detect and support discrepancies in the currency symbol used by a peer for the same token. For example, a peer that advertises "XBT" with a token identifier of "bitcoin-mainnet" should be compatible with our "BTC" that also is identified as "bitcoin-mainnet". This is not included in this commit as it would require further refactoring and complexity.

Another follow-up may be creating a test suite for the `Peer` class or refactoring it to move logic elsewhere (along with tests for that logic). There is some logic around handling node state updates where information regarding the peer's supported currencies may change that is currently not tested.

Closes #910.

BREAKING CHANGE: Changed p2p messaging structure for `SessionInit` and `NodeStateUpdate` packets.