### PR TITLE
Prevent Raiden from being first swap leg

### DIFF
--- a/lib/http/HttpService.ts
+++ b/lib/http/HttpService.ts
@@ -5,6 +5,7 @@ class HttpService {
   constructor(private service: Service) {}
 
   public resolveHashRaiden = async (resolveRequest: RaidenResolveRequest): Promise<RaidenResolveResponse> => {
+    // TODO: add reveal_timeout, settle time out,  token, etc
     const secret = await this.service.resolveHash({
       rHash: resolveRequest.secrethash.slice(2),
       amount: resolveRequest.amount,

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -33,7 +33,7 @@ async function parseResponseBody<T>(res: http.IncomingMessage): Promise<T> {
  */
 class RaidenClient extends SwapClient {
   public readonly type = SwapClientType.Raiden;
-  public readonly cltvDelta: number = 1;
+  public readonly cltvDelta: number = 5760;
   public address?: string;
   /** A map of currency symbols to token addresses. */
   public tokenAddresses = new Map<string, string>();
@@ -151,8 +151,9 @@ class RaidenClient extends SwapClient {
 
   public getRoutes =  async (_amount: number, _destination: string) => {
     // stub placeholder, query routes not currently implemented in raiden
+    // assume a fixed lock time of 100 Raiden's blocks
     return [{
-      getTotalTimeLock: () => 1,
+      getTotalTimeLock: () => 101,
     }];
   }
 

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -10,11 +10,11 @@ import { Models } from '../db/DB';
 import { SwapClientType } from '../constants/enums';
 import { EventEmitter } from 'events';
 
-function isRaidenClient(swapClient: SwapClient): swapClient is RaidenClient {
+export function isRaidenClient(swapClient: SwapClient): swapClient is RaidenClient {
   return (swapClient.type === SwapClientType.Raiden);
 }
 
-function isLndClient(swapClient: SwapClient): swapClient is LndClient {
+export function isLndClient(swapClient: SwapClient): swapClient is LndClient {
   return (swapClient.type === SwapClientType.Lnd);
 }
 


### PR DESCRIPTION
This PR prevents Raiden from being first leg of swap.
It better calculates the maker CLTV by using cltv-delta of 5760 in the case of raiden.
This is only a basis for a better change