### PR TITLE
fix: clean shutdown

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -108,9 +108,6 @@ class Xud extends EventEmitter {
 
       const initPromises: Promise<any>[] = [];
 
-      this.swapClientManager = new SwapClientManager(this.config, loggers);
-      initPromises.push(this.swapClientManager.init(this.db.models));
-
       this.swaps = new Swaps(loggers.swaps, this.db.models, this.pool, this.swapClientManager);
       initPromises.push(this.swaps.init());
 


### PR DESCRIPTION
This removes unnecessary code that created duplicate swap client managers and interfered with the graceful shutdown procedure.