### PR TITLE
fix: change dai ropsten contract to kyber dai ropsten contract

### DIFF
--- a/lib/db/seeds/testnet.ts
+++ b/lib/db/seeds/testnet.ts
@@ -21,7 +21,7 @@ const currencies = [
     id: 'DAI',
     swapClient: SwapClientType.Raiden,
     decimalPlaces: 18,
-    tokenAddress: '0x6d56f1c68356a147897d4f9a3dc63b97a275b8fa',
+    tokenAddress: '0xad6d458402f60fd3bd25163575031acdce07538d',
   },
 ] as db.CurrencyAttributes[];
 


### PR DESCRIPTION
The former one (https://ropsten.etherscan.io/token/0x6d56f1c68356a147897d4f9a3dc63b97a275b8fa) only has 100 DAI supply, whereas Kyber's https://ropsten.etherscan.io/token/0xad6d458402f60fd3bd25163575031acdce07538d has a bit more and is actively in use.

As per https://ropsten-api.kyber.network/currencies.