### PR TITLE
fix(raiden): getRoutes amount comparison

### DIFF
--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -203,7 +203,7 @@ class RaidenClient extends SwapClient {
     // not implemented, raiden does not use invoices
   }
 
-  public getRoutes = async (amount: number, destination: string, currency: string) => {
+  public getRoutes = async (units: number, destination: string, currency: string) => {
     // a query routes call is not currently provided by raiden
 
     /** A placeholder route value that assumes a fixed lock time of 100 Raiden's blocks. */
@@ -212,6 +212,11 @@ class RaidenClient extends SwapClient {
     };
 
     if (this.directChannelChecks) {
+      // convert received units to amount
+      const amount = this.unitConverter.unitsToAmount({
+        currency,
+        units,
+      });
       // temporary check for a direct channel in raiden
       const tokenAddress = this.tokenAddresses.get(currency);
       const channels = await this.getChannels(tokenAddress);


### PR DESCRIPTION
In this PR we fix an issue where `SwapClient.getRoutes` method received
units (smallest unit per currency) and was comparing them to amounts
(satoshis per coin).