### PR TITLE
feat: shutdown xud on error during init

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -161,22 +161,19 @@ class Xud extends EventEmitter {
 
         if (!this.config.webproxy.disable) {
           this.grpcAPIProxy = new GrpcWebProxyServer(loggers.rpc);
-          try {
-            await this.grpcAPIProxy.listen(
-              this.config.webproxy.port,
-              this.config.rpc.port,
-              this.config.rpc.host,
-              path.join(this.config.xudir, 'tls.cert'),
-            );
-          } catch (err) {
-            this.logger.error('Could not start gRPC web proxy server', err);
-          }
+          await this.grpcAPIProxy.listen(
+            this.config.webproxy.port,
+            this.config.rpc.port,
+            this.config.rpc.host,
+            path.join(this.config.xudir, 'tls.cert'),
+          );
         }
       } else {
-        this.logger.warn('RPC server is disabled.');
+        this.logger.info('RPC server is disabled.');
       }
     } catch (err) {
-      this.logger.error('Unexpected error during initialization', err);
+      this.logger.error('Unexpected error during initialization, shutting down...', err);
+      await this.shutdown();
     }
   }
 

--- a/lib/grpc/webproxy/GrpcWebProxyServer.ts
+++ b/lib/grpc/webproxy/GrpcWebProxyServer.ts
@@ -38,6 +38,7 @@ class GrpcWebProxyServer {
     return new Promise<void>((resolve, reject) => {
       /** A handler to handle an error while trying to begin listening. */
       const listenErrHandler = (err: Error) => {
+        this.logger.error('Error on web proxy beginning to listen', err);
         reject(err);
       };
 


### PR DESCRIPTION
This commit shuts down `xud` when there is an unexpected error during initialization. Allowing it to continue could result in an unexpected or undesirable state without the user being aware. Shutting down prompts the user to investigate and correct the error before restarting.