### PR TITLE
feat(swap): persist active swap deals to db

### DIFF
--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -55,19 +55,23 @@ export enum SwapRole {
 }
 
 export enum SwapPhase {
-  /** The swap has been created locally. */
+  /** The swap deal has been created locally. */
   SwapCreated = 0,
-  /** The swap has been sent to a peer to request approval. */
+  /** We've made a request to a peer to accept this swap. */
   SwapRequested = 1,
   /** The terms of the swap have been agreed to, and we will attempt to execute it. */
-  SwapAgreed = 2,
+  SwapAccepted = 2,
   /**
-   * We have commanded swap client to send payment according to the agreed terms. The payment (and swap)
-   * could still fail due to no route with sufficient capacity, lack of cooperation from the
-   * receiver or any intermediary node along the route, or an unexpected error from swap client.
+   * We have made a request to the swap client to send payment according to the agreed terms.
+   * The payment (and swap) could still fail due to no route with sufficient capacity, lack of
+   * cooperation from the receiver or any intermediary node along the route, or an unexpected
+   * error from the swap client.
    */
   SendingPayment = 3,
-  /** We have received the agreed amount of the swap, and the preimage is now known to both sides. */
+  /**
+   * We have received the agreed amount of the swap and released the preimage to the
+   * receiving swap client so it can accept payment.
+   */
   PaymentReceived = 4,
   /** The swap has been formally completed and both sides have confirmed they've received payment. */
   SwapCompleted = 5,

--- a/lib/swaps/SwapRepository.ts
+++ b/lib/swaps/SwapRepository.ts
@@ -19,14 +19,18 @@ class SwapRepository {
     });
   }
 
-  public addSwapDeal = async (swapDeal: db.SwapDealFactory): Promise<db.SwapDealInstance> => {
+  public saveSwapDeal = async (swapDeal: db.SwapDealFactory, swapOrder?: db.OrderFactory) => {
+    if (swapOrder) {
+      await this.models.Order.upsert(swapOrder);
+    }
+
     const node = await this.models.Node.findOne({
       where: {
         nodePubKey: swapDeal.peerPubKey,
       },
     });
     const attributes = { ...swapDeal, nodeId: node!.id } as db.SwapDealAttributes;
-    return this.models.SwapDeal.create(attributes);
+    await this.models.SwapDeal.upsert(attributes);
   }
 }
 export default SwapRepository;

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -60,8 +60,11 @@ export type SwapDeal = {
   makerToTakerRoutes?: Route[];
   /** The identifier for the payment channel network node we should pay to complete the swap.  */
   destination?: string;
+  /** The time when we created this swap deal locally. */
   createTime: number;
+  /** The time when we began executing the swap by sending payment. */
   executeTime?: number;
+  /** The time when the swap either completed successfully or failed. */
   completeTime?: number;
 };
 

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -20,6 +20,13 @@ jest.mock('../../../lib/p2p/Peer');
 const mockedPeer = <jest.Mock<Peer>><any>Peer;
 jest.mock('../../../lib/lndclient/LndClient');
 const mockedLnd = <jest.Mock<LndClient>><any>LndClient;
+jest.mock('../../../lib/swaps/SwapRepository', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      saveSwapDeal: jest.fn(),
+    };
+  });
+});
 const getMockedLnd = (cltvDelta: number) => {
   const lnd = new mockedLnd();
   // @ts-ignore

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -108,7 +108,7 @@ describe('Database', () => {
     const { rHash } = deal;
     const trade: TradeFactory = { rHash, quantity: deal.quantity!, makerOrderId: order.id };
     await orderBookRepo.addTrade(trade);
-    await swapRepo.addSwapDeal(deal);
+    await swapRepo.saveSwapDeal(deal);
 
     const swapInstance = await db.models.SwapDeal.findOne({ where: { rHash } });
     expect(swapInstance!.orderId).to.equal(order.id);


### PR DESCRIPTION
This commit persists the state of swap deals to the database upon each phase change once a deal has been accepted to. This is done to be able to prevent loss of funds and recover gracefully from any active swaps should `xud` crash unexpectedly.

This is the first step towards closing #1079.

I wound up leaving the existing phases as is, and just updated the comments instead and renamed `SwapAgreed` to `SwapAccepted` to align with our terminology elsewhere. I started adding separate phases for maker/taker but it would've required changing quite a few lines of code, and ultimately for recovery purposes we can determine the precise state by looking at both `phase` and `role`.