### PR TITLE
 feat(raiden): check cltv delay 

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -143,6 +143,11 @@ const { argv } = require('yargs')
       type: 'number',
       alias: 'p',
     },
+    'raiden.cltvdelta': {
+      describe: 'CLTV delta for the final timelock',
+      type: 'boolean',
+      default: undefined,
+    },
     'raiden.disable': {
       describe: 'Disable raiden integration',
       type: 'boolean',

--- a/bin/xud
+++ b/bin/xud
@@ -14,6 +14,10 @@ const { argv } = require('yargs')
       type: 'boolean',
       default: undefined,
     },
+    lockbuffer: {
+      describe: 'Lock time in hours to add to cross-chain hop for swaps',
+      type: 'number',
+    },
     loglevel: {
       describe: 'Verbosity of the logger',
       type: 'string',
@@ -89,10 +93,6 @@ const { argv } = require('yargs')
       describe: 'Path to the SSL certificate for lnd',
       type: 'string',
     },
-    'lnd.[currency].cltvdelta': {
-      describe: 'CLTV delta for the final timelock',
-      type: 'number',
-    },
     'lnd.[currency].disable': {
       describe: 'Disable lnd integration',
       type: 'boolean',
@@ -143,11 +143,6 @@ const { argv } = require('yargs')
       type: 'number',
       alias: 'p',
     },
-    'raiden.cltvdelta': {
-      describe: 'CLTV delta for the final timelock',
-      type: 'boolean',
-      default: undefined,
-    },
     'raiden.disable': {
       describe: 'Disable raiden integration',
       type: 'boolean',
@@ -196,7 +191,6 @@ const { argv } = require('yargs')
     currencies.forEach((currency) => {
       parseBoolean(arg[currency], 'disable');
       parseBoolean(arg[currency], 'nomacaroons');
-      parseNumber(arg[currency], 'cltvdelta');
       parseNumber(arg[currency], 'port');
     });
 

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -127,6 +127,7 @@ class Config {
       disable: false,
       host: 'localhost',
       port: 5001,
+      cltvdelta: 5760,
     };
   }
 

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -17,6 +17,8 @@ class Config {
   public logpath: string;
   public logdateformat: string;
   public network: XuNetwork;
+  /** The lock time in hours that we add to the cross-chain "hop" for swaps. */
+  public lockbuffer: number;
   public rpc: { disable: boolean, host: string, port: number };
   public http: { host: string, port: number };
   public lnd: { [currency: string]: LndClientConfig | undefined } = {};
@@ -75,6 +77,7 @@ class Config {
     this.logdateformat = 'DD/MM/YYYY HH:mm:ss.SSS';
     this.network = this.getDefaultNetwork();
     this.dbpath = this.getDefaultDbPath();
+    this.lockbuffer = 24;
 
     this.p2p = {
       listen: true,
@@ -110,7 +113,6 @@ class Config {
       macaroonpath: path.join(lndDefaultDatadir, 'data', 'chain', 'bitcoin', this.network, 'admin.macaroon'),
       host: 'localhost',
       port: 10009,
-      cltvdelta: 144,
       nomacaroons: false,
     };
     this.lnd.LTC = {
@@ -120,14 +122,12 @@ class Config {
         this.network === XuNetwork.TestNet ? 'testnet4' : this.network, 'admin.macaroon'),
       host: 'localhost',
       port: 10010,
-      cltvdelta: 576,
       nomacaroons: false,
     };
     this.raiden = {
       disable: false,
       host: 'localhost',
       port: 5001,
-      cltvdelta: 5760,
     };
   }
 

--- a/lib/http/HttpService.ts
+++ b/lib/http/HttpService.ts
@@ -10,7 +10,7 @@ class HttpService {
       rHash: resolveRequest.secrethash.slice(2),
       amount: resolveRequest.amount,
       tokenAddress: resolveRequest.token,
-      cltvDelta: resolveRequest.expiration,
+      expiration: resolveRequest.expiration,
     });
     return { secret };
   }

--- a/lib/http/HttpService.ts
+++ b/lib/http/HttpService.ts
@@ -5,10 +5,12 @@ class HttpService {
   constructor(private service: Service) {}
 
   public resolveHashRaiden = async (resolveRequest: RaidenResolveRequest): Promise<RaidenResolveResponse> => {
-    // TODO: add reveal_timeout, settle time out,  token, etc
+    // TODO: add settle time out, etc
     const secret = await this.service.resolveHash({
       rHash: resolveRequest.secrethash.slice(2),
       amount: resolveRequest.amount,
+      tokenAddress: resolveRequest.token,
+      cltvDelta: resolveRequest.expiration,
     });
     return { secret };
   }

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -53,13 +53,23 @@ class LndClient extends SwapClient {
   private invoiceSubscriptions = new Map<string, ClientReadableStream<lndrpc.Invoice>>();
   private maximumOutboundAmount = 0;
 
+  private static MINUTES_PER_BLOCK_BY_CURRENCY: { [key: string]: number } = {
+    BTC: 10,
+    LTC: 2.5,
+  };
+
   /**
    * Creates an lnd client.
    * @param config the lnd configuration
    */
   constructor(private config: LndClientConfig, public currency: string, logger: Logger) {
     super(logger);
-    this.cltvDelta = config.cltvdelta || 0;
+    assert(config.cltvdelta > 0, 'cltv delta must be greater than 0');
+    this.cltvDelta = config.cltvdelta;
+  }
+
+  public get minutesPerBlock() {
+    return LndClient.MINUTES_PER_BLOCK_BY_CURRENCY[this.currency];
   }
 
   /** Initializes the client for calls to lnd and verifies that we can connect to it.  */

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -36,7 +36,10 @@ const MAXFEE = 0.03;
 /** A class representing a client to interact with lnd. */
 class LndClient extends SwapClient {
   public readonly type = SwapClientType.Lnd;
-  public readonly cltvDelta: number;
+  public readonly lockBuffer: number;
+  public readonly finalLock: number;
+  public config: LndClientConfig;
+  public currency: string;
   private lightning?: LightningClient | LightningMethodIndex;
   private walletUnlocker?: WalletUnlockerClient | InvoicesMethodIndex;
   private invoices?: InvoicesClient | InvoicesMethodIndex;
@@ -60,12 +63,17 @@ class LndClient extends SwapClient {
 
   /**
    * Creates an lnd client.
-   * @param config the lnd configuration
    */
-  constructor(private config: LndClientConfig, public currency: string, logger: Logger) {
+  constructor(
+    { config, logger, currency, lockBufferHours }:
+    { config: LndClientConfig, logger: Logger, currency: string, lockBufferHours: number },
+  ) {
     super(logger);
-    assert(config.cltvdelta > 0, 'cltv delta must be greater than 0');
-    this.cltvDelta = config.cltvdelta;
+    this.config = config;
+    this.currency = currency;
+    this.lockBuffer = Math.round(lockBufferHours * 60 / LndClient.MINUTES_PER_BLOCK_BY_CURRENCY[currency]);
+     // we set the expected final lock to 400 minutes which is the default for bitcoin on lnd 0.7.1
+    this.finalLock = Math.round(400 / LndClient.MINUTES_PER_BLOCK_BY_CURRENCY[currency]);
   }
 
   public get minutesPerBlock() {
@@ -74,7 +82,7 @@ class LndClient extends SwapClient {
 
   /** Initializes the client for calls to lnd and verifies that we can connect to it.  */
   public init = async () => {
-    assert(this.cltvDelta > 0, `lnd-${this.currency}: cltvdelta must be a positive number`);
+    assert(this.lockBuffer > 0, `lnd-${this.currency}: lock buffer must be a positive number`);
 
     const { disable, certpath, macaroonpath, nomacaroons, host, port } = this.config;
     if (disable) {
@@ -313,7 +321,7 @@ class LndClient extends SwapClient {
       // In case of sanity swaps we don't know the
       // takerCltvDelta or the makerCltvDelta. Using our
       // client's default.
-      finalCltvDelta: this.cltvDelta,
+      finalCltvDelta: this.lockBuffer,
     });
     const preimage = await this.executeSendRequest(request);
     return preimage;
@@ -342,11 +350,9 @@ class LndClient extends SwapClient {
         rHash: deal.rHash,
         destination: deal.takerPubKey!,
         amount: deal.takerAmount,
-        // Using the agreed upon takerCltvDelta. Taker won't accept
-        // our payment if we provide a smaller value.
-        finalCltvDelta: deal.takerCltvDelta,
         // Enforcing the maximum duration/length of the payment by
         // specifying the cltvLimit.
+        finalCltvDelta: deal.takerCltvDelta,
         cltvLimit: deal.makerCltvDelta,
       });
     }
@@ -518,7 +524,7 @@ class LndClient extends SwapClient {
     return this.unaryCall<lndrpc.ListChannelsRequest, lndrpc.ListChannelsResponse>('listChannels', new lndrpc.ListChannelsRequest());
   }
 
-  public getRoutes =  async (amount: number, destination: string, _currency: string, finalCltvDelta = this.cltvDelta): Promise<lndrpc.Route[]> => {
+  public getRoutes =  async (amount: number, destination: string, _currency: string, finalCltvDelta = this.lockBuffer): Promise<lndrpc.Route[]> => {
     const request = new lndrpc.QueryRoutesRequest();
     request.setAmt(amount);
     request.setFinalCltvDelta(finalCltvDelta);

--- a/lib/lndclient/types.ts
+++ b/lib/lndclient/types.ts
@@ -5,7 +5,6 @@ export type LndClientConfig = {
   macaroonpath: string;
   host: string;
   port: number;
-  cltvdelta: number;
   nomacaroons: boolean;
 };
 

--- a/lib/p2p/packets/types/SwapAcceptedPacket.ts
+++ b/lib/p2p/packets/types/SwapAcceptedPacket.ts
@@ -7,6 +7,7 @@ export type SwapAcceptedPacketBody = {
   rHash: string;
   /** Specifies the accepted quantity (which may be less than the proposed quantity). */
   quantity: number;
+  /** The CLTV delta from the current height that should be used to set the timelock for the final hop when sending to maker. */
   makerCltvDelta: number;
 };
 

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -42,7 +42,8 @@ async function parseResponseBody<T>(res: http.IncomingMessage): Promise<T> {
  */
 class RaidenClient extends SwapClient {
   public readonly type = SwapClientType.Raiden;
-  public readonly cltvDelta: number;
+  public readonly lockBuffer: number;
+  public readonly finalLock = 100;
   public address?: string;
   /** A map of currency symbols to token addresses. */
   public tokenAddresses = new Map<string, string>();
@@ -57,14 +58,13 @@ class RaidenClient extends SwapClient {
    * Creates a raiden client.
    */
   constructor(
-    { config, logger, unitConverter, directChannelChecks = false }:
-    { config: RaidenClientConfig, logger: Logger, unitConverter: UnitConverter, directChannelChecks: boolean },
+    { config, logger, unitConverter, directChannelChecks = false, lockBufferHours }:
+    { config: RaidenClientConfig, logger: Logger, unitConverter: UnitConverter, directChannelChecks: boolean, lockBufferHours: number },
   ) {
     super(logger);
-    const { disable, host, port, cltvdelta } = config;
+    const { disable, host, port } = config;
 
-    assert(cltvdelta > 0, 'cltv delta must be greater than 0');
-    this.cltvDelta = cltvdelta;
+    this.lockBuffer = Math.round(lockBufferHours * 60 / this.minutesPerBlock);
     this.port = port;
     this.host = host;
     this.disable = disable;

--- a/lib/raidenclient/types.ts
+++ b/lib/raidenclient/types.ts
@@ -5,7 +5,6 @@ export type RaidenClientConfig = {
   disable: boolean;
   host: string;
   port: number;
-  cltvdelta: number;
 };
 
 /** General information about the state of this raiden client. */

--- a/lib/raidenclient/types.ts
+++ b/lib/raidenclient/types.ts
@@ -5,6 +5,7 @@ export type RaidenClientConfig = {
   disable: boolean;
   host: string;
   port: number;
+  cltvdelta: number;
 };
 
 /** General information about the state of this raiden client. */
@@ -54,6 +55,7 @@ export type TokenPaymentRequest = {
   amount: number,
   secret_hash: string,
   identifier?: number,
+  lock_timeout?: number,
 };
 
 export type RaidenResolveRequest = {
@@ -63,13 +65,15 @@ export type RaidenResolveRequest = {
   secrethash: string;
   /** The amount of the incoming payment pending resolution, in the smallest units supported by the token. */
   amount: number;
+  /** The maximum number of blocks allowed between the setting of a hashlock and the revealing of the related secret. */
+  reveal_timeout: number;
+  /** The lock expiration for the incoming payment. */
+  expiration: number;
+  // 'settle_timeout': raiden.config['settle_timeout'],
   // unused fields on the raiden request listed below, taken from raiden codebase
   // 'payment_identifier': secret_request_event.payment_identifier,
   // 'payment_sender': to_hex(secret_request_event.recipient),
-  // 'expiration': secret_request_event.expiration,
   // 'payment_recipient': to_hex(raiden.address),
-  // 'reveal_timeout': raiden.config['reveal_timeout'],
-  // 'settle_timeout': raiden.config['settle_timeout'],
 };
 
 export type RaidenResolveResponse = {

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -48,6 +48,8 @@ abstract class SwapClient extends EventEmitter {
     super();
   }
 
+  public abstract get minutesPerBlock(): number;
+
   /**
    * Returns the total balance available across all channels.
    * @param currency the currency whose balance to query for, otherwise all/any

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -33,7 +33,18 @@ interface SwapClient {
  * A base class to represent an external swap client such as lnd or Raiden.
  */
 abstract class SwapClient extends EventEmitter {
-  public abstract readonly cltvDelta: number;
+  /**
+   * The number of blocks to use for determining the minimum delay for an incoming payment in excess
+   * of the total time delay of the contingent outgoing payment. This buffer ensures that the lock
+   * for incoming payments does not expire before the contingent outgoing payment lock.
+   */
+  public abstract readonly lockBuffer: number;
+  /**
+   * The number of blocks of lock time to expect on the final incoming hop of a swap. This affects
+   * only the second leg of a swap where knowledge of the preimage is not contingent on making a
+   * separate payment.
+   */
+  public abstract readonly finalLock: number;
   public abstract readonly type: SwapClientType;
   protected status: ClientStatus = ClientStatus.NotInitialized;
   protected reconnectionTimer?: NodeJS.Timer;

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -51,6 +51,7 @@ class SwapClientManager extends EventEmitter {
     this.raidenClient = new RaidenClient({
       unitConverter,
       config: config.raiden,
+      lockBufferHours: config.lockbuffer,
       logger: loggers.raiden,
       directChannelChecks: config.debug.raidenDirectChannelChecks,
     });
@@ -67,11 +68,12 @@ class SwapClientManager extends EventEmitter {
     for (const currency in this.config.lnd) {
       const lndConfig = this.config.lnd[currency]!;
       if (!lndConfig.disable) {
-        const lndClient = new LndClient(
-          lndConfig,
+        const lndClient = new LndClient({
           currency,
-          this.loggers.lnd.createSubLogger(currency),
-        );
+          config: lndConfig,
+          lockBufferHours: this.config.lockbuffer,
+          logger: this.loggers.lnd.createSubLogger(currency),
+        });
         this.swapClients.set(currency, lndClient);
         initPromises.push(lndClient.init());
       }

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -102,4 +102,7 @@ export type ResolveRequest = {
   /** The amount of the incoming payment pending resolution, in the smallest units supported by the token. */
   amount: number,
   rHash: string,
+  tokenAddress: string,
+  /** The number of blocks before the HTLC expires. */
+  cltvDelta: number,
 };

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -103,6 +103,6 @@ export type ResolveRequest = {
   amount: number,
   rHash: string,
   tokenAddress: string,
-  /** The number of blocks before the HTLC expires. */
-  cltvDelta: number,
+  /** The number of blocks before the incoming payment expires. */
+  expiration: number,
 };

--- a/test/jest/HttpService.spec.ts
+++ b/test/jest/HttpService.spec.ts
@@ -34,10 +34,10 @@ describe('HttpService', () => {
     await httpService.resolveHashRaiden(resolveRequest);
     expect(service.resolveHash)
       .toHaveBeenCalledWith({
+        expiration,
         amount: resolveRequest.amount,
         rHash: secretHash,
         tokenAddress: token,
-        cltvDelta: expiration,
       });
   });
 

--- a/test/jest/HttpService.spec.ts
+++ b/test/jest/HttpService.spec.ts
@@ -1,14 +1,19 @@
 import HttpService from '../../lib/http/HttpService';
 import Service from '../../lib/service/Service';
+import { RaidenResolveRequest } from '../../lib/raidenclient/types';
 
 jest.mock('../../lib/service/Service');
 const mockedService = <jest.Mock<Service>><any>Service;
 
+const token = '0x4c354c76d5f73a63a90be776897dc81fb6238772';
+const expiration = 75;
 const secretHash = '2ea852a816e4390f1468b9b1389be14e3a965479beb2c97354a409993eb52e46';
-const resolveRequest = {
-  token: '0x4c354c76d5f73a63a90be776897dc81fb6238772',
+const resolveRequest: RaidenResolveRequest = {
+  token,
+  expiration,
   secrethash: `0x${secretHash}`,
   amount: 1,
+  reveal_timeout: 50,
 };
 
 describe('HttpService', () => {
@@ -31,6 +36,8 @@ describe('HttpService', () => {
       .toHaveBeenCalledWith({
         amount: resolveRequest.amount,
         rHash: secretHash,
+        tokenAddress: token,
+        cltvDelta: expiration,
       });
   });
 

--- a/test/jest/LndClient.spec.ts
+++ b/test/jest/LndClient.spec.ts
@@ -25,6 +25,7 @@ describe('LndClient', () => {
   let config: LndClientConfig;
   let currency: string;
   let logger: Logger;
+  const lockBufferHours = 24;
 
   beforeEach(() => {
     config = {
@@ -33,7 +34,6 @@ describe('LndClient', () => {
       macaroonpath: '/macaroon/path',
       host: '127.0.0.1',
       port: 4321,
-      cltvdelta: 144,
       nomacaroons: true,
     };
     currency = 'BTC';
@@ -60,7 +60,7 @@ describe('LndClient', () => {
 
     test('it throws when connectPeer fails', async () => {
       expect.assertions(3);
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['connectPeer'] = jest.fn().mockImplementation(() => {
         throw new Error('connectPeer failed');
       });
@@ -80,7 +80,7 @@ describe('LndClient', () => {
 
     test('it tries all 2 lnd uris when connectPeer to first one fails', async () => {
       expect.assertions(3);
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['openChannelSync'] = jest.fn().mockReturnValue(Promise.resolve());
       const connectPeerFail = () => {
         throw new Error('connectPeer failed');
@@ -104,7 +104,7 @@ describe('LndClient', () => {
 
     test('it does succeed when connecting to already connected peer', async () => {
       expect.assertions(4);
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['openChannelSync'] = jest.fn().mockReturnValue(Promise.resolve());
       const alreadyConnected = () => {
         throw new Error('already connected');
@@ -127,7 +127,7 @@ describe('LndClient', () => {
     test('it throws when timeout reached', async () => {
       expect.assertions(3);
       jest.useFakeTimers();
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['openChannelSync'] = jest.fn().mockReturnValue(Promise.resolve());
       const timeOut = () => {
         jest.runAllTimers();
@@ -151,7 +151,7 @@ describe('LndClient', () => {
 
     test('it stops trying to connect to lnd uris when first once succeeds', async () => {
       expect.assertions(3);
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['openChannelSync'] = jest.fn().mockReturnValue(Promise.resolve());
       lnd['connectPeer'] = jest.fn()
         .mockImplementationOnce(() => {
@@ -171,7 +171,7 @@ describe('LndClient', () => {
 
     test('it throws when openchannel fails', async () => {
       expect.assertions(2);
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['connectPeer'] = jest.fn().mockReturnValue(Promise.resolve());
       lnd['openChannelSync'] = jest.fn().mockImplementation(() => {
         throw new Error('openChannelSync error');
@@ -193,7 +193,7 @@ describe('LndClient', () => {
   describe('sendPayment', () => {
 
     test('it resolves upon maker success', async () => {
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['sendPaymentSync'] = jest.fn()
         .mockReturnValue(Promise.resolve(getSendPaymentSyncResponse()));
       const deal = getValidDeal();
@@ -203,14 +203,14 @@ describe('LndClient', () => {
       expect(buildSendRequestSpy).toHaveBeenCalledWith({
         amount: deal.takerAmount,
         destination: deal.takerPubKey,
-        finalCltvDelta: deal.takerCltvDelta,
         rHash: deal.rHash,
         cltvLimit: deal.makerCltvDelta,
+        finalCltvDelta: deal.takerCltvDelta,
       });
     });
 
     test('it resolves upon taker success', async () => {
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['sendPaymentSync'] = jest.fn()
         .mockReturnValue(Promise.resolve(getSendPaymentSyncResponse()));
       const deal = {
@@ -229,7 +229,7 @@ describe('LndClient', () => {
     });
 
     test('it rejects upon sendPaymentSync error', async () => {
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['sendPaymentSync'] = jest.fn()
         .mockReturnValue(Promise.resolve(getSendPaymentSyncErrorResponse()));
       await expect(lnd.sendPayment(getValidDeal()))
@@ -237,7 +237,7 @@ describe('LndClient', () => {
     });
 
     test('it resolves upon sendSmallestAmount success', async () => {
-      lnd = new LndClient(config, currency, logger);
+      lnd = new LndClient({ config, currency, lockBufferHours, logger });
       lnd['sendPaymentSync'] = jest.fn()
         .mockReturnValue(Promise.resolve(getSendPaymentSyncResponse()));
       const buildSendRequestSpy = jest.spyOn(lnd as any, 'buildSendRequest');
@@ -248,7 +248,7 @@ describe('LndClient', () => {
       expect(buildSendRequestSpy).toHaveBeenCalledWith({
         destination,
         rHash,
-        finalCltvDelta: lnd.cltvDelta,
+        finalCltvDelta: lnd.lockBuffer,
         amount: 1,
       });
     });

--- a/test/jest/RaidenClient.spec.ts
+++ b/test/jest/RaidenClient.spec.ts
@@ -75,6 +75,7 @@ describe('RaidenClient', () => {
       disable: false,
       host: '127.0.0.1',
       port: 1234,
+      cltvdelta: 5760,
     };
     raidenLogger = new Logger({});
     raidenLogger.info = jest.fn();

--- a/test/jest/RaidenClient.spec.ts
+++ b/test/jest/RaidenClient.spec.ts
@@ -69,13 +69,13 @@ describe('RaidenClient', () => {
   let config: RaidenClientConfig;
   let raidenLogger: Logger;
   let unitConverter: UnitConverter;
+  const lockBufferHours = 24;
 
   beforeEach(() => {
     config = {
       disable: false,
       host: '127.0.0.1',
       port: 1234,
-      cltvdelta: 5760,
     };
     raidenLogger = new Logger({});
     raidenLogger.info = jest.fn();
@@ -91,7 +91,7 @@ describe('RaidenClient', () => {
 
   describe('sendPayment', () => {
     test('it removes 0x from secret', async () => {
-      raiden = new RaidenClient({ unitConverter, config, directChannelChecks: true, logger: raidenLogger });
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
       await raiden.init(currencyInstances as CurrencyInstance[]);
       const validTokenPaymentResponse: TokenPaymentResponse = getValidTokenPaymentResponse();
       raiden['tokenPayment'] = jest.fn()
@@ -103,7 +103,7 @@ describe('RaidenClient', () => {
     });
 
     test('it rejects in case of empty secret response', async () => {
-      raiden = new RaidenClient({ unitConverter, config, directChannelChecks: true, logger: raidenLogger });
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
       await raiden.init(currencyInstances as CurrencyInstance[]);
       const invalidTokenPaymentResponse: TokenPaymentResponse = {
         ...getValidTokenPaymentResponse(),
@@ -131,7 +131,7 @@ describe('RaidenClient', () => {
 
     test('it fails when tokenAddress for currency not found', async () => {
       expect.assertions(1);
-      raiden = new RaidenClient({ unitConverter, config, directChannelChecks: true, logger: raidenLogger });
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
       await raiden.init([] as CurrencyInstance[]);
       try {
         await raiden.openChannel({
@@ -146,7 +146,7 @@ describe('RaidenClient', () => {
 
     test('it throws when openChannel fails', async () => {
       expect.assertions(1);
-      raiden = new RaidenClient({ unitConverter, config, directChannelChecks: true, logger: raidenLogger });
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
       const peerRaidenAddress = '0x10D8CCAD85C7dc123090B43aA1f98C00a303BFC5';
       const currency = 'WETH';
       const mockTokenAddresses = new Map<string, string>();
@@ -169,7 +169,7 @@ describe('RaidenClient', () => {
 
     test('it opens a channel', async () => {
       expect.assertions(2);
-      raiden = new RaidenClient({ unitConverter, config, directChannelChecks: true, logger: raidenLogger });
+      raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
       const peerRaidenAddress = '0x10D8CCAD85C7dc123090B43aA1f98C00a303BFC5';
       const currency = 'WETH';
       const mockTokenAddresses = new Map<string, string>();
@@ -193,7 +193,7 @@ describe('RaidenClient', () => {
   });
 
   test('channelBalance calculates the total balance of open channels for a currency', async () => {
-    raiden = new RaidenClient({ unitConverter, config, directChannelChecks: true, logger: raidenLogger });
+    raiden = new RaidenClient({ unitConverter, config, lockBufferHours, directChannelChecks: true, logger: raidenLogger });
     await raiden.init(currencyInstances as CurrencyInstance[]);
     raiden.tokenAddresses.get = jest.fn().mockReturnValue(channelBalanceTokenAddress);
     raiden['getChannels'] = jest.fn()

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -93,7 +93,6 @@ describe('Swaps.SwapClientManager', () => {
         certpath: 'tls.cert',
         host: 'localhost',
         port: 10009,
-        cltvdelta: 144,
         nomacaroons: true,
         macaroonpath: '',
       },
@@ -102,7 +101,6 @@ describe('Swaps.SwapClientManager', () => {
         certpath: 'tls.cert',
         host: 'localhost',
         port: 10009,
-        cltvdelta: 144,
         nomacaroons: true,
         macaroonpath: '',
       },
@@ -111,7 +109,6 @@ describe('Swaps.SwapClientManager', () => {
       disable: false,
       host: 'localhost',
       port: 1234,
-      cltvdelta: 5760,
     };
     config.debug = {
       raidenDirectChannelChecks: true,

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -111,6 +111,7 @@ describe('Swaps.SwapClientManager', () => {
       disable: false,
       host: 'localhost',
       port: 1234,
+      cltvdelta: 5760,
     };
     config.debug = {
       raidenDirectChannelChecks: true,

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -27,10 +27,10 @@ jest.mock('../../../lib/swaps/SwapRepository', () => {
     };
   });
 });
-const getMockedLnd = (cltvDelta: number) => {
+const getMockedLnd = (lockBuffer: number) => {
   const lnd = new mockedLnd();
   // @ts-ignore
-  lnd.cltvDelta = cltvDelta;
+  lnd.lockBuffer = lockBuffer;
   // @ts-ignore
   lnd.type = SwapClientType.Lnd;
   lnd.isConnected = jest.fn().mockReturnValue(true);

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -241,6 +241,12 @@ describe('Swaps', () => {
         { getTotalTimeLock: () => 1543845 },
       ]);
       lndBtc.getHeight = jest.fn().mockReturnValue(1543701);
+      Object.defineProperty(lndBtc, 'minutesPerBlock', {
+        get: () => { return 10; },
+      });
+      Object.defineProperty(lndLtc, 'minutesPerBlock', {
+        get: () => { return 2.5; },
+      });
       swapClientManager.get = jest.fn().mockImplementation((currency) => {
         if (currency === takerCurrency) {
           return lndBtc;


### PR DESCRIPTION
Closes #1052. This is a followup of #1072 and builds off of the commit in that PR. I decided to split this into a separate PR because the logic is fairly complex to me and I felt it would greatly expand the scope of the original PR.

This refines the logic to determine whether a Raiden payment on the first leg of a swap (taker to maker) extends sufficient cltv delay according to the maker's specified minimum cltv delay.

This also checks the `token` field of a Raiden resolve request to ensure that it matches the expected token address for the deal. It also improves calculation of the `cltvDeltaFactor` to use hardcoded values for the average time per block for each chain, rather than using the configured cltv delays for each currency. Changing the configured values from the defaults could have resulted in a skewed factor.

The cltv delay for the final hop of a raiden payment is set to the `reveal_timeout` of the resolve request. Currently, given the limits in Raiden for this value, the cltv delay for a swap where the first leg of the swap uses Raiden will almost always be insufficient. The only exception is if the configured cltv delay for the 2nd leg of the swap is greatly reduced and if there are no hops.

Note: While working on this and setting the hardcoded time per block, it occurred to me that it would probably make sense to set a global final hop cltv delay config variable that's specified in terms of hours or minutes which is in turn used to calculate the `cltvDelta` for each chain. If that makes sense I could make that chain as part of this PR since I'm already touching the configuration for the `cltvDelta` for Raiden, such that we could technically reduce it to a level low enough that we could have it be the first leg of a swap.

This adds a 24h buffer between the second and first leg. Closes https://github.com/ExchangeUnion/xud/issues/1043