### PR TITLE
fix: swap sent/received amounts in satoshis

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -951,8 +951,8 @@
 | pair_id | [string](#string) |  | The trading pair that the swap is for. |
 | quantity | [uint64](#uint64) |  | The order quantity that was swapped. |
 | r_hash | [string](#string) |  | The hex-encoded payment hash for the swap. |
-| amount_received | [int64](#int64) |  | The amount of the smallest base unit of the currency (like satoshis or wei) received. |
-| amount_sent | [int64](#int64) |  | The amount of the smallest base unit of the currency (like satoshis or wei) sent. |
+| amount_received | [uint64](#uint64) |  | The amount received denominated in satoshis. |
+| amount_sent | [uint64](#uint64) |  | The amount sent denominated in satoshis. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer that executed this order. |
 | role | [SwapSuccess.Role](#xudrpc.SwapSuccess.Role) |  | Our role in the swap, either MAKER or TAKER. |
 | currency_received | [string](#string) |  | The ticker symbol of the currency received. |

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -66,9 +66,9 @@ export enum SwapPhase {
    * could still fail due to no route with sufficient capacity, lack of cooperation from the
    * receiver or any intermediary node along the route, or an unexpected error from swap client.
    */
-  SendingAmount = 3,
+  SendingPayment = 3,
   /** We have received the agreed amount of the swap, and the preimage is now known to both sides. */
-  AmountReceived = 4,
+  PaymentReceived = 4,
   /** The swap has been formally completed and both sides have confirmed they've received payment. */
   SwapCompleted = 5,
 }

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -28,7 +28,8 @@ export type CurrencyAttributes = CurrencyFactory & {
 export type CurrencyInstance = CurrencyAttributes & Sequelize.Instance<CurrencyAttributes>;
 
 /* SwapDeal */
-export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal, 'makerToTakerRoutes' | 'price' | 'pairId' | 'isBuy'>>;
+export type SwapDealFactory = Pick<SwapDeal, Exclude<keyof SwapDeal,
+  'makerToTakerRoutes' | 'price' | 'pairId' | 'isBuy' | 'takerUnits' | 'makerUnits'>>;
 
 export type SwapDealAttributes = SwapDealFactory & {
   /** The internal db node id of the counterparty peer for this swap deal. */

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -312,11 +312,11 @@ class LndClient extends SwapClient {
       if (deal.role === SwapRole.Taker) {
         // we are the taker paying the maker
         request.setFinalCltvDelta(deal.makerCltvDelta!);
-        request.setAmt(deal.makerAmount);
+        request.setAmt(deal.makerUnits);
       } else {
         // we are the maker paying the taker
         request.setFinalCltvDelta(deal.takerCltvDelta);
-        request.setAmt(deal.takerAmount);
+        request.setAmt(deal.takerUnits);
       }
 
       try {

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -173,7 +173,7 @@ class OrderBook extends EventEmitter {
       }
     });
     this.swaps.on('swap.failed', (deal) => {
-      if (deal.role === SwapRole.Maker && (deal.phase === SwapPhase.SwapAgreed || deal.phase === SwapPhase.SendingAmount)) {
+      if (deal.role === SwapRole.Maker && (deal.phase === SwapPhase.SwapAgreed || deal.phase === SwapPhase.SendingPayment)) {
         // if our order is the maker and the swap failed after it was agreed to but before it was executed
         // we must release the hold on the order that we set when we agreed to the deal
         this.removeOrderHold(deal.orderId, deal.pairId, deal.quantity!);
@@ -376,13 +376,13 @@ class OrderBook extends EventEmitter {
 
     if (!this.nobalancechecks) {
       // check if sufficient outbound channel capacity exists
-      const { outboundCurrency, outboundAmount } = Swaps.calculateInboundOutboundAmounts(order.quantity, order.price, order.isBuy, order.pairId);
+      const { outboundCurrency, outboundUnits } = Swaps.calculateInboundOutboundAmounts(order.quantity, order.price, order.isBuy, order.pairId);
       const swapClient = this.swaps.swapClientManager.get(outboundCurrency);
       if (!swapClient) {
         throw swapsErrors.SWAP_CLIENT_NOT_FOUND(outboundCurrency);
       }
-      if (outboundAmount > swapClient.maximumOutboundCapacity) {
-        throw errors.INSUFFICIENT_OUTBOUND_BALANCE(outboundCurrency, outboundAmount, swapClient.maximumOutboundCapacity);
+      if (outboundUnits > swapClient.maximumOutboundCapacity) {
+        throw errors.INSUFFICIENT_OUTBOUND_BALANCE(outboundCurrency, outboundUnits, swapClient.maximumOutboundCapacity);
       }
     }
 

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1321,13 +1321,13 @@
         },
         "amount_received": {
           "type": "string",
-          "format": "int64",
-          "description": "The amount of the smallest base unit of the currency (like satoshis or wei) received."
+          "format": "uint64",
+          "description": "The amount received denominated in satoshis."
         },
         "amount_sent": {
           "type": "string",
-          "format": "int64",
-          "description": "The amount of the smallest base unit of the currency (like satoshis or wei) sent."
+          "format": "uint64",
+          "description": "The amount sent denominated in satoshis."
         },
         "peer_pub_key": {
           "type": "string",

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -9943,11 +9943,11 @@ proto.xudrpc.SwapSuccess.deserializeBinaryFromReader = function(msg, reader) {
       msg.setRHash(value);
       break;
     case 8:
-      var value = /** @type {number} */ (reader.readInt64());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setAmountReceived(value);
       break;
     case 9:
-      var value = /** @type {number} */ (reader.readInt64());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setAmountSent(value);
       break;
     case 10:
@@ -10040,14 +10040,14 @@ proto.xudrpc.SwapSuccess.serializeBinaryToWriter = function(message, writer) {
   }
   f = message.getAmountReceived();
   if (f !== 0) {
-    writer.writeInt64(
+    writer.writeUint64(
       8,
       f
     );
   }
   f = message.getAmountSent();
   if (f !== 0) {
-    writer.writeInt64(
+    writer.writeUint64(
       9,
       f
     );
@@ -10181,7 +10181,7 @@ proto.xudrpc.SwapSuccess.prototype.setRHash = function(value) {
 
 
 /**
- * optional int64 amount_received = 8;
+ * optional uint64 amount_received = 8;
  * @return {number}
  */
 proto.xudrpc.SwapSuccess.prototype.getAmountReceived = function() {
@@ -10196,7 +10196,7 @@ proto.xudrpc.SwapSuccess.prototype.setAmountReceived = function(value) {
 
 
 /**
- * optional int64 amount_sent = 9;
+ * optional uint64 amount_sent = 9;
  * @return {number}
  */
 proto.xudrpc.SwapSuccess.prototype.getAmountSent = function() {

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -110,11 +110,11 @@ class RaidenClient extends SwapClient {
     let tokenAddress;
     if (deal.role === SwapRole.Maker) {
       // we are the maker paying the taker
-      amount = deal.takerAmount;
+      amount = deal.takerUnits;
       tokenAddress = this.tokenAddresses.get(deal.takerCurrency);
     } else {
       // we are the taker paying the maker
-      amount = deal.makerAmount;
+      amount = deal.makerUnits;
       tokenAddress = this.tokenAddresses.get(deal.makerCurrency);
     }
     if (!tokenAddress) {

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -32,16 +32,20 @@ export type SwapDeal = {
   quantity?: number;
   /** The trading pair for the swap. The pairId together with the orderId are needed to find the maker order in the order book. */
   pairId: string;
-  /** The number of satoshis (or equivalent) the taker is expecting to receive. */
+  /** The amount the taker is expecting to receive denominated in satoshis. */
   takerAmount: number;
+  /** The number of the smallest base units of the currency (like satoshis or wei) the maker is expecting to receive. */
+  takerUnits: number;
   /** The currency the taker is expecting to receive. */
   takerCurrency: string;
   /** Taker's lnd pubkey on the taker currency's network. */
   takerPubKey?: string;
   /** The CLTV delta from the current height that should be used to set the timelock for the final hop when sending to taker. */
   takerCltvDelta: number;
-  /** The number of satoshis (or equivalent) the maker is expecting to receive. */
+  /** The amount the maker is expecting to receive denominated in satoshis. */
   makerAmount: number;
+  /** The number of the smallest base units of the currency (like satoshis or wei) the maker is expecting to receive. */
+  makerUnits: number;
   /** The currency the maker is expecting to receive. */
   makerCurrency: string;
   /** The CLTV delta from the current height that should be used to set the timelock for the final hop when sending to maker. */
@@ -63,9 +67,9 @@ export type SwapDeal = {
 
 /** The result of a successful swap. */
 export type SwapSuccess = Pick<SwapDeal, 'orderId' | 'localId' | 'pairId' | 'rHash' | 'peerPubKey' | 'price' | 'rPreimage' | 'role'> & {
-  /** The amount of satoshis (or equivalent) received. */
+  /** The amount received denominated in satoshis. */
   amountReceived: number;
-  /** The amount of satoshis (or equivalent) sent. */
+  /** The amount sent denominated in satoshis. */
   amountSent: number;
   /** The ticker symbol of the currency received. */
   currencyReceived: string;

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -605,10 +605,10 @@ message SwapSuccess {
   uint64 quantity = 4 [json_name = "quantity"];
   // The hex-encoded payment hash for the swap.
   string r_hash = 5 [json_name = "r_hash"];
-  // The amount of the smallest base unit of the currency (like satoshis or wei) received.
-  int64 amount_received = 8 [json_name = "amount_received"];
-  // The amount of the smallest base unit of the currency (like satoshis or wei) sent.
-  int64 amount_sent = 9 [json_name = "amount_sent"];
+  // The amount received denominated in satoshis.
+  uint64 amount_received = 8 [json_name = "amount_received"];
+  // The amount sent denominated in satoshis.
+  uint64 amount_sent = 9 [json_name = "amount_sent"];
   // The node pub key of the peer that executed this order.
   string peer_pub_key = 10 [json_name = "peer_pub_key"];
   enum Role {

--- a/test/integration/Swaps.spec.ts
+++ b/test/integration/Swaps.spec.ts
@@ -69,6 +69,8 @@ const validSwapDeal = () => {
     makerCurrency: 'LTC',
     takerAmount: 8,
     makerAmount: 1000,
+    takerUnits: 8,
+    makerUnits: 1000,
     peerPubKey: '030130758847ada485520016a075833b8638c7e5a56889cb4b76e10c0f61f3520c',
     localId: '20b63440-e689-11e8-aa83-51505ebd3ca7',
     price: 0.008,

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -184,8 +184,10 @@ describe('OrderBook', () => {
       return {
         inboundCurrency: 'BTC',
         inboundAmount: 50000000000,
+        inboundUnits: 50000000000,
         outboundCurrency: 'LTC',
         outboundAmount: quantity,
+        outboundUnits: quantity,
       };
     };
     swaps.swapClientManager.get = jest.fn().mockReturnValue({

--- a/test/jest/RaidenClient.spec.ts
+++ b/test/jest/RaidenClient.spec.ts
@@ -29,6 +29,8 @@ const getValidDeal = () => {
     quantity: 10000,
     makerAmount: 10000,
     takerAmount: 1000,
+    makerUnits: 10000,
+    takerUnits: 1000,
     makerCurrency: 'LTC',
     takerCurrency: 'BTC',
     destination: '034c5266591bff232d1647f45bcf6bbc548d3d6f70b2992d28aba0afae067880ac',

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -40,6 +40,8 @@ const deal: SwapDeal = {
   makerCurrency: 'LTC',
   takerAmount: 5000,
   makerAmount: 1000000,
+  takerUnits: 5000,
+  makerUnits: 1000000,
   takerCltvDelta: 144,
   makerCltvDelta: 144,
   rPreimage: '60743C0B6BFA885E30F101705764F43F8EF7E613DD0F07AD5178C7D9B1682B9E',

--- a/test/unit/Swaps.spec.ts
+++ b/test/unit/Swaps.spec.ts
@@ -30,8 +30,10 @@ describe('Swaps', () => {
     isBuy: true,
     makerCurrency: 'LTC',
     takerCurrency: 'BTC',
-    makerAmount: Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity,
-    takerAmount: Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price,
+    makerAmount: quantity,
+    takerAmount: quantity * price,
+    makerUnits: Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity,
+    takerUnits: Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price,
     createTime: 1540716251106,
   };
 
@@ -40,8 +42,10 @@ describe('Swaps', () => {
     pairId: 'WETH/BTC',
     makerCurrency: 'WETH',
     takerCurrency: 'BTC',
-    makerAmount: Swaps['UNITS_PER_CURRENCY']['WETH'] * quantity,
-    takerAmount: Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price,
+    makerAmount: quantity,
+    takerAmount: quantity * price,
+    makerUnits: Swaps['UNITS_PER_CURRENCY']['WETH'] * quantity,
+    takerUnits: Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price,
   };
 
   /** A swap deal for a sell order, mirrored from the buy deal for convenience. */
@@ -52,6 +56,8 @@ describe('Swaps', () => {
     makerCurrency: buyDeal.takerCurrency,
     takerAmount: buyDeal.makerAmount,
     makerAmount: buyDeal.takerAmount,
+    takerUnits: buyDeal.makerUnits,
+    makerUnits: buyDeal.takerUnits,
   };
 
   const swapRequest: SwapRequestPacketBody = {
@@ -63,21 +69,27 @@ describe('Swaps', () => {
   };
 
   it('should calculate swap amounts and currencies for a buy order', () => {
-    const { makerCurrency, makerAmount, takerCurrency, takerAmount } = Swaps['calculateMakerTakerAmounts'](
-      buyDeal.quantity!, buyDeal.price, buyDeal.isBuy, buyDeal.pairId,
-    );
+    const { makerCurrency, makerAmount, takerCurrency, takerAmount, makerUnits, takerUnits } =
+      Swaps['calculateMakerTakerAmounts'](
+        buyDeal.quantity!, buyDeal.price, buyDeal.isBuy, buyDeal.pairId,
+      );
     expect(makerAmount).to.equal(buyDeal.makerAmount);
     expect(takerAmount).to.equal(buyDeal.takerAmount);
+    expect(makerUnits).to.equal(buyDeal.makerUnits);
+    expect(takerUnits).to.equal(buyDeal.takerUnits);
     expect(makerCurrency).to.equal(buyDeal.makerCurrency);
     expect(takerCurrency).to.equal(buyDeal.takerCurrency);
   });
 
   it('should calculate swap amounts and currencies for a sell order', () => {
-    const { makerCurrency, makerAmount, takerCurrency, takerAmount } = Swaps['calculateMakerTakerAmounts'](
-      sellDeal.quantity!, sellDeal.price, sellDeal.isBuy, sellDeal.pairId,
-    );
+    const { makerCurrency, makerAmount, takerCurrency, takerAmount, makerUnits, takerUnits } =
+      Swaps['calculateMakerTakerAmounts'](
+        sellDeal.quantity!, sellDeal.price, sellDeal.isBuy, sellDeal.pairId,
+      );
     expect(makerAmount).to.equal(sellDeal.makerAmount);
     expect(takerAmount).to.equal(sellDeal.takerAmount);
+    expect(makerUnits).to.equal(sellDeal.makerUnits);
+    expect(takerUnits).to.equal(sellDeal.takerUnits);
     expect(makerCurrency).to.equal(sellDeal.makerCurrency);
     expect(takerCurrency).to.equal(sellDeal.takerCurrency);
   });
@@ -93,35 +105,52 @@ describe('Swaps', () => {
   });
 
   it('should calculate inbound and outbound amounts and currencies for a buy order', () => {
-    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount } =
+    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount, inboundUnits, outboundUnits } =
       Swaps.calculateInboundOutboundAmounts(quantity, price, true, pairId);
     expect(inboundCurrency).to.equal('LTC');
-    expect(inboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity);
+    expect(inboundAmount).to.equal(quantity);
+    expect(inboundUnits).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity);
     expect(outboundCurrency).to.equal('BTC');
-    expect(outboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity * price);
+    expect(outboundAmount).to.equal(quantity * price);
+    expect(outboundUnits).to.equal(Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price);
   });
 
   it('should calculate inbound and outbound amounts and currencies for a sell order', () => {
-    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount } =
+    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount, inboundUnits, outboundUnits } =
       Swaps.calculateInboundOutboundAmounts(quantity, price, false, pairId);
     expect(inboundCurrency).to.equal('BTC');
-    expect(inboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity * price);
+    expect(inboundAmount).to.equal(quantity * price);
+    expect(inboundUnits).to.equal(Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price);
     expect(outboundCurrency).to.equal('LTC');
-    expect(outboundAmount).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity);
+    expect(outboundAmount).to.equal(quantity);
+    expect(outboundUnits).to.equal(Swaps['UNITS_PER_CURRENCY']['LTC'] * quantity);
   });
 
   it('should calculate 0 outbound amount for a market buy order', () => {
-    const { outboundCurrency, outboundAmount } =
+    const { outboundCurrency, outboundAmount, outboundUnits } =
       Swaps.calculateInboundOutboundAmounts(quantity, 0, true, pairId);
     expect(outboundCurrency).to.equal('BTC');
     expect(outboundAmount).to.equal(0);
+    expect(outboundUnits).to.equal(0);
   });
 
   it('should calculate 0 inbound amount for a market sell order', () => {
-    const { inboundCurrency, inboundAmount } =
+    const { inboundCurrency, inboundAmount, inboundUnits } =
       Swaps.calculateInboundOutboundAmounts(quantity, Number.POSITIVE_INFINITY, false, pairId);
     expect(inboundCurrency).to.equal('BTC');
     expect(inboundAmount).to.equal(0);
+    expect(inboundUnits).to.equal(0);
+  });
+
+  it('should calculate inbound and outbound amounts and currencies for a raiden order', () => {
+    const { inboundCurrency, inboundAmount, outboundCurrency, outboundAmount, inboundUnits, outboundUnits } =
+      Swaps.calculateInboundOutboundAmounts(quantity, price, true, 'WETH/BTC');
+    expect(inboundCurrency).to.equal('WETH');
+    expect(inboundAmount).to.equal(quantity);
+    expect(inboundUnits).to.equal(Swaps['UNITS_PER_CURRENCY']['WETH'] * quantity);
+    expect(outboundCurrency).to.equal('BTC');
+    expect(outboundAmount).to.equal(quantity * price);
+    expect(outboundUnits).to.equal(Swaps['UNITS_PER_CURRENCY']['BTC'] * quantity * price);
   });
 
   it('should validate a good swap request', () => {


### PR DESCRIPTION
Fixes #1063.

This scales the `amountReceived`, `amountSent`, `makerAmount`, and `takerAmount` fields to always be denominated in satoshis, even for currencies where the smallest unit is smaller than  a satoshi. In their place this adds `takerUnits` and `makerUnits` to the `SwapDeal` type to track the amounts in each currency's base unit for sending & receiving.

This prevents errors on the rpc layer, where amounts in wei can easily exceed the limits of `int64`. It also prevents issues in storing these values in the database, where these fields are likewise represented as 64 bit integers.

This also renames several enum values to use the word "Payment" instead of "Amount" (as in "PaymentReceived") to avoid any possible confusion since "amount" is typically used to refer to a number.