### PR TITLE
feat(initservice): return list of wallets

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -294,6 +294,8 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | seed_mnemonic | [string](#string) | repeated |  |
+| initialized_lnds | [string](#string) | repeated | The list of lnd clients that were initialized. |
+| initialized_raiden | [bool](#bool) |  | Whether raiden was initialized. |
 
 
 
@@ -1039,6 +1041,12 @@
 
 ### UnlockNodeResponse
 
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unlocked_lnds | [string](#string) | repeated | The list of lnd clients that were unlocked. |
+| unlocked_raiden | [bool](#bool) |  | Whether raiden was unlocked. |
 
 
 

--- a/lib/grpc/GrpcInitService.ts
+++ b/lib/grpc/GrpcInitService.ts
@@ -34,10 +34,13 @@ class GrpcInitService {
    */
   public createNode: grpc.handleUnaryCall<xudrpc.CreateNodeRequest, xudrpc.CreateNodeResponse> = async (call, callback) => {
     try {
-      const mnemonic = await this.initService.createNode(call.request.toObject());
+      const { mnemonic, initializedLndWallets } = await this.initService.createNode(call.request.toObject());
       const response = new xudrpc.CreateNodeResponse();
       if (mnemonic) {
         response.setSeedMnemonicList(mnemonic);
+      }
+      if (initializedLndWallets) {
+        response.setInitializedLndsList(initializedLndWallets);
       }
 
       callback(null, response);
@@ -52,8 +55,9 @@ class GrpcInitService {
    */
   public unlockNode: grpc.handleUnaryCall<xudrpc.UnlockNodeRequest, xudrpc.UnlockNodeResponse> = async (call, callback) => {
     try {
-      await this.initService.unlockNode(call.request.toObject());
+      const unlockedLndClients = await this.initService.unlockNode(call.request.toObject());
       const response = new xudrpc.UnlockNodeResponse();
+      response.setUnlockedLndsList(unlockedLndClients);
 
       callback(null, response);
     } catch (err) {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -757,6 +757,18 @@
           "items": {
             "type": "string"
           }
+        },
+        "initialized_lnds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of lnd clients that were initialized."
+        },
+        "initialized_raiden": {
+          "type": "boolean",
+          "format": "boolean",
+          "description": "Whether raiden was initialized."
         }
       }
     },
@@ -1394,7 +1406,21 @@
       "type": "object"
     },
     "xudrpcUnlockNodeResponse": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "unlocked_lnds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of lnd clients that were unlocked."
+        },
+        "unlocked_raiden": {
+          "type": "boolean",
+          "format": "boolean",
+          "description": "Whether raiden was unlocked."
+        }
+      }
     }
   }
 }

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -33,6 +33,14 @@ export class CreateNodeResponse extends jspb.Message {
     setSeedMnemonicList(value: Array<string>): void;
     addSeedMnemonic(value: string, index?: number): string;
 
+    clearInitializedLndsList(): void;
+    getInitializedLndsList(): Array<string>;
+    setInitializedLndsList(value: Array<string>): void;
+    addInitializedLnds(value: string, index?: number): string;
+
+    getInitializedRaiden(): boolean;
+    setInitializedRaiden(value: boolean): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CreateNodeResponse.AsObject;
@@ -47,6 +55,8 @@ export class CreateNodeResponse extends jspb.Message {
 export namespace CreateNodeResponse {
     export type AsObject = {
         seedMnemonicList: Array<string>,
+        initializedLndsList: Array<string>,
+        initializedRaiden: boolean,
     }
 }
 
@@ -72,6 +82,14 @@ export namespace UnlockNodeRequest {
 }
 
 export class UnlockNodeResponse extends jspb.Message { 
+    clearUnlockedLndsList(): void;
+    getUnlockedLndsList(): Array<string>;
+    setUnlockedLndsList(value: Array<string>): void;
+    addUnlockedLnds(value: string, index?: number): string;
+
+    getUnlockedRaiden(): boolean;
+    setUnlockedRaiden(value: boolean): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): UnlockNodeResponse.AsObject;
@@ -85,6 +103,8 @@ export class UnlockNodeResponse extends jspb.Message {
 
 export namespace UnlockNodeResponse {
     export type AsObject = {
+        unlockedLndsList: Array<string>,
+        unlockedRaiden: boolean,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -239,7 +239,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.xudrpc.CreateNodeResponse.repeatedFields_ = [1];
+proto.xudrpc.CreateNodeResponse.repeatedFields_ = [1,2];
 
 
 
@@ -270,7 +270,9 @@ proto.xudrpc.CreateNodeResponse.prototype.toObject = function(opt_includeInstanc
  */
 proto.xudrpc.CreateNodeResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    seedMnemonicList: jspb.Message.getRepeatedField(msg, 1)
+    seedMnemonicList: jspb.Message.getRepeatedField(msg, 1),
+    initializedLndsList: jspb.Message.getRepeatedField(msg, 2),
+    initializedRaiden: jspb.Message.getFieldWithDefault(msg, 3, false)
   };
 
   if (includeInstance) {
@@ -311,6 +313,14 @@ proto.xudrpc.CreateNodeResponse.deserializeBinaryFromReader = function(msg, read
       var value = /** @type {string} */ (reader.readString());
       msg.addSeedMnemonic(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addInitializedLnds(value);
+      break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setInitializedRaiden(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -347,6 +357,20 @@ proto.xudrpc.CreateNodeResponse.serializeBinaryToWriter = function(message, writ
       f
     );
   }
+  f = message.getInitializedLndsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      2,
+      f
+    );
+  }
+  f = message.getInitializedRaiden();
+  if (f) {
+    writer.writeBool(
+      3,
+      f
+    );
+  }
 };
 
 
@@ -376,6 +400,52 @@ proto.xudrpc.CreateNodeResponse.prototype.addSeedMnemonic = function(value, opt_
 
 proto.xudrpc.CreateNodeResponse.prototype.clearSeedMnemonicList = function() {
   this.setSeedMnemonicList([]);
+};
+
+
+/**
+ * repeated string initialized_lnds = 2;
+ * @return {!Array.<string>}
+ */
+proto.xudrpc.CreateNodeResponse.prototype.getInitializedLndsList = function() {
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 2));
+};
+
+
+/** @param {!Array.<string>} value */
+proto.xudrpc.CreateNodeResponse.prototype.setInitializedLndsList = function(value) {
+  jspb.Message.setField(this, 2, value || []);
+};
+
+
+/**
+ * @param {!string} value
+ * @param {number=} opt_index
+ */
+proto.xudrpc.CreateNodeResponse.prototype.addInitializedLnds = function(value, opt_index) {
+  jspb.Message.addToRepeatedField(this, 2, value, opt_index);
+};
+
+
+proto.xudrpc.CreateNodeResponse.prototype.clearInitializedLndsList = function() {
+  this.setInitializedLndsList([]);
+};
+
+
+/**
+ * optional bool initialized_raiden = 3;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.xudrpc.CreateNodeResponse.prototype.getInitializedRaiden = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 3, false));
+};
+
+
+/** @param {boolean} value */
+proto.xudrpc.CreateNodeResponse.prototype.setInitializedRaiden = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -533,12 +603,19 @@ proto.xudrpc.UnlockNodeRequest.prototype.setPassword = function(value) {
  * @constructor
  */
 proto.xudrpc.UnlockNodeResponse = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.xudrpc.UnlockNodeResponse.repeatedFields_, null);
 };
 goog.inherits(proto.xudrpc.UnlockNodeResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
   proto.xudrpc.UnlockNodeResponse.displayName = 'proto.xudrpc.UnlockNodeResponse';
 }
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.xudrpc.UnlockNodeResponse.repeatedFields_ = [1];
+
 
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
@@ -568,7 +645,8 @@ proto.xudrpc.UnlockNodeResponse.prototype.toObject = function(opt_includeInstanc
  */
 proto.xudrpc.UnlockNodeResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-
+    unlockedLndsList: jspb.Message.getRepeatedField(msg, 1),
+    unlockedRaiden: jspb.Message.getFieldWithDefault(msg, 2, false)
   };
 
   if (includeInstance) {
@@ -605,6 +683,14 @@ proto.xudrpc.UnlockNodeResponse.deserializeBinaryFromReader = function(msg, read
     }
     var field = reader.getFieldNumber();
     switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addUnlockedLnds(value);
+      break;
+    case 2:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setUnlockedRaiden(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -634,6 +720,66 @@ proto.xudrpc.UnlockNodeResponse.prototype.serializeBinary = function() {
  */
 proto.xudrpc.UnlockNodeResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getUnlockedLndsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      1,
+      f
+    );
+  }
+  f = message.getUnlockedRaiden();
+  if (f) {
+    writer.writeBool(
+      2,
+      f
+    );
+  }
+};
+
+
+/**
+ * repeated string unlocked_lnds = 1;
+ * @return {!Array.<string>}
+ */
+proto.xudrpc.UnlockNodeResponse.prototype.getUnlockedLndsList = function() {
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 1));
+};
+
+
+/** @param {!Array.<string>} value */
+proto.xudrpc.UnlockNodeResponse.prototype.setUnlockedLndsList = function(value) {
+  jspb.Message.setField(this, 1, value || []);
+};
+
+
+/**
+ * @param {!string} value
+ * @param {number=} opt_index
+ */
+proto.xudrpc.UnlockNodeResponse.prototype.addUnlockedLnds = function(value, opt_index) {
+  jspb.Message.addToRepeatedField(this, 1, value, opt_index);
+};
+
+
+proto.xudrpc.UnlockNodeResponse.prototype.clearUnlockedLndsList = function() {
+  this.setUnlockedLndsList([]);
+};
+
+
+/**
+ * optional bool unlocked_raiden = 2;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.xudrpc.UnlockNodeResponse.prototype.getUnlockedRaiden = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 2, false));
+};
+
+
+/** @param {boolean} value */
+proto.xudrpc.UnlockNodeResponse.prototype.setUnlockedRaiden = function(value) {
+  jspb.Message.setField(this, 2, value);
 };
 
 

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -127,36 +127,50 @@ class SwapClientManager extends EventEmitter {
   public initWallets = async (walletPassword: string, seedMnemonic: string[]) => {
     // loop through swap clients to find locked lnd clients
     const initWalletPromises: Promise<any>[] = [];
+    const createdLndWallets: string[] = [];
     for (const swapClient of this.swapClients.values()) {
       if (isLndClient(swapClient) && swapClient.isWaitingUnlock()) {
-        initWalletPromises.push(swapClient.initWallet(walletPassword, seedMnemonic));
+        const initWalletPromise = swapClient.initWallet(walletPassword, seedMnemonic).then(() => {
+          createdLndWallets.push(swapClient.currency);
+        }).catch(() => {
+          this.loggers.lnd.debug(`could not initialize ${swapClient.currency} client`);
+        });
+        initWalletPromises.push(initWalletPromise);
       }
     }
 
-    await Promise.all(initWalletPromises).catch((err) => {
-      this.loggers.lnd.debug(`could not initialize one or more wallets: ${JSON.stringify(err)}`);
-    });
+    await Promise.all(initWalletPromises);
 
     // TODO: create raiden address
+
+    return createdLndWallets;
   }
 
   /**
-   * Initializes wallets with seed and password.
+   * Unlocks wallets with a password.
+   * @returns an array of currencies for each lnd client that was unlocked
    */
   public unlockWallets = async (walletPassword: string) => {
     // loop through swap clients to find locked lnd clients
     const unlockWalletPromises: Promise<any>[] = [];
+    const unlockedLndClients: string[] = [];
+
     for (const swapClient of this.swapClients.values()) {
       if (isLndClient(swapClient) && swapClient.isWaitingUnlock()) {
-        unlockWalletPromises.push(swapClient.unlockWallet(walletPassword));
+        const unlockWalletPromise = swapClient.unlockWallet(walletPassword).then(() => {
+          unlockedLndClients.push(swapClient.currency);
+        }).catch(() => {
+          this.loggers.lnd.debug(`could not unlock ${swapClient.currency} client`);
+        });
+        unlockWalletPromises.push(unlockWalletPromise);
       }
     }
 
-    await Promise.all(unlockWalletPromises).catch((err) => {
-      this.loggers.lnd.debug(`could not unlock one or more wallets: ${JSON.stringify(err)}`);
-    });
+    await Promise.all(unlockWalletPromises);
 
     // TODO: unlock raiden
+
+    return unlockedLndClients;
   }
 
   /**

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -37,6 +37,10 @@ message CreateNodeRequest {
 }
 message CreateNodeResponse {
   repeated string seed_mnemonic = 1;
+  // The list of lnd clients that were initialized.
+  repeated string initialized_lnds = 2;
+  // Whether raiden was initialized.
+  bool initialized_raiden = 3;
 }
 
 message UnlockNodeRequest {
@@ -44,7 +48,12 @@ message UnlockNodeRequest {
   // well as underlying client wallets such as lnd.
   string password = 1;
 }
-message UnlockNodeResponse { }
+message UnlockNodeResponse {
+  // The list of lnd clients that were unlocked.
+  repeated string unlocked_lnds = 1;
+  // Whether raiden was unlocked.
+  bool unlocked_raiden = 2;
+}
 
 service Xud {
   /* Adds a currency to the list of supported currencies. Once added, the currency may be used for


### PR DESCRIPTION
This adds the list of lnd clients that were initialized or unlocked by an `InitNode` or `CreateNode` call to their respective responses. This can be used to display potentially helpful information to the user.

Closes #1018.