### PR TITLE
refactor(lnd): don't log blank uris

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -236,7 +236,11 @@ class LndClient extends SwapClient {
             this.logger.debug(`pubkey is ${newPubKey}`);
             this.identityPubKey = newPubKey;
             newUris = getInfoResponse.getUrisList();
-            this.logger.debug(`uris are ${newUris}`);
+            if (newUris.length) {
+              this.logger.debug(`uris are ${newUris}`);
+            } else {
+              this.logger.debug('no uris advertised');
+            }
             this.urisList = newUris;
           }
           const chain = getInfoResponse.getChainsList()[0];


### PR DESCRIPTION
This changes the way lnd uris are logged to state that no uris are advertised when the array of uris is empty.