### PR TITLE
fix: testnet seed node pubkey update

### DIFF
--- a/lib/p2p/seeds/testnet.ts
+++ b/lib/p2p/seeds/testnet.ts
@@ -2,7 +2,7 @@ import * as db from '../../db/types';
 
 export default [
   {
-    nodePubKey: '02d8ac24fe2952d0d4c9eaa188a1d51ae4d80879fa311a3729a23a15b24f121d6c',
+    nodePubKey: '02ee43f389523d7947e6a456eeb70f8429535f216654d1b1fdc753e48a96ca1469',
     addresses: [{ host: 'xud1.testnet.exchangeunion.com', port: 8885 }],
   },
 ] as db.NodeAttributes[];


### PR DESCRIPTION
Cloud instance was not responsive, had to reinstall - nodepubkey changed.

Tested locally.