### PR TITLE
refactor: proto definition cleanup

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -189,8 +189,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| balance | [int64](#int64) |  | Sum of channels balances denominated in satoshis or equivalent. |
-| pending_open_balance | [int64](#int64) |  | Sum of channels pending balances denominated in satoshis or equivalent. |
+| balance | [uint64](#uint64) |  | Sum of channel balances denominated in satoshis. |
+| pending_open_balance | [uint64](#uint64) |  | Sum of pending channel balances denominated in satoshis. |
 
 
 
@@ -321,7 +321,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| num_nodes | [int32](#int32) |  |  |
+| num_nodes | [uint32](#uint32) |  |  |
 
 
 
@@ -339,7 +339,7 @@
 | order_id | [string](#string) |  | The order id of the maker order. |
 | pair_id | [string](#string) |  | The trading pair of the swap orders. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly. |
-| quantity | [uint64](#uint64) |  | The quantity to swap. The whole order will be swapped if unspecified. |
+| quantity | [uint64](#uint64) |  | The quantity to swap denominated in satoshis. The whole order will be swapped if unspecified. |
 
 
 
@@ -367,8 +367,8 @@
 | version | [string](#string) |  | The version of this instance of xud. |
 | node_pub_key | [string](#string) |  | The node pub key of this node. |
 | uris | [string](#string) | repeated | A list of uris that can be used to connect to this node. These are shared with peers. |
-| num_peers | [int32](#int32) |  | The number of currently connected peers. |
-| num_pairs | [int32](#int32) |  | The number of supported trading pairs. |
+| num_peers | [uint32](#uint32) |  | The number of currently connected peers. |
+| num_pairs | [uint32](#uint32) |  | The number of supported trading pairs. |
 | orders | [OrdersCount](#xudrpc.OrdersCount) |  | The number of active, standing orders in the order book. |
 | lnd | [GetInfoResponse.LndEntry](#xudrpc.GetInfoResponse.LndEntry) | repeated |  |
 | raiden | [RaidenInfo](#xudrpc.RaidenInfo) |  |  |
@@ -417,7 +417,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| reputationScore | [int32](#int32) |  | The node&#39;s reputation score. Points are subtracted for unexpected or potentially malicious behavior. Points are added when swaps are successfully executed. |
+| reputationScore | [sint32](#sint32) |  | The node&#39;s reputation score. Points are subtracted for unexpected or potentially malicious behavior. Points are added when swaps are successfully executed. |
 | banned | [bool](#bool) |  | Whether the node is currently banned. |
 
 
@@ -460,7 +460,7 @@
 | ----- | ---- | ----- | ----------- |
 | pair_id | [string](#string) |  | The trading pair for which to retrieve orders. |
 | include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not. |
-| limit | [int32](#int32) |  | The maximum number of orders to return from each side of the order book. |
+| limit | [uint32](#uint32) |  | The maximum number of orders to return from each side of the order book. |
 
 
 
@@ -556,9 +556,9 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| active | [int32](#int32) |  | The number of active/online channels for this lnd instance that can be used for swaps. |
-| inactive | [int32](#int32) |  | The number of inactive/offline channels for this lnd instance. |
-| pending | [int32](#int32) |  | The number of channels that are pending on-chain confirmation before they can be used. |
+| active | [uint32](#uint32) |  | The number of active/online channels for this lnd instance that can be used for swaps. |
+| inactive | [uint32](#uint32) |  | The number of inactive/offline channels for this lnd instance. |
+| pending | [uint32](#uint32) |  | The number of channels that are pending on-chain confirmation before they can be used. |
 
 
 
@@ -576,7 +576,7 @@
 | error | [string](#string) |  |  |
 | channels | [LndChannels](#xudrpc.LndChannels) |  |  |
 | chains | [Chain](#xudrpc.Chain) | repeated |  |
-| blockheight | [int32](#int32) |  |  |
+| blockheight | [uint32](#uint32) |  |  |
 | uris | [string](#string) | repeated |  |
 | version | [string](#string) |  |  |
 | alias | [string](#string) |  |  |
@@ -600,10 +600,10 @@
 | id | [string](#string) |  | A UUID for this order. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer that created this order. |
 | local_id | [string](#string) |  | The local id for this order. |
-| created_at | [int64](#int64) |  | The epoch time when this order was created. |
+| created_at | [uint64](#uint64) |  | The epoch time when this order was created. |
 | side | [OrderSide](#xudrpc.OrderSide) |  | Whether this order is a buy or sell |
 | is_own_order | [bool](#bool) |  | Whether this order is a local own order or a remote peer order. |
-| hold | [uint64](#uint64) |  | The quantity on hold pending swap exectuion. |
+| hold | [uint64](#uint64) |  | The quantity on hold pending swap execution. |
 
 
 
@@ -618,7 +618,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| quantity | [uint64](#uint64) |  | The quantity of the order being removed. |
+| quantity | [uint64](#uint64) |  | The quantity removed from the order. |
 | pair_id | [string](#string) |  | The trading pair that the order is for. |
 | order_id | [string](#string) |  | The global UUID for the order. |
 | local_id | [string](#string) |  | The local id for the order, if applicable. |
@@ -669,8 +669,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| peer | [int32](#int32) |  | The number of orders belonging to remote xud nodes. |
-| own | [int32](#int32) |  | The number of orders belonging to our local xud node. |
+| peer | [uint32](#uint32) |  | The number of orders belonging to remote xud nodes. |
+| own | [uint32](#uint32) |  | The number of orders belonging to our local xud node. |
 
 
 
@@ -691,7 +691,7 @@
 | inbound | [bool](#bool) |  | Indicates whether this peer was connected inbound. |
 | pairs | [string](#string) | repeated | A list of trading pair tickers supported by this peer. |
 | xud_version | [string](#string) |  | The version of xud being used by the peer. |
-| seconds_connected | [int32](#int32) |  | The time in seconds that we have been connected to this peer. |
+| seconds_connected | [uint32](#uint32) |  | The time in seconds that we have been connected to this peer. |
 | raiden_address | [string](#string) |  | The raiden address for this peer |
 
 
@@ -742,10 +742,10 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | price | [double](#double) |  | The price of the order. |
-| quantity | [uint64](#uint64) |  | The quantity of the order in satoshis. |
+| quantity | [uint64](#uint64) |  | The quantity of the order denominated in satoshis. |
 | pair_id | [string](#string) |  | The trading pair that the order is for. |
 | order_id | [string](#string) |  | The local id to assign to the order. |
-| side | [OrderSide](#xudrpc.OrderSide) |  | Whether the order is a Buy or Sell. |
+| side | [OrderSide](#xudrpc.OrderSide) |  | Whether the order is a buy or sell. |
 
 
 
@@ -780,7 +780,7 @@
 | ----- | ---- | ----- | ----------- |
 | error | [string](#string) |  |  |
 | address | [string](#string) |  |  |
-| channels | [int32](#int32) |  |  |
+| channels | [uint32](#uint32) |  |  |
 | version | [string](#string) |  |  |
 
 
@@ -822,7 +822,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | order_id | [string](#string) |  | The local id of the order to remove. |
-| quantity | [uint64](#uint64) |  | The quantity to remove from the order. If zero or unspecified then entire order is removed. |
+| quantity | [uint64](#uint64) |  | The quantity to remove from the order denominated in satoshis. If zero or unspecified then the entire order is removed. |
 
 
 
@@ -950,7 +950,7 @@
 | local_id | [string](#string) |  | The local id for the order that was swapped. |
 | pair_id | [string](#string) |  | The trading pair that the swap is for. |
 | quantity | [uint64](#uint64) |  | The order quantity that was swapped. |
-| r_hash | [string](#string) |  | The hex-encoded payment hash for the swaps. |
+| r_hash | [string](#string) |  | The hex-encoded payment hash for the swap. |
 | amount_received | [int64](#int64) |  | The amount of the smallest base unit of the currency (like satoshis or wei) received. |
 | amount_sent | [int64](#int64) |  | The amount of the smallest base unit of the currency (like satoshis or wei) sent. |
 | peer_pub_key | [string](#string) |  | The node pub key of the peer that executed this order. |

--- a/lib/orderbook/types.ts
+++ b/lib/orderbook/types.ts
@@ -56,7 +56,7 @@ export type OrderIdentifier = Pick<MarketOrder, 'pairId'> & {
 type Local = {
   /** A local identifier for the order. */
   localId: string;
-  /** The amount of an order that is on hold pending swap exectuion. */
+  /** The amount of an order that is on hold pending swap execution. */
   hold: number;
 };
 

--- a/lib/proto/xudp2p_pb.js
+++ b/lib/proto/xudp2p_pb.js
@@ -3890,7 +3890,7 @@ proto.xudp2p.SwapRequestPacket.deserializeBinaryFromReader = function(msg, reade
       msg.setRHash(value);
       break;
     case 6:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setTakerCltvDelta(value);
       break;
     default:
@@ -3959,7 +3959,7 @@ proto.xudp2p.SwapRequestPacket.serializeBinaryToWriter = function(message, write
   }
   f = message.getTakerCltvDelta();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       6,
       f
     );
@@ -4043,7 +4043,7 @@ proto.xudp2p.SwapRequestPacket.prototype.setRHash = function(value) {
 
 
 /**
- * optional int32 taker_cltv_delta = 6;
+ * optional uint32 taker_cltv_delta = 6;
  * @return {number}
  */
 proto.xudp2p.SwapRequestPacket.prototype.getTakerCltvDelta = function() {
@@ -4162,7 +4162,7 @@ proto.xudp2p.SwapAcceptedPacket.deserializeBinaryFromReader = function(msg, read
       msg.setQuantity(value);
       break;
     case 5:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setMakerCltvDelta(value);
       break;
     default:
@@ -4224,7 +4224,7 @@ proto.xudp2p.SwapAcceptedPacket.serializeBinaryToWriter = function(message, writ
   }
   f = message.getMakerCltvDelta();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       5,
       f
     );
@@ -4293,7 +4293,7 @@ proto.xudp2p.SwapAcceptedPacket.prototype.setQuantity = function(value) {
 
 
 /**
- * optional int32 maker_cltv_delta = 5;
+ * optional uint32 maker_cltv_delta = 5;
  * @return {number}
  */
 proto.xudp2p.SwapAcceptedPacket.prototype.getMakerCltvDelta = function() {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -297,7 +297,7 @@
             "in": "query",
             "required": false,
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         ],
         "tags": [
@@ -698,13 +698,13 @@
       "properties": {
         "balance": {
           "type": "string",
-          "format": "int64",
-          "description": "Sum of channels balances denominated in satoshis or equivalent."
+          "format": "uint64",
+          "description": "Sum of channel balances denominated in satoshis."
         },
         "pending_open_balance": {
           "type": "string",
-          "format": "int64",
-          "description": "Sum of channels pending balances denominated in satoshis or equivalent."
+          "format": "uint64",
+          "description": "Sum of pending channel balances denominated in satoshis."
         }
       }
     },
@@ -757,7 +757,7 @@
       "properties": {
         "num_nodes": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         }
       }
     },
@@ -779,7 +779,7 @@
         "quantity": {
           "type": "string",
           "format": "uint64",
-          "description": "The quantity to swap. The whole order will be swapped if unspecified."
+          "description": "The quantity to swap denominated in satoshis. The whole order will be swapped if unspecified."
         }
       }
     },
@@ -803,12 +803,12 @@
         },
         "num_peers": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of currently connected peers."
         },
         "num_pairs": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of supported trading pairs."
         },
         "orders": {
@@ -894,17 +894,17 @@
       "properties": {
         "active": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of active/online channels for this lnd instance that can be used for swaps."
         },
         "inactive": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of inactive/offline channels for this lnd instance."
         },
         "pending": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of channels that are pending on-chain confirmation before they can be used."
         }
       }
@@ -926,7 +926,7 @@
         },
         "blockheight": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "uris": {
           "type": "array",
@@ -973,7 +973,7 @@
         },
         "created_at": {
           "type": "string",
-          "format": "int64",
+          "format": "uint64",
           "description": "The epoch time when this order was created."
         },
         "side": {
@@ -988,7 +988,7 @@
         "hold": {
           "type": "string",
           "format": "uint64",
-          "description": "The quantity on hold pending swap exectuion."
+          "description": "The quantity on hold pending swap execution."
         }
       }
     },
@@ -998,7 +998,7 @@
         "quantity": {
           "type": "string",
           "format": "uint64",
-          "description": "The quantity of the order being removed."
+          "description": "The quantity removed from the order."
         },
         "pair_id": {
           "type": "string",
@@ -1064,12 +1064,12 @@
       "properties": {
         "peer": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of orders belonging to remote xud nodes."
         },
         "own": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The number of orders belonging to our local xud node."
         }
       }
@@ -1110,7 +1110,7 @@
         },
         "seconds_connected": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "description": "The time in seconds that we have been connected to this peer."
         },
         "raiden_address": {
@@ -1151,7 +1151,7 @@
         "quantity": {
           "type": "string",
           "format": "uint64",
-          "description": "The quantity of the order in satoshis."
+          "description": "The quantity of the order denominated in satoshis."
         },
         "pair_id": {
           "type": "string",
@@ -1163,7 +1163,7 @@
         },
         "side": {
           "$ref": "#/definitions/xudrpcOrderSide",
-          "description": "Whether the order is a Buy or Sell."
+          "description": "Whether the order is a buy or sell."
         }
       }
     },
@@ -1208,7 +1208,7 @@
         },
         "channels": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "version": {
           "type": "string"
@@ -1237,7 +1237,7 @@
         "quantity": {
           "type": "string",
           "format": "uint64",
-          "description": "The quantity to remove from the order. If zero or unspecified then entire order is removed."
+          "description": "The quantity to remove from the order denominated in satoshis.\nIf zero or unspecified then the entire order is removed."
         }
       }
     },
@@ -1317,7 +1317,7 @@
         },
         "r_hash": {
           "type": "string",
-          "description": "The hex-encoded payment hash for the swaps."
+          "description": "The hex-encoded payment hash for the swap."
         },
         "amount_received": {
           "type": "string",

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -1780,11 +1780,11 @@ proto.xudrpc.ChannelBalance.deserializeBinaryFromReader = function(msg, reader) 
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readInt64());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setBalance(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readInt64());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setPendingOpenBalance(value);
       break;
     default:
@@ -1818,14 +1818,14 @@ proto.xudrpc.ChannelBalance.serializeBinaryToWriter = function(message, writer) 
   var f = undefined;
   f = message.getBalance();
   if (f !== 0) {
-    writer.writeInt64(
+    writer.writeUint64(
       1,
       f
     );
   }
   f = message.getPendingOpenBalance();
   if (f !== 0) {
-    writer.writeInt64(
+    writer.writeUint64(
       2,
       f
     );
@@ -1834,7 +1834,7 @@ proto.xudrpc.ChannelBalance.serializeBinaryToWriter = function(message, writer) 
 
 
 /**
- * optional int64 balance = 1;
+ * optional uint64 balance = 1;
  * @return {number}
  */
 proto.xudrpc.ChannelBalance.prototype.getBalance = function() {
@@ -1849,7 +1849,7 @@ proto.xudrpc.ChannelBalance.prototype.setBalance = function(value) {
 
 
 /**
- * optional int64 pending_open_balance = 2;
+ * optional uint64 pending_open_balance = 2;
  * @return {number}
  */
 proto.xudrpc.ChannelBalance.prototype.getPendingOpenBalance = function() {
@@ -3107,11 +3107,11 @@ proto.xudrpc.GetInfoResponse.deserializeBinaryFromReader = function(msg, reader)
       msg.addUris(value);
       break;
     case 4:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setNumPeers(value);
       break;
     case 5:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setNumPairs(value);
       break;
     case 6:
@@ -3182,14 +3182,14 @@ proto.xudrpc.GetInfoResponse.serializeBinaryToWriter = function(message, writer)
   }
   f = message.getNumPeers();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       4,
       f
     );
   }
   f = message.getNumPairs();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       5,
       f
     );
@@ -3277,7 +3277,7 @@ proto.xudrpc.GetInfoResponse.prototype.clearUrisList = function() {
 
 
 /**
- * optional int32 num_peers = 4;
+ * optional uint32 num_peers = 4;
  * @return {number}
  */
 proto.xudrpc.GetInfoResponse.prototype.getNumPeers = function() {
@@ -3292,7 +3292,7 @@ proto.xudrpc.GetInfoResponse.prototype.setNumPeers = function(value) {
 
 
 /**
- * optional int32 num_pairs = 5;
+ * optional uint32 num_pairs = 5;
  * @return {number}
  */
 proto.xudrpc.GetInfoResponse.prototype.getNumPairs = function() {
@@ -3612,7 +3612,7 @@ proto.xudrpc.GetNodeInfoResponse.deserializeBinaryFromReader = function(msg, rea
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readSint32());
       msg.setReputationscore(value);
       break;
     case 2:
@@ -3650,7 +3650,7 @@ proto.xudrpc.GetNodeInfoResponse.serializeBinaryToWriter = function(message, wri
   var f = undefined;
   f = message.getReputationscore();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeSint32(
       1,
       f
     );
@@ -3666,7 +3666,7 @@ proto.xudrpc.GetNodeInfoResponse.serializeBinaryToWriter = function(message, wri
 
 
 /**
- * optional int32 reputationScore = 1;
+ * optional sint32 reputationScore = 1;
  * @return {number}
  */
 proto.xudrpc.GetNodeInfoResponse.prototype.getReputationscore = function() {
@@ -3792,7 +3792,7 @@ proto.xudrpc.ListOrdersRequest.deserializeBinaryFromReader = function(msg, reade
       msg.setIncludeOwnOrders(value);
       break;
     case 3:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setLimit(value);
       break;
     default:
@@ -3840,7 +3840,7 @@ proto.xudrpc.ListOrdersRequest.serializeBinaryToWriter = function(message, write
   }
   f = message.getLimit();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       3,
       f
     );
@@ -3881,7 +3881,7 @@ proto.xudrpc.ListOrdersRequest.prototype.setIncludeOwnOrders = function(value) {
 
 
 /**
- * optional int32 limit = 3;
+ * optional uint32 limit = 3;
  * @return {number}
  */
 proto.xudrpc.ListOrdersRequest.prototype.getLimit = function() {
@@ -4968,15 +4968,15 @@ proto.xudrpc.LndChannels.deserializeBinaryFromReader = function(msg, reader) {
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setActive(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setInactive(value);
       break;
     case 3:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setPending(value);
       break;
     default:
@@ -5010,21 +5010,21 @@ proto.xudrpc.LndChannels.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getActive();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       1,
       f
     );
   }
   f = message.getInactive();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       2,
       f
     );
   }
   f = message.getPending();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       3,
       f
     );
@@ -5033,7 +5033,7 @@ proto.xudrpc.LndChannels.serializeBinaryToWriter = function(message, writer) {
 
 
 /**
- * optional int32 active = 1;
+ * optional uint32 active = 1;
  * @return {number}
  */
 proto.xudrpc.LndChannels.prototype.getActive = function() {
@@ -5048,7 +5048,7 @@ proto.xudrpc.LndChannels.prototype.setActive = function(value) {
 
 
 /**
- * optional int32 inactive = 2;
+ * optional uint32 inactive = 2;
  * @return {number}
  */
 proto.xudrpc.LndChannels.prototype.getInactive = function() {
@@ -5063,7 +5063,7 @@ proto.xudrpc.LndChannels.prototype.setInactive = function(value) {
 
 
 /**
- * optional int32 pending = 3;
+ * optional uint32 pending = 3;
  * @return {number}
  */
 proto.xudrpc.LndChannels.prototype.getPending = function() {
@@ -5190,7 +5190,7 @@ proto.xudrpc.LndInfo.deserializeBinaryFromReader = function(msg, reader) {
       msg.addChains(value);
       break;
     case 4:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setBlockheight(value);
       break;
     case 5:
@@ -5259,7 +5259,7 @@ proto.xudrpc.LndInfo.serializeBinaryToWriter = function(message, writer) {
   }
   f = message.getBlockheight();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       4,
       f
     );
@@ -5365,7 +5365,7 @@ proto.xudrpc.LndInfo.prototype.clearChainsList = function() {
 
 
 /**
- * optional int32 blockheight = 4;
+ * optional uint32 blockheight = 4;
  * @return {number}
  */
 proto.xudrpc.LndInfo.prototype.getBlockheight = function() {
@@ -5582,7 +5582,7 @@ proto.xudrpc.Order.deserializeBinaryFromReader = function(msg, reader) {
       msg.setLocalId(value);
       break;
     case 7:
-      var value = /** @type {number} */ (reader.readInt64());
+      var value = /** @type {number} */ (reader.readUint64());
       msg.setCreatedAt(value);
       break;
     case 8:
@@ -5670,7 +5670,7 @@ proto.xudrpc.Order.serializeBinaryToWriter = function(message, writer) {
   }
   f = message.getCreatedAt();
   if (f !== 0) {
-    writer.writeInt64(
+    writer.writeUint64(
       7,
       f
     );
@@ -5818,7 +5818,7 @@ proto.xudrpc.Order.prototype.hasLocalId = function() {
 
 
 /**
- * optional int64 created_at = 7;
+ * optional uint64 created_at = 7;
  * @return {number}
  */
 proto.xudrpc.Order.prototype.getCreatedAt = function() {
@@ -6660,11 +6660,11 @@ proto.xudrpc.OrdersCount.deserializeBinaryFromReader = function(msg, reader) {
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setPeer(value);
       break;
     case 2:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setOwn(value);
       break;
     default:
@@ -6698,14 +6698,14 @@ proto.xudrpc.OrdersCount.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getPeer();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       1,
       f
     );
   }
   f = message.getOwn();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       2,
       f
     );
@@ -6714,7 +6714,7 @@ proto.xudrpc.OrdersCount.serializeBinaryToWriter = function(message, writer) {
 
 
 /**
- * optional int32 peer = 1;
+ * optional uint32 peer = 1;
  * @return {number}
  */
 proto.xudrpc.OrdersCount.prototype.getPeer = function() {
@@ -6729,7 +6729,7 @@ proto.xudrpc.OrdersCount.prototype.setPeer = function(value) {
 
 
 /**
- * optional int32 own = 2;
+ * optional uint32 own = 2;
  * @return {number}
  */
 proto.xudrpc.OrdersCount.prototype.getOwn = function() {
@@ -6868,7 +6868,7 @@ proto.xudrpc.Peer.deserializeBinaryFromReader = function(msg, reader) {
       msg.setXudVersion(value);
       break;
     case 7:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setSecondsConnected(value);
       break;
     case 8:
@@ -6945,7 +6945,7 @@ proto.xudrpc.Peer.serializeBinaryToWriter = function(message, writer) {
   }
   f = message.getSecondsConnected();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       7,
       f
     );
@@ -7070,7 +7070,7 @@ proto.xudrpc.Peer.prototype.setXudVersion = function(value) {
 
 
 /**
- * optional int32 seconds_connected = 7;
+ * optional uint32 seconds_connected = 7;
  * @return {number}
  */
 proto.xudrpc.Peer.prototype.getSecondsConnected = function() {
@@ -8068,7 +8068,7 @@ proto.xudrpc.RaidenInfo.deserializeBinaryFromReader = function(msg, reader) {
       msg.setAddress(value);
       break;
     case 3:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setChannels(value);
       break;
     case 4:
@@ -8120,7 +8120,7 @@ proto.xudrpc.RaidenInfo.serializeBinaryToWriter = function(message, writer) {
   }
   f = message.getChannels();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       3,
       f
     );
@@ -8166,7 +8166,7 @@ proto.xudrpc.RaidenInfo.prototype.setAddress = function(value) {
 
 
 /**
- * optional int32 channels = 3;
+ * optional uint32 channels = 3;
  * @return {number}
  */
 proto.xudrpc.RaidenInfo.prototype.getChannels = function() {
@@ -9249,7 +9249,7 @@ proto.xudrpc.DiscoverNodesResponse.deserializeBinaryFromReader = function(msg, r
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readInt32());
+      var value = /** @type {number} */ (reader.readUint32());
       msg.setNumNodes(value);
       break;
     default:
@@ -9283,7 +9283,7 @@ proto.xudrpc.DiscoverNodesResponse.serializeBinaryToWriter = function(message, w
   var f = undefined;
   f = message.getNumNodes();
   if (f !== 0) {
-    writer.writeInt32(
+    writer.writeUint32(
       1,
       f
     );
@@ -9292,7 +9292,7 @@ proto.xudrpc.DiscoverNodesResponse.serializeBinaryToWriter = function(message, w
 
 
 /**
- * optional int32 num_nodes = 1;
+ * optional uint32 num_nodes = 1;
  * @return {number}
  */
 proto.xudrpc.DiscoverNodesResponse.prototype.getNumNodes = function() {

--- a/proto/xudp2p.proto
+++ b/proto/xudp2p.proto
@@ -116,7 +116,7 @@ message SwapRequestPacket {
     string pair_id = 3;
     string order_id = 4;
     string r_hash = 5;
-    int32 taker_cltv_delta = 6;
+    uint32 taker_cltv_delta = 6;
 }
 
 message SwapAcceptedPacket {
@@ -124,7 +124,7 @@ message SwapAcceptedPacket {
     string req_id = 2;
     string r_hash = 3;
     double quantity = 4;
-    int32 maker_cltv_delta = 5;
+    uint32 maker_cltv_delta = 5;
 }
 
 message SwapCompletePacket {

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -290,17 +290,17 @@ message BanRequest {
 message BanResponse {}
 
 message Chain {
-    // The blockchain the swap client is on (eg bitcoin, litecoin)
-    string chain = 1 [json_name = "chain"];
-    // The network the swap client is on (eg regtest, testnet, mainnet)
-    string network = 2 [json_name = "network"];
+  // The blockchain the swap client is on (eg bitcoin, litecoin)
+  string chain = 1 [json_name = "chain"];
+  // The network the swap client is on (eg regtest, testnet, mainnet)
+  string network = 2 [json_name = "network"];
 }
 
 message ChannelBalance {
-  // Sum of channels balances denominated in satoshis or equivalent.
-  int64 balance = 1 [json_name = "balance"];
-  // Sum of channels pending balances denominated in satoshis or equivalent.
-  int64 pending_open_balance = 2 [json_name = "pending_open_balance"];
+  // Sum of channel balances denominated in satoshis.
+  uint64 balance = 1 [json_name = "balance"];
+  // Sum of pending channel balances denominated in satoshis.
+  uint64 pending_open_balance = 2 [json_name = "pending_open_balance"];
 }
 
 message ChannelBalanceRequest {
@@ -327,7 +327,7 @@ message ExecuteSwapRequest {
   string pair_id = 2 [json_name = "pair_id"];
   // The node pub key of the peer which owns the maker order. This is optional but helps locate the order more quickly.
   string peer_pub_key = 3 [json_name = "peer_pub_key"];
-  // The quantity to swap. The whole order will be swapped if unspecified.
+  // The quantity to swap denominated in satoshis. The whole order will be swapped if unspecified.
   uint64 quantity = 4 [json_name = "quantity"];
 }
 
@@ -353,9 +353,9 @@ message GetInfoResponse {
   // A list of uris that can be used to connect to this node. These are shared with peers.
   repeated string uris = 3 [json_name = "uris"];
   // The number of currently connected peers.
-  int32 num_peers = 4 [json_name = "num_peers"];
+  uint32 num_peers = 4 [json_name = "num_peers"];
   // The number of supported trading pairs.
-  int32 num_pairs = 5 [json_name = "num_pairs"];
+  uint32 num_pairs = 5 [json_name = "num_pairs"];
   // The number of active, standing orders in the order book.
   OrdersCount orders = 6 [json_name = "orders"];
   map<string, LndInfo> lnd = 7 [json_name = "lnd"];
@@ -369,7 +369,7 @@ message GetNodeInfoRequest {
 message GetNodeInfoResponse {
   // The node's reputation score. Points are subtracted for unexpected or potentially malicious
   // behavior. Points are added when swaps are successfully executed.
-  int32 reputationScore = 1 [json_name = "reputation"];
+  sint32 reputationScore = 1 [json_name = "reputation"];
   // Whether the node is currently banned.
   bool banned = 2 [json_name = "banned"];
 }
@@ -380,7 +380,7 @@ message ListOrdersRequest {
   // Whether own orders should be included in result or not.
   bool include_own_orders = 2 [json_name = "include_own_orders"];
   // The maximum number of orders to return from each side of the order book.
-  int32 limit = 3 [json_name = "limit"];
+  uint32 limit = 3 [json_name = "limit"];
 }
 message ListOrdersResponse {
   // A map between pair ids and their buy and sell orders.
@@ -407,18 +407,18 @@ message ListPeersResponse {
 
 message LndChannels {
   // The number of active/online channels for this lnd instance that can be used for swaps.
-  int32 active = 1 [json_name = "active"];
+  uint32 active = 1 [json_name = "active"];
   // The number of inactive/offline channels for this lnd instance.
-  int32 inactive = 2 [json_name = "inactive"];
+  uint32 inactive = 2 [json_name = "inactive"];
   // The number of channels that are pending on-chain confirmation before they can be used.
-  int32 pending = 3 [json_name = "pending"];
+  uint32 pending = 3 [json_name = "pending"];
 }
 
 message LndInfo {
   string error = 1 [json_name = "error"];
   LndChannels channels = 2 [json_name = "channels"];
   repeated Chain chains = 3 [json_name = "chains"];
-  int32 blockheight = 4 [json_name = "blockheight"];
+  uint32 blockheight = 4 [json_name = "blockheight"];
   repeated string uris = 5 [json_name = "uris"];
   string version = 6 [json_name = "version"];
   string alias = 7 [json_name = "alias"];
@@ -440,12 +440,12 @@ message Order {
     string local_id = 6 [json_name = "local_id"];
   }
   // The epoch time when this order was created.
-  int64 created_at = 7 [json_name = "created_at"];
+  uint64 created_at = 7 [json_name = "created_at"];
   // Whether this order is a buy or sell
   OrderSide side = 8 [json_name = "side"];
   // Whether this order is a local own order or a remote peer order.
   bool is_own_order = 9 [json_name = "is_own_order"];
-  // The quantity on hold pending swap exectuion.
+  // The quantity on hold pending swap execution.
   uint64 hold = 10 [json_name = "hold"];
 }
 
@@ -459,7 +459,7 @@ message OrderUpdate {
 }
 
 message OrderRemoval {
-  // The quantity of the order being removed.
+  // The quantity removed from the order.
   uint64 quantity = 1 [json_name = "quantity"];
   // The trading pair that the order is for.
   string pair_id = 2 [json_name = "pair_id"];
@@ -480,9 +480,9 @@ message Orders {
 
 message OrdersCount {
   // The number of orders belonging to remote xud nodes.
-  int32 peer = 1 [json_name = "peer"];
+  uint32 peer = 1 [json_name = "peer"];
   // The number of orders belonging to our local xud node.
-  int32 own = 2 [json_name = "own"];
+  uint32 own = 2 [json_name = "own"];
 }
 
 message Peer {
@@ -499,7 +499,7 @@ message Peer {
   // The version of xud being used by the peer.
   string xud_version = 6 [json_name = "xud_version"];
   // The time in seconds that we have been connected to this peer.
-  int32 seconds_connected = 7 [json_name = "seconds_connected"];
+  uint32 seconds_connected = 7 [json_name = "seconds_connected"];
   // The raiden address for this peer
   string raiden_address = 8 [json_name = "raiden_address"];
 }
@@ -507,13 +507,13 @@ message Peer {
 message PlaceOrderRequest {
   // The price of the order.
   double price = 1 [json_name = "price"];
-  // The quantity of the order in satoshis.
+  // The quantity of the order denominated in satoshis.
   uint64 quantity = 2 [json_name = "quantity"];
   // The trading pair that the order is for.
   string pair_id = 3 [json_name = "pair_id"];
   // The local id to assign to the order.
   string order_id = 4 [json_name = "order_id"];
-  // Whether the order is a Buy or Sell.
+  // Whether the order is a buy or sell.
   OrderSide side = 5 [json_name = "side"];
 }
 message PlaceOrderResponse {
@@ -543,7 +543,7 @@ message PlaceOrderEvent {
 message RaidenInfo {
   string error = 1 [json_name = "error"];
   string address = 2 [json_name = "address"];
-  int32 channels = 3 [json_name = "channels"];
+  uint32 channels = 3 [json_name = "channels"];
   string version = 4 [json_name = "version"];
 }
 
@@ -556,7 +556,8 @@ message RemoveCurrencyResponse {}
 message RemoveOrderRequest {
   // The local id of the order to remove.
   string order_id = 1 [json_name = "order_id"];
-  // The quantity to remove from the order. If zero or unspecified then entire order is removed.
+  // The quantity to remove from the order denominated in satoshis.
+  // If zero or unspecified then the entire order is removed.
   uint64 quantity = 2 [json_name = "quantity"];
 }
 message RemoveOrderResponse {
@@ -572,11 +573,11 @@ message RemovePairRequest {
 message RemovePairResponse {}
 
 message DiscoverNodesRequest {
-    // The node pub key of the peer to discover nodes from.
-    string peer_pub_key = 1 [json_name = "peer_pub_key"];
+  // The node pub key of the peer to discover nodes from.
+  string peer_pub_key = 1 [json_name = "peer_pub_key"];
 }
 message DiscoverNodesResponse {
-    int32 num_nodes = 1 [json_name = "num_nodes"];
+  uint32 num_nodes = 1 [json_name = "num_nodes"];
 }
 
 message ShutdownRequest {}
@@ -602,7 +603,7 @@ message SwapSuccess {
   string pair_id = 3 [json_name = "pair_id"];
   // The order quantity that was swapped.
   uint64 quantity = 4 [json_name = "quantity"];
-  // The hex-encoded payment hash for the swaps.
+  // The hex-encoded payment hash for the swap.
   string r_hash = 5 [json_name = "r_hash"];
   // The amount of the smallest base unit of the currency (like satoshis or wei) received.
   int64 amount_received = 8 [json_name = "amount_received"];


### PR DESCRIPTION
This makes minor changes to our protobuf definitions files to use unsigned integers where appropriate, have consistent indentation, and clarify comments.