### PR TITLE
feat(cli): formatted channelbalance output

### DIFF
--- a/lib/cli/commands/channelbalance.ts
+++ b/lib/cli/commands/channelbalance.ts
@@ -1,6 +1,7 @@
 import { callback, loadXudClient } from '../command';
 import { Arguments } from 'yargs';
-import { ChannelBalanceRequest } from '../../proto/xudrpc_pb';
+import { ChannelBalanceRequest, ChannelBalanceResponse } from '../../proto/xudrpc_pb';
+import { satsToCoinsStr } from '../utils';
 
 export const command = 'channelbalance [currency]';
 
@@ -13,10 +14,18 @@ export const builder = {
   },
 };
 
+export const formatOutput = (response: ChannelBalanceResponse.AsObject) => {
+  const balancesMap = response.balancesMap;
+  balancesMap.forEach(([currency, channelBalance]) => {
+    const pendingBalance = channelBalance.pendingOpenBalance ? ` (+${satsToCoinsStr(channelBalance.pendingOpenBalance)} ${currency} pending)` : '';
+    console.log(`${satsToCoinsStr(channelBalance.balance)} ${currency}${pendingBalance}`);
+  });
+};
+
 export const handler = (argv: Arguments) => {
   const request = new ChannelBalanceRequest();
   if (argv.currency) {
     request.setCurrency(argv.currency.toUpperCase());
   }
-  loadXudClient(argv).channelBalance(request, callback(argv));
+  loadXudClient(argv).channelBalance(request, callback(argv, formatOutput));
 };


### PR DESCRIPTION
This formats the output of the `channelbalance` xucli command. It prints one currency's balance per line and converts the satoshi amounts provided by the rpc response into whole units as so.

```
$ xucli channelbalance
12.5 BTC
0 DAI
1125 LTC
0 WETH
```