### PR TITLE
fix(lnd): waitForReady infinite deadline

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -237,12 +237,10 @@ class LndClient extends SwapClient {
     }
 
     if (!this.isConnected()) {
-      this.logger.debug(`trying to verify connection to lnd at ${this.uri}`);
+      this.logger.info(`trying to verify connection to lnd at ${this.uri}`);
       const lightningClient = new LightningClient(this.uri, this.credentials);
       const clientReadyPromise = new Promise((resolve, reject) => {
-        // if we're not initialized, don't wait for lnd to come online and mark client as disconnected immediately
-        const deadline = this.isNotInitialized() ? 0 : Number.POSITIVE_INFINITY;
-        lightningClient.waitForReady(deadline, (err) => {
+        lightningClient.waitForReady(Number.POSITIVE_INFINITY, (err) => {
           if (err) {
             reject(err);
           } else {
@@ -310,8 +308,8 @@ class LndClient extends SwapClient {
           this.lightning = undefined;
           await this.setStatus(ClientStatus.WaitingUnlock);
         } else {
-          this.logger.error(`could not verify connection to lnd at ${this.uri}, error: ${JSON.stringify(err)},
-            retrying in ${LndClient.RECONNECT_TIMER} ms`);
+          const errStr = typeof(err) === 'string' ? err : JSON.stringify(err);
+          this.logger.error(`could not verify connection at ${this.uri}, error: ${errStr}, retrying in ${LndClient.RECONNECT_TIMER} ms`);
           await this.disconnect();
         }
       }

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -78,6 +78,7 @@ abstract class SwapClient extends EventEmitter {
     return new Promise<void>((resolve, reject) => {
       const verifyTimeout = setTimeout(() => {
         // we could not verify the connection within the allotted time
+        this.logger.info(`could not verify connection within initialization time limit of ${SwapClient.INITIALIZATION_TIME_LIMIT}`);
         resolve();
       }, SwapClient.INITIALIZATION_TIME_LIMIT);
       this.verifyConnection().then(() => {


### PR DESCRIPTION
This fixes a bug where the first attempt to verify a connection to lnd would fail on the first attempt due to the `deadline` of 0 for the `waitForReady` being exceeded immediately with the latest version of lnd. Subsequent attempts would not exceed the deadline.

Instead, this always uses a deadline of infinity meaning xud will always wait for lnd to be online before it attempts a `GetInfo` call to verify the connection. This leverages the recently added `verifyConnectionWithTimeout` logic to timeout the initial connection verification if lnd remains offline so that it doesn't hold up the xud initialization procedure.

I've tested this both in the case of lnd being online when xud starts and lnd being offline and it works as expected in both cases.