### PR TITLE
feat(swaps): recover crashed swap deals

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -379,6 +379,7 @@
 | orders | [OrdersCount](#xudrpc.OrdersCount) |  | The number of active, standing orders in the order book. |
 | lnd | [GetInfoResponse.LndEntry](#xudrpc.GetInfoResponse.LndEntry) | repeated |  |
 | raiden | [RaidenInfo](#xudrpc.RaidenInfo) |  |  |
+| pending_swap_hashes | [string](#string) | repeated |  |
 
 
 

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -222,7 +222,9 @@ class Xud extends EventEmitter {
     }
     if (this.grpcAPIProxy) {
       closePromises.push(this.grpcAPIProxy.close());
-      await this.grpcAPIProxy.close();
+    }
+    if (this.swaps) {
+      this.swaps.close();
     }
     await Promise.all(closePromises);
 

--- a/lib/cli/commands/getinfo.ts
+++ b/lib/cli/commands/getinfo.ts
@@ -4,14 +4,6 @@ import Table, { VerticalTable } from 'cli-table3';
 import colors from 'colors/safe';
 import { GetInfoRequest, GetInfoResponse, LndInfo, RaidenInfo } from '../../proto/xudrpc_pb';
 
-type generalInfo = {
-  version: string;
-  numPeers: number;
-  numPairs: number;
-  nodePubKey: string;
-  orders: {own: number, peer: number} | undefined
-};
-
 const displayChannels = (channels: any, asset: string) => {
   const table = new Table() as VerticalTable;
   Object.keys(channels).forEach((key: any) => {
@@ -74,7 +66,7 @@ const displayLndInfo = (asset: string, info: LndInfo.AsObject) => {
   }
 };
 
-const displayGeneral = (info: generalInfo) => {
+const displayGeneral = (info: GetInfoResponse.AsObject) => {
   const table = new Table() as VerticalTable;
   table.push(
     { [colors.blue('Version')]: info.version },
@@ -86,6 +78,11 @@ const displayGeneral = (info: generalInfo) => {
     table.push(
       { [colors.blue('Own orders')]: info.orders.own },
       { [colors.blue('Peer orders')]: info.orders.peer },
+    );
+  }
+  if (info.pendingSwapHashesList) {
+    table.push(
+      { [colors.blue('Pending swaps')]: JSON.stringify(info.pendingSwapHashesList) },
     );
   }
   console.log(colors.underline(colors.bold('\nGeneral XUD Info')));
@@ -105,13 +102,7 @@ const displayRaiden = (info: RaidenInfo.AsObject) => {
 };
 
 const displayGetInfo = (response: GetInfoResponse.AsObject) => {
-  displayGeneral({
-    nodePubKey: response.nodePubKey,
-    numPairs: response.numPairs,
-    numPeers: response.numPeers,
-    version: response.version,
-    orders: response.orders,
-  });
+  displayGeneral(response);
   if (response.raiden) {
     displayRaiden(response.raiden);
   }

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -81,6 +81,12 @@ export enum SwapState {
   Active = 0,
   Error = 1,
   Completed = 2,
+  /**
+   * A swap that was executed but wasn't formally completed. This may occur as a result of xud
+   * crashing late in the swap process, after htlcs for both legs of the swap are set up but
+   * before the swap is formally complete.
+   */
+  Recovered = 3,
 }
 
 export enum ReputationEvent {
@@ -126,7 +132,9 @@ export enum SwapFailureReason {
   /** The swap failed due to an unrecognized error. */
   UnknownError = 12,
   /** The swap failed due to an error or unexpected behavior on behalf of the remote peer. */
-  RemoteError = 12,
+  RemoteError = 13,
+  /** The swap failed because of a system or xud crash while the swap was being executed. */
+  Crash = 14,
 }
 
 export enum DisconnectionReason {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -879,6 +879,12 @@
         },
         "raiden": {
           "$ref": "#/definitions/xudrpcRaidenInfo"
+        },
+        "pending_swap_hashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -543,6 +543,11 @@ export class GetInfoResponse extends jspb.Message {
     getRaiden(): RaidenInfo | undefined;
     setRaiden(value?: RaidenInfo): void;
 
+    clearPendingSwapHashesList(): void;
+    getPendingSwapHashesList(): Array<string>;
+    setPendingSwapHashesList(value: Array<string>): void;
+    addPendingSwapHashes(value: string, index?: number): string;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
@@ -565,6 +570,7 @@ export namespace GetInfoResponse {
 
         lndMap: Array<[string, LndInfo.AsObject]>,
         raiden?: RaidenInfo.AsObject,
+        pendingSwapHashesList: Array<string>,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -3482,7 +3482,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.xudrpc.GetInfoResponse.repeatedFields_ = [3];
+proto.xudrpc.GetInfoResponse.repeatedFields_ = [3,9];
 
 
 
@@ -3520,7 +3520,8 @@ proto.xudrpc.GetInfoResponse.toObject = function(includeInstance, msg) {
     numPairs: jspb.Message.getFieldWithDefault(msg, 5, 0),
     orders: (f = msg.getOrders()) && proto.xudrpc.OrdersCount.toObject(includeInstance, f),
     lndMap: (f = msg.getLndMap()) ? f.toObject(includeInstance, proto.xudrpc.LndInfo.toObject) : [],
-    raiden: (f = msg.getRaiden()) && proto.xudrpc.RaidenInfo.toObject(includeInstance, f)
+    raiden: (f = msg.getRaiden()) && proto.xudrpc.RaidenInfo.toObject(includeInstance, f),
+    pendingSwapHashesList: jspb.Message.getRepeatedField(msg, 9)
   };
 
   if (includeInstance) {
@@ -3592,6 +3593,10 @@ proto.xudrpc.GetInfoResponse.deserializeBinaryFromReader = function(msg, reader)
       var value = new proto.xudrpc.RaidenInfo;
       reader.readMessage(value,proto.xudrpc.RaidenInfo.deserializeBinaryFromReader);
       msg.setRaiden(value);
+      break;
+    case 9:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addPendingSwapHashes(value);
       break;
     default:
       reader.skipField();
@@ -3675,6 +3680,13 @@ proto.xudrpc.GetInfoResponse.serializeBinaryToWriter = function(message, writer)
       8,
       f,
       proto.xudrpc.RaidenInfo.serializeBinaryToWriter
+    );
+  }
+  f = message.getPendingSwapHashesList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      9,
+      f
     );
   }
 };
@@ -3844,6 +3856,35 @@ proto.xudrpc.GetInfoResponse.prototype.clearRaiden = function() {
  */
 proto.xudrpc.GetInfoResponse.prototype.hasRaiden = function() {
   return jspb.Message.getField(this, 8) != null;
+};
+
+
+/**
+ * repeated string pending_swap_hashes = 9;
+ * @return {!Array.<string>}
+ */
+proto.xudrpc.GetInfoResponse.prototype.getPendingSwapHashesList = function() {
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 9));
+};
+
+
+/** @param {!Array.<string>} value */
+proto.xudrpc.GetInfoResponse.prototype.setPendingSwapHashesList = function(value) {
+  jspb.Message.setField(this, 9, value || []);
+};
+
+
+/**
+ * @param {!string} value
+ * @param {number=} opt_index
+ */
+proto.xudrpc.GetInfoResponse.prototype.addPendingSwapHashes = function(value, opt_index) {
+  jspb.Message.addToRepeatedField(this, 9, value, opt_index);
+};
+
+
+proto.xudrpc.GetInfoResponse.prototype.clearPendingSwapHashesList = function() {
+  this.setPendingSwapHashesList([]);
 };
 
 

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -1,22 +1,25 @@
-import http from 'http';
-import Logger from '../Logger';
-import SwapClient, { ClientStatus, ChannelBalance } from '../swaps/SwapClient';
-import errors from './errors';
-import { SwapDeal } from '../swaps/types';
-import { SwapClientType, SwapState, SwapRole } from '../constants/enums';
 import assert from 'assert';
-import {
-  RaidenClientConfig,
-  RaidenInfo,
-  OpenChannelPayload,
-  Channel,
-  TokenPaymentRequest,
-  TokenPaymentResponse,
-} from './types';
-import { UnitConverter } from '../utils/UnitConverter';
+import http from 'http';
+import { SwapClientType, SwapRole, SwapState } from '../constants/enums';
 import { CurrencyInstance } from '../db/types';
+import Logger from '../Logger';
+import SwapClient, { ChannelBalance, ClientStatus, PaymentState } from '../swaps/SwapClient';
+import { SwapDeal } from '../swaps/types';
+import { UnitConverter } from '../utils/UnitConverter';
+import errors from './errors';
+import { Channel, OpenChannelPayload, PaymentEvent, RaidenClientConfig, RaidenInfo, TokenPaymentRequest, TokenPaymentResponse } from './types';
 
 type RaidenErrorResponse = { errors: string };
+
+type PendingTransfer = {
+  initiator: string;
+  locked_amount: string;
+  payment_identifier: string;
+  role: string;
+  target: string;
+  token_address: string;
+  transferred_amount: string;
+};
 
 /**
  * A utility function to parse the payload from an http response.
@@ -74,6 +77,14 @@ class RaidenClient extends SwapClient {
 
   public get minutesPerBlock() {
     return 0.25; // 15 seconds per block target
+  }
+
+  /**
+   * Derives an integer identifier using the first 4 bytes of a provided payment hash in hex.
+   * @param rHash a payment hash in hex
+   */
+  private static getIdentifier(rHash: string) {
+    return parseInt(rHash.substr(0, 8), 16);
   }
 
   /**
@@ -210,6 +221,61 @@ class RaidenClient extends SwapClient {
 
   public removeInvoice = async () => {
     // not implemented, raiden does not use invoices
+  }
+
+  public lookupPayment = async (rHash: string, currency?: string, destination?: string) => {
+    const identifier = RaidenClient.getIdentifier(rHash);
+
+    // first check if the payment is pending
+    const pendingTransfers = await this.getPendingTransfers(currency, destination);
+    for (const pendingTransfer of pendingTransfers) {
+      if (identifier === Number(pendingTransfer.payment_identifier)) {
+        return { state: PaymentState.Pending };
+      }
+    }
+
+    // if the payment isn't pending, check if it has succeeded or failed
+    const paymentEvents = await this.getPaymentEvents(currency, destination);
+    for (const paymentEvent of paymentEvents) {
+      if (paymentEvent.identifier === identifier) {
+        const success = paymentEvent.event === 'EventPaymentSentSuccess';
+        if (success) {
+          const preimage = paymentEvent.secret;
+          return { preimage, state: PaymentState.Succeeded };
+        } else {
+          return { state: PaymentState.Failed };
+        }
+      }
+    }
+
+    // if there is no pending payment or event found, we assume that the payment was never attempted by raiden
+    return { state: PaymentState.Failed };
+  }
+
+  private getPendingTransfers = async (currency?: string, destination?: string) => {
+    let endpoint = 'pending_transfers';
+    if (currency) {
+      const tokenAddress = this.tokenAddresses.get(currency);
+      endpoint += `/${tokenAddress}`;
+      if (destination) {
+        endpoint += `/${destination}`;
+      }
+    }
+    const res = await this.sendRequest(endpoint, 'GET');
+    return parseResponseBody<PendingTransfer[]>(res);
+  }
+
+  private getPaymentEvents = async (currency?: string, destination?: string) => {
+    let endpoint = 'payments';
+    if (currency) {
+      const tokenAddress = this.tokenAddresses.get(currency);
+      endpoint += `/${tokenAddress}`;
+      if (destination) {
+        endpoint += `/${destination}`;
+      }
+    }
+    const res = await this.sendRequest(endpoint, 'GET');
+    return parseResponseBody<PaymentEvent[]>(res);
   }
 
   public getRoute = async (units: number, destination: string, currency: string) => {
@@ -427,8 +493,8 @@ class RaidenClient extends SwapClient {
    */
   private tokenPayment = async (payload: TokenPaymentRequest): Promise<TokenPaymentResponse> => {
     const endpoint = `payments/${payload.token_address}/${payload.target_address}`;
-    payload.identifier = Math.round(Math.random() * (Number.MAX_SAFE_INTEGER - 1) + 1);
     if (payload.secret_hash) {
+      payload.identifier = RaidenClient.getIdentifier(payload.secret_hash);
       payload.secret_hash = `0x${payload.secret_hash}`;
     }
 

--- a/lib/raidenclient/types.ts
+++ b/lib/raidenclient/types.ts
@@ -74,3 +74,17 @@ export type RaidenResolveResponse = {
   /** The preimage in hex format. */
   secret: string,
 };
+
+export type PaymentEvent = {
+  event: string;
+  payment_network_address: string;
+  token_network_address: string
+  identifier: number;
+  amount?: number;
+  target?: string
+  initiator?: string;
+  secret?: string;
+  route?: string[];
+  reason?: string;
+  log_time: string;
+};

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -37,6 +37,7 @@ type XudInfo = {
   orders: { peer: number, own: number};
   lnd: Map<string, LndInfo>;
   raiden?: RaidenInfo;
+  pendingSwapHashes: string[];
 };
 
 /** Functions to check argument validity and throw [[INVALID_ARGUMENT]] when invalid. */
@@ -276,6 +277,7 @@ class Service {
         peer: peerOrdersCount,
         own: ownOrdersCount,
       },
+      pendingSwapHashes: this.swaps.getPendingSwapHashes(),
     };
   }
 
@@ -469,4 +471,4 @@ class Service {
   }
 }
 export default Service;
-export { ServiceComponents };
+export { ServiceComponents, XudInfo };

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -24,6 +24,17 @@ export type SwapClientInfo = {
   newUris?: string[];
 };
 
+export enum PaymentState {
+  Succeeded,
+  Failed,
+  Pending,
+}
+
+export type PaymentStatus = {
+  state: PaymentState,
+  preimage?: string,
+};
+
 interface SwapClient {
   on(event: 'connectionVerified', listener: (swapClientInfo: SwapClientInfo) => void): this;
   emit(event: 'connectionVerified', swapClientInfo: SwapClientInfo): boolean;
@@ -155,6 +166,12 @@ abstract class SwapClient extends EventEmitter {
   public abstract async settleInvoice(rHash: string, rPreimage: string): Promise<void>;
 
   public abstract async removeInvoice(rHash: string): Promise<void>;
+
+  /**
+   * Checks to see whether we've made a payment using a given rHash.
+   * @returns the preimage for the payment, or `undefined` if no payment was made
+   */
+  public abstract async lookupPayment(rHash: string, currency?: string, destination?: string): Promise<PaymentStatus>;
 
   /**
    * Gets the block height of the chain backing this swap client.

--- a/lib/swaps/SwapRecovery.ts
+++ b/lib/swaps/SwapRecovery.ts
@@ -1,0 +1,123 @@
+import SwapClientManager from './SwapClientManager';
+import { SwapDealInstance } from '../db/types';
+import Logger from '../Logger';
+import { SwapPhase, SwapState, SwapFailureReason, SwapRole, SwapClientType } from '../constants/enums';
+import SwapClient, { PaymentState } from './SwapClient';
+
+/**
+ * A class that's responsible for recovering swap deals that were interrupted due to a system or xud crash,
+ * ensuring that we do not lose funds on a partially completed swap.
+ */
+class SwapRecovery {
+  /** A set of swaps where we have a pending outgoing payment for swaps where we don't know the preimage. */
+  public pendingSwaps: Set<SwapDealInstance> = new Set();
+  private pendingSwapsTimer?: NodeJS.Timeout;
+  /** The time in milliseconds between checks on the status of pending swaps. */
+  private static readonly PENDING_SWAP_RECHECK_INTERVAL = 300000;
+
+  constructor(private swapClientManager: SwapClientManager, private logger: Logger) { }
+
+  public beginTimer = () => {
+    if (!this.pendingSwapsTimer) {
+      this.pendingSwapsTimer = setInterval(this.checkPendingSwaps, SwapRecovery.PENDING_SWAP_RECHECK_INTERVAL);
+    }
+  }
+
+  private checkPendingSwaps = () => {
+    this.pendingSwaps.forEach(pendingSwap => this.recoverDeal(pendingSwap).catch(this.logger.error));
+  }
+
+  public stopTimer = () => {
+    if (this.pendingSwapsTimer) {
+      clearInterval(this.pendingSwapsTimer);
+      this.pendingSwapsTimer = undefined;
+    }
+  }
+
+  private failDeal = async (deal: SwapDealInstance, receivingSwapClient?: SwapClient) => {
+    if (receivingSwapClient) {
+      try {
+        await receivingSwapClient.removeInvoice(deal.rHash);
+      } catch (err) {
+        this.logger.error(`could not remove invoice for ${deal.rHash}`, err);
+      }
+    }
+    deal.state = SwapState.Error;
+    deal.failureReason = SwapFailureReason.Crash;
+    this.pendingSwaps.delete(deal);
+    await deal.save();
+  }
+
+  public recoverDeal = async (deal: SwapDealInstance) => {
+    const makerSwapClient = this.swapClientManager.get(deal.makerCurrency);
+    const takerSwapClient = this.swapClientManager.get(deal.takerCurrency);
+    if (!makerSwapClient || !makerSwapClient.isConnected()) {
+      this.logger.warn(`could not recover deal ${deal.rHash} because ${deal.makerCurrency} swap client is offline`);
+      this.pendingSwaps.add(deal);
+      return;
+    }
+    if (!takerSwapClient || !takerSwapClient.isConnected()) {
+      this.logger.warn(`could not recover deal ${deal.rHash} because ${deal.takerCurrency} swap client is offline`);
+      this.pendingSwaps.add(deal);
+      return;
+    }
+
+    this.logger.info(`recovering swap deal ${deal.rHash}`);
+    switch (deal.phase) {
+      case SwapPhase.SwapAccepted:
+        // we accepted the deal but stopped before sending payment
+        // cancel the open invoice if we have one
+        await this.failDeal(deal, makerSwapClient);
+        break;
+      case SwapPhase.SendingPayment:
+        // we started sending payment but didn't claim our payment
+        if (deal.role === SwapRole.Maker) {
+          // we should check to see if our payment went through
+          // if it did, we can claim payment with the preimage for our side of the swap
+          const paymentStatus = await takerSwapClient.lookupPayment(deal.rHash);
+          if (paymentStatus.state === PaymentState.Succeeded) {
+            try {
+              deal.rPreimage = paymentStatus.preimage!;
+              if (makerSwapClient.type === SwapClientType.Raiden) {
+                // tslint:disable-next-line: max-line-length
+                this.logger.warn(`cannot claim payment on Raiden for swap ${deal.rHash} using preimage ${deal.rPreimage}, this should be investigated manually`);
+              } else {
+                await makerSwapClient.settleInvoice(deal.rHash, deal.rPreimage);
+                this.logger.info(`recovered ${deal.makerCurrency} swap payment of ${deal.makerAmount} using preimage ${deal.rPreimage}`);
+              }
+              deal.state = SwapState.Recovered;
+              this.pendingSwaps.delete(deal);
+              await deal.save();
+              // TODO: update order and trade in database to indicate they were executed
+            } catch (err) {
+              // tslint:disable-next-line: max-line-length
+              this.logger.error(`could not settle ${deal.makerCurrency} invoice for payment ${deal.rHash} and preimage ${deal.rPreimage}, this should be investigated manually`, err);
+              await this.failDeal(deal);
+            }
+          } else if (paymentStatus.state === PaymentState.Failed) {
+            // the payment failed, so cancel the open invoice if we have one
+            await this.failDeal(deal, makerSwapClient);
+          } else {
+            // the payment is pending, we will need to follow up on this
+            this.logger.info(`recovered swap for ${deal.rHash} still has pending payments and will be monitored`);
+            this.pendingSwaps.add(deal);
+          }
+        } else if (deal.role === SwapRole.Taker) {
+          // we are not at risk of losing funds, but we should cancel any open invoices
+          await this.failDeal(deal, takerSwapClient);
+        }
+        break;
+      case SwapPhase.PaymentReceived:
+        // we've claimed our payment
+        // TODO: send a swap completed packet? it may be too late to do so
+        deal.state = SwapState.Recovered;
+        await deal.save();
+        break;
+      default:
+        break;
+    }
+
+  }
+}
+
+export default SwapRecovery;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:crypto": "mocha --timeout 10000 -r ts-node/register test/crypto/*",
     "test:sim": "(npm run compile && cd test/simulation && export PATH=\"$PWD/go/bin:$PATH\" && GOPATH=$PWD/go GO111MODULE=on go test -run=TestIntegration -v)",
     "test:sim:security": "(npm run compile && cd test/simulation && export PATH=\"$PWD/go/bin:$PATH\" && GOPATH=$PWD/go GO111MODULE=on go test -run=TestSecurity -v)",
+    "test:sim:instability": "(npm run compile && cd test/simulation && export PATH=\"$PWD/go/bin:$PATH\" && GOPATH=$PWD/go GO111MODULE=on go test -run=TestInstability -v)",
     "test:jest": "jest",
     "test:seedutil": "jest seedutil",
     "test:jest:watch": "jest --watch",

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -400,6 +400,7 @@ message GetInfoResponse {
   OrdersCount orders = 6 [json_name = "orders"];
   map<string, LndInfo> lnd = 7 [json_name = "lnd"];
   RaidenInfo raiden = 8 [json_name = "raiden"];
+  repeated string pending_swap_hashes = 9 [json_name = "pending_swap_hashes"];
 }
 
 message GetNodeInfoRequest {

--- a/test/jest/RaidenClient.spec.ts
+++ b/test/jest/RaidenClient.spec.ts
@@ -5,6 +5,7 @@ import { SwapDeal } from '../../lib/swaps/types';
 import { UnitConverter } from '../../lib/utils/UnitConverter';
 import { CurrencyInstance } from '../../lib/db/types';
 import { getValidDeal } from '../utils';
+import { PaymentState } from '../../lib/swaps/SwapClient';
 
 const getValidTokenPaymentResponse = () => {
   return {
@@ -189,6 +190,45 @@ describe('RaidenClient', () => {
         total_deposit: units,
         settle_timeout: 500,
       });
+    });
+  });
+
+  describe('lookupPayment', () => {
+    const paymentHash = '63699fb42306ea693c7c9c038c18ecc8c7dbc8095b8ddd8d2e4421f2ce7b4c0c';
+
+    test('it detects payment in pending state', async () => {
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
+      const peerRaidenAddress = '0x10D8CCAD85C7dc123090B43aA1f98C00a303BFC5';
+      const currency = 'WETH';
+      const mockTokenAddresses = new Map<string, string>();
+      mockTokenAddresses.set('WETH', wethTokenAddress);
+      raiden.tokenAddresses = mockTokenAddresses;
+      raiden['getPendingTransfers'] = jest.fn().mockReturnValue(Promise.resolve([{
+        payment_identifier: RaidenClient['getIdentifier'](paymentHash),
+      }]));
+      raiden['getPaymentEvents'] = jest.fn();
+      await raiden.init(currencyInstances as CurrencyInstance[]);
+      await expect(raiden.lookupPayment(paymentHash, currency, peerRaidenAddress))
+        .resolves.toHaveProperty('state', PaymentState.Pending);
+      expect(raiden['getPendingTransfers']).toHaveBeenCalledTimes(1);
+      expect(raiden['getPendingTransfers']).toHaveBeenCalledWith(currency, peerRaidenAddress);
+      expect(raiden['getPaymentEvents']).toHaveBeenCalledTimes(0);
+    });
+
+    test('it checks if payment has failed or completed if it is not pending', async () => {
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
+      const peerRaidenAddress = '0x10D8CCAD85C7dc123090B43aA1f98C00a303BFC5';
+      const currency = 'WETH';
+      const mockTokenAddresses = new Map<string, string>();
+      mockTokenAddresses.set('WETH', wethTokenAddress);
+      raiden.tokenAddresses = mockTokenAddresses;
+      raiden['getPendingTransfers'] = jest.fn().mockReturnValue(Promise.resolve([]));
+      raiden['getPaymentEvents'] = jest.fn().mockReturnValue(Promise.resolve([]));
+      await raiden.init(currencyInstances as CurrencyInstance[]);
+      await raiden.lookupPayment(paymentHash, currency, peerRaidenAddress);
+      expect(raiden['getPendingTransfers']).toHaveBeenCalledTimes(1);
+      expect(raiden['getPaymentEvents']).toHaveBeenCalledTimes(1);
+      expect(raiden['getPaymentEvents']).toHaveBeenCalledWith(currency, peerRaidenAddress);
     });
   });
 

--- a/test/jest/SwapRecovery.ts
+++ b/test/jest/SwapRecovery.ts
@@ -1,0 +1,171 @@
+import { SwapClientType, SwapFailureReason, SwapPhase, SwapRole, SwapState } from '../../lib/constants/enums';
+import LndClient from '../../lib/lndclient/LndClient';
+import Logger from '../../lib/Logger';
+import Peer from '../../lib/p2p/Peer';
+import { PaymentState } from '../../lib/swaps/SwapClient';
+import SwapClientManager from '../../lib/swaps/SwapClientManager';
+import SwapRecovery from '../../lib/swaps/SwapRecovery';
+
+jest.mock('../../lib/Logger');
+const mockedLogger = <jest.Mock<Logger>><any>Logger;
+jest.mock('../../lib/swaps/SwapClientManager');
+const mockedSwapClientManager = <jest.Mock<SwapClientManager>><any>SwapClientManager;
+jest.mock('../../lib/p2p/Peer');
+const mockedPeer = <jest.Mock<Peer>><any>Peer;
+jest.mock('../../lib/lndclient/LndClient');
+const mockedLnd = <jest.Mock<LndClient>><any>LndClient;
+const getMockedLnd = (lockBuffer: number) => {
+  const lnd = new mockedLnd();
+  // @ts-ignore
+  lnd.lockBuffer = lockBuffer;
+  // @ts-ignore
+  lnd.type = SwapClientType.Lnd;
+  lnd.isConnected = jest.fn().mockReturnValue(true);
+  lnd.removeInvoice = jest.fn();
+  lnd.settleInvoice = jest.fn();
+  return lnd;
+};
+
+const save = jest.fn();
+const takerCurrency = 'LTC';
+const makerCurrency = 'BTC';
+const swapDealInstance = {
+  save,
+  takerCurrency,
+  makerCurrency,
+  state: SwapState.Active,
+  role: SwapRole.Maker,
+  peerPubKey: '02a9a503beb4f291c77cbea972c0fe2410f3bb0d62178896dcfae958edc8541b3c',
+  orderId: '4e6926b0-c25a-11e9-ac60-17a7cbc02f5c',
+  localId: '4e6926b0-c25a-11e9-ac60-17a7cbc02f5c',
+  proposedQuantity: 1000,
+  takerAmount: 100000,
+  makerAmount: 1000,
+  takerCltvDelta: 576,
+  rHash: '5ff06a3cbe98713b9015843119da243ecac8097dcb5bd5a6923ac8eed340ddc9',
+  createTime: 1566820828545,
+};
+
+describe('SwapRecovery', () => {
+  let swapRecovery: SwapRecovery;
+  let logger: Logger;
+  let swapClientManager: SwapClientManager;
+  let peer: Peer;
+  let lndBtc: LndClient;
+  let lndLtc: LndClient;
+
+  beforeEach(() => {
+    logger = new mockedLogger();
+    logger.debug = jest.fn();
+    logger.error = jest.fn();
+    logger.info = jest.fn();
+    swapClientManager = new mockedSwapClientManager();
+    swapClientManager.get = jest.fn().mockImplementation((currency) => {
+      if (currency === 'BTC') {
+        return lndBtc;
+      }
+      if (currency === 'LTC') {
+        return lndLtc;
+      }
+      return;
+    });
+    peer = new mockedPeer();
+    peer.sendPacket = jest.fn();
+    lndBtc = getMockedLnd(144);
+    lndLtc = getMockedLnd(576);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('it fails a deal', async () => {
+    const deal: any = { ...swapDealInstance };
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    swapRecovery.pendingSwaps.delete = jest.fn();
+
+    await swapRecovery['failDeal'](deal, lndBtc);
+    expect(deal.state).toEqual(SwapState.Error);
+    expect(deal.failureReason).toEqual(SwapFailureReason.Crash);
+    expect(swapRecovery.pendingSwaps.delete).toHaveBeenCalledTimes(1);
+    expect(swapRecovery.pendingSwaps.delete).toHaveBeenCalledWith(deal);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  test('it fails a swap that was accepted but not started payments', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.phase = SwapPhase.SwapAccepted;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    swapRecovery['failDeal'] = jest.fn();
+
+    await swapRecovery.recoverDeal(deal);
+    expect(swapRecovery['failDeal']).toHaveBeenCalledTimes(1);
+    expect(swapRecovery['failDeal']).toHaveBeenCalledWith(deal, lndBtc);
+  });
+
+  test('it fails a swap where we were sending payment as taker', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.role = SwapRole.Taker;
+    deal.phase = SwapPhase.SendingPayment;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    swapRecovery['failDeal'] = jest.fn();
+
+    await swapRecovery.recoverDeal(deal);
+    expect(swapRecovery['failDeal']).toHaveBeenCalledTimes(1);
+    expect(swapRecovery['failDeal']).toHaveBeenCalledWith(deal, lndLtc);
+  });
+
+  test('it completes a swap where we received payment', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.phase = SwapPhase.PaymentReceived;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+
+    await swapRecovery.recoverDeal(deal);
+    expect(deal.state).toEqual(SwapState.Recovered);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  test('it completes a successful payment when we were sending payment as maker', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.phase = SwapPhase.SendingPayment;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    const preimage = 'preimage';
+    lndLtc.lookupPayment = jest.fn().mockReturnValue({ preimage, state: PaymentState.Succeeded });
+
+    await swapRecovery.recoverDeal(deal);
+    expect(lndLtc.lookupPayment).toHaveBeenCalledTimes(1);
+    expect(lndLtc.lookupPayment).toHaveBeenCalledWith(deal.rHash);
+    expect(lndBtc.settleInvoice).toHaveBeenCalledTimes(1);
+    expect(lndBtc.settleInvoice).toHaveBeenCalledWith(deal.rHash, preimage);
+    expect(deal.state).toEqual(SwapState.Recovered);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  test('it fails a failed payment when we were sending payment as maker', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.phase = SwapPhase.SendingPayment;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    lndLtc.lookupPayment = jest.fn().mockReturnValue({ state: PaymentState.Failed });
+
+    swapRecovery['failDeal'] = jest.fn();
+
+    await swapRecovery.recoverDeal(deal);
+    expect(lndLtc.lookupPayment).toHaveBeenCalledTimes(1);
+    expect(lndLtc.lookupPayment).toHaveBeenCalledWith(deal.rHash);
+    expect(swapRecovery['failDeal']).toHaveBeenCalledTimes(1);
+    expect(swapRecovery['failDeal']).toHaveBeenCalledWith(deal, lndBtc);
+  });
+
+  test('it tracks a pending payment when we were sending payment as maker', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.phase = SwapPhase.SendingPayment;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    lndLtc.lookupPayment = jest.fn().mockReturnValue({ state: PaymentState.Pending });
+
+    await swapRecovery.recoverDeal(deal);
+    expect(lndLtc.lookupPayment).toHaveBeenCalledTimes(1);
+    expect(lndLtc.lookupPayment).toHaveBeenCalledWith(deal.rHash);
+    expect(swapRecovery.pendingSwaps).toContain(deal);
+  });
+
+});

--- a/test/simulation/harnessTest.go
+++ b/test/simulation/harnessTest.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/ExchangeUnion/xud-simulation/xudtest"
 	goerrors "github.com/go-errors/errors"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type testCase struct {

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"time"
+
+	"github.com/ExchangeUnion/xud-simulation/xudrpc"
+	"github.com/ExchangeUnion/xud-simulation/xudtest"
+)
+
+var ltcQuantity int64 = 1000000
+
+// instabilityTestCases are test cases which try to simulate instability
+// due to bugs, network outages, or system issues. They test whether xud
+// can handle such problems gracefully and prevent loss of funds.
+var instabilityTestCases = []*testCase{
+	{
+		name: "network initialization", // must be the first test case to be run
+		test: testNetworkInit,
+	},
+	{
+		name: "maker crashed after send payment",
+		test: testMakerCrashedAfterSend,
+	},
+	{
+		name: "maker crashed after send payment with delayed settlement",
+		test: testMakerCrashedAfterSendDelayedSettlement,
+	},
+}
+
+func testMakerCrashedAfterSend(net *xudtest.NetworkHarness, ht *harnessTest) {
+	var err error
+	net.Alice, err = net.SetCustomXud(net.Alice, "instability", []string{"BREAKSWAP=MAKER_CRASH_AFTER_SEND"})
+	ht.assert.NoError(err)
+	ht.act.init(net.Alice)
+
+	// Connect Alice to Bob.
+	ht.act.connect(net.Alice, net.Bob)
+	ht.act.verifyConnectivity(net.Alice, net.Bob)
+
+	// Save the initial balance.
+	alicePrevBalance, err := getBalance(ht.ctx, net.Alice)
+	ht.assert.NoError(err)
+	alicePrevLtcBalance := alicePrevBalance.ltc.channel.GetBalance()
+
+	// Place an order on Alice.
+	aliceOrderReq := &xudrpc.PlaceOrderRequest{
+		OrderId:  "maker_order_id",
+		Price:    0.02,
+		Quantity: uint64(ltcQuantity),
+		PairId:   "LTC/BTC",
+		Side:     xudrpc.OrderSide_BUY,
+	}
+	ht.act.placeOrderAndBroadcast(net.Alice, net.Bob, aliceOrderReq)
+
+	// Place a matching order on Bob.
+	bobOrderReq := &xudrpc.PlaceOrderRequest{
+		OrderId:  "taker_order_id",
+		Price:    aliceOrderReq.Price,
+		Quantity: aliceOrderReq.Quantity,
+		PairId:   aliceOrderReq.PairId,
+		Side:     xudrpc.OrderSide_SELL,
+	}
+	_, err = net.Bob.Client.PlaceOrderSync(ht.ctx, bobOrderReq)
+
+	<-net.Alice.ProcessExit
+
+	net.Alice.Start(nil)
+
+	// Brief delay to allow for swap to be recovered consistently
+	time.Sleep(1 * time.Second)
+
+	// Verify that alice received her LTC
+	aliceBalance, err := getBalance(ht.ctx, net.Alice)
+	ht.assert.NoError(err)
+	aliceLtcBalance := aliceBalance.ltc.channel.GetBalance()
+	ht.assert.Equal(alicePrevLtcBalance+ltcQuantity, aliceLtcBalance, "alice did not receive LTC")
+}
+
+func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht *harnessTest) {
+	var err error
+	net.Alice, err = net.SetCustomXud(net.Alice, "instability", []string{"BREAKSWAP=MAKER_CRASH_AFTER_SEND"})
+	ht.assert.NoError(err)
+
+	net.Bob, err = net.SetCustomXud(net.Bob, "instability", []string{"BREAKSWAP=TAKER_DELAY_BEFORE_SETTLE"})
+	ht.assert.NoError(err)
+
+	ht.act.init(net.Alice)
+	ht.act.init(net.Bob)
+
+	// Connect Alice to Bob.
+	ht.act.connect(net.Alice, net.Bob)
+	ht.act.verifyConnectivity(net.Alice, net.Bob)
+
+	// Save the initial balance.
+	alicePrevBalance, err := getBalance(ht.ctx, net.Alice)
+	ht.assert.NoError(err)
+	alicePrevLtcBalance := alicePrevBalance.ltc.channel.GetBalance()
+
+	// Place an order on Alice.
+	aliceOrderReq := &xudrpc.PlaceOrderRequest{
+		OrderId:  "maker_order_id",
+		Price:    0.02,
+		Quantity: uint64(ltcQuantity),
+		PairId:   "LTC/BTC",
+		Side:     xudrpc.OrderSide_BUY,
+	}
+	ht.act.placeOrderAndBroadcast(net.Alice, net.Bob, aliceOrderReq)
+
+	// Place a matching order on Bob.
+	bobOrderReq := &xudrpc.PlaceOrderRequest{
+		OrderId:  "taker_order_id",
+		Price:    aliceOrderReq.Price,
+		Quantity: aliceOrderReq.Quantity,
+		PairId:   aliceOrderReq.PairId,
+		Side:     xudrpc.OrderSide_SELL,
+	}
+	go net.Bob.Client.PlaceOrderSync(ht.ctx, bobOrderReq)
+
+	<-net.Alice.ProcessExit
+
+	net.Alice.Start(nil)
+
+	// Verify that alice hasn't claimed her LTC yet. The incoming LTC payment
+	// cannot be settled until the outgoing BTC payment is settled by bob,
+	// which is being intentionally delayed.
+	aliceIntermediateBalance, err := getBalance(ht.ctx, net.Alice)
+	ht.assert.NoError(err)
+	aliceIntermediateLtcBalance := aliceIntermediateBalance.ltc.channel.GetBalance()
+	ht.assert.NotEqual(alicePrevLtcBalance+ltcQuantity, aliceIntermediateLtcBalance)
+
+	// Delay to allow for payment to be claimed by bob then recovered by alice
+	time.Sleep(4 * time.Second)
+
+	// Verify that alice received her LTC
+	aliceBalance, err := getBalance(ht.ctx, net.Alice)
+	ht.assert.NoError(err)
+	aliceLtcBalance := aliceBalance.ltc.channel.GetBalance()
+	ht.assert.Equal(alicePrevLtcBalance+ltcQuantity, aliceLtcBalance, "alice did not receive LTC")
+}

--- a/test/simulation/xudtest/harness.go
+++ b/test/simulation/xudtest/harness.go
@@ -60,7 +60,7 @@ func (n *NetworkHarness) SetCustomXud(node *HarnessNode, branch string, envVars 
 
 	xudPath := filepath.Join(wd, "./temp", branch)
 	if _, err := os.Stat(xudPath); os.IsNotExist(err) {
-		log.Printf("custon xud not found at %v, installing...", xudPath)
+		log.Printf("custom xud not found at %v, installing...", xudPath)
 		_, err := exec.Command("git", "clone", "-b", branch, "https://github.com/ExchangeUnion/xud", xudPath).Output()
 		if err != nil {
 			return nil, fmt.Errorf("custom xud git clone failure: %v", err)
@@ -95,7 +95,7 @@ func (n *NetworkHarness) SetCustomXud(node *HarnessNode, branch string, envVars 
 	errChan := make(chan error, 1)
 	go func() {
 		defer wg.Done()
-		if err := customNode.start(n.errorChan); err != nil {
+		if err := customNode.Start(n.errorChan); err != nil {
 			if err != nil {
 				errChan <- err
 				return
@@ -120,7 +120,7 @@ func (n *NetworkHarness) newNode(name string, xudPath string, noBalanceChecks bo
 	return node, nil
 }
 
-// Start starts this xud node and its corresponding lnd nodes.
+// Start starts all xud nodes and their corresponding lnd nodes.
 func (n *NetworkHarness) Start() error {
 	var wg sync.WaitGroup
 	wg.Add(4)
@@ -130,7 +130,7 @@ func (n *NetworkHarness) Start() error {
 		node := _node
 		go func() {
 			defer wg.Done()
-			if err := node.start(n.errorChan); err != nil {
+			if err := node.Start(n.errorChan); err != nil {
 				if err != nil {
 					errChan <- err
 					return

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -177,7 +177,7 @@ func (hn *HarnessNode) SetEnvVars(envVars []string) {
 }
 
 // Start launches a new running process of xud.
-func (hn *HarnessNode) start(errorChan chan<- *XudError) error {
+func (hn *HarnessNode) Start(errorChan chan<- *XudError) error {
 	hn.quit = make(chan struct{})
 
 	args := hn.Cfg.genArgs()
@@ -210,7 +210,7 @@ func (hn *HarnessNode) start(errorChan chan<- *XudError) error {
 		defer hn.wg.Done()
 
 		err := hn.Cmd.Wait()
-		if err != nil {
+		if err != nil && errorChan != nil {
 			errorChan <- &XudError{hn, errors.Errorf("%v: %v\n%v\n", err, errb.String(), out.String())}
 		}
 


### PR DESCRIPTION
Closes #1079 & #1183. This builds off of PR #1080.

This commit attempts to recover swap deals that were interrupted due to a system or `xud` crash. In the case where we are the maker and have attempted to send payment for the second leg of the swap, we attempt to query the swap client for the preimage of that payment in case it went through. We can then use that preimage to try to claim the payment from the first leg of the swap. In all other cases, we simply attempt to close any open invoices and mark the swap deal as having errored.

Raiden currently does not expose an API call to query for the preimage of a completed payment. Any pending swaps are listed in the `GetInfo` response.

The recovery attempts happen once on `xud` startup by looking for any swap deals in the database that have an `Active` state.

I haven't tested this code yet but it is ready to review, if I have time I will also start adding some test cases. This may be a good candidate for a simulation test, since recovering funds in the case of xud crashing while waiting for the `sendPayment` response depends substantially on lnd.

This commit includes a suite of test cases for the newly added functionality. It also adds a new suite of simulation tests to test how `xud` responds to instability. It simulates crashes immediately after the maker sends payment as part of a swap. When the maker comes back online, it will fetch the preimage for the successful payment and use it to settle the incoming payment from the interrupted swap.

This tests two key cases, one where the maker's payment goes through while the maker is offline, and another where the payment goes through only after the maker has come back online. In the latter case, the maker must detect that the payment is in a pending state and monitor it in case it goes through.