### PR TITLE
chore: change openchannel error message

### DIFF
--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -286,7 +286,7 @@ class SwapClientManager extends EventEmitter {
     }
     const peerIdentifier = peer.getIdentifier(swapClient.type, currency);
     if (!peerIdentifier) {
-      throw new Error('unable to get swap client pubKey for peer');
+      throw new Error('peer not connected to swap client');
     }
     const units = this.unitConverter.amountToUnits({
       amount,

--- a/test/jest/__snapshots__/SwapClientManager.spec.ts.snap
+++ b/test/jest/__snapshots__/SwapClientManager.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Swaps.SwapClientManager openChannel it fails lnd without lndUris 1`] = `[Error: unable to get lnd listening uris]`;
 
-exports[`Swaps.SwapClientManager openChannel it fails without peerSwapClientPubKey 1`] = `[Error: unable to get swap client pubKey for peer]`;
+exports[`Swaps.SwapClientManager openChannel it fails without peerSwapClientPubKey 1`] = `[Error: peer not connected to swap client]`;
 
 exports[`Swaps.SwapClientManager openChannel it fails without swap client 1`] = `
 Object {


### PR DESCRIPTION
Linked issue: https://github.com/ExchangeUnion/xud/issues/1133
I replaced the suggested "not connected to peer X" with "peer not connected to swap client" as this seemed to be a little bit more precise. As peer's nodePubKey is already mentioned in the same row, I suggest to omit it from the message.