### PR TITLE
feat(swapclient): add timeout to initialization

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -114,7 +114,7 @@ class LndClient extends SwapClient {
     }
 
     this.uri = `${host}:${port}`;
-    await this.verifyConnection();
+    await this.verifyConnectionWithTimeout();
   }
 
   public get pubKey() {

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -85,7 +85,7 @@ class RaidenClient extends SwapClient {
       return;
     }
     this.setTokenAddresses(currencyInstances);
-    await this.verifyConnection();
+    await this.verifyConnectionWithTimeout();
   }
 
   /**


### PR DESCRIPTION
This adds a timeout to the initialization procedure for swap clients. Previously, initialization would wait for as long as it took to receive a response from the client. In cases where raiden or lnd hangs on the response, xud would hang as well.

Now, xud will wait a fixed time limit before proceeding with initialization, leaving the client in a not connected state. The swap client will be marked as connected if and when we get a successful response.