### PR TITLE
Add xud pubkey to reconnection log message

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -512,7 +512,7 @@ class Peer extends EventEmitter {
         }
 
         this.logger.debug(
-          `Connection attempt #${retries + 1} to peer (${addressUtils.toString(this.address)}) ` +
+          `Connection attempt #${retries + 1} to peer ${this.expectedNodePubKey}@${addressUtils.toString(this.address)} ` +
           `failed: ${err.message}. retrying in ${retryDelay / 1000} sec...`,
         );
 


### PR DESCRIPTION
This PR fixes a bug described in https://github.com/ExchangeUnion/xud/issues/1136.

I used expectedNodePubKey field of Peer class to get and display the value of pubkey.
Just an observation note: in my opinion the fact that the nodePubKey field of the same class has a value only when the connection is established is a bit unintuitive.

Closes #1136.