### PR TITLE
fix(swaps): prevent crash on send payment failure

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -700,6 +700,7 @@ class Swaps extends EventEmitter {
         failureReason: SwapFailureReason.SendPaymentFailure,
         errorMessage: err.message,
       });
+      return;
     }
 
     // swap succeeded!


### PR DESCRIPTION
This fixes a bug where we would attempt to set a swap as successful after it had errored due to a send payment failure.

Fixes #1155.