### PR TITLE
test: multi-hop sim test

### DIFF
--- a/test/simulation/README.md
+++ b/test/simulation/README.md
@@ -44,3 +44,4 @@ $ GOPATH=$PWD/go GO111MODULE=on go test -v
 ### Swaps
 - [x] Placed order should trigger a swap.
 - [ ] Placed order should trigger a swap and order invalidation on the maker order to all connected peers besides the taker peer.
+- [x] Swaps that use multihop routes for payment on lnd.

--- a/test/simulation/actions.go
+++ b/test/simulation/actions.go
@@ -400,7 +400,7 @@ func getInfo(ctx context.Context, n *xudtest.HarnessNode) (*xudrpc.GetInfoRespon
 }
 
 func openBtcChannel(ctx context.Context, ln *lntest.NetworkHarness, srcNode, destNode *lntest.HarnessNode) (*lnrpc.ChannelPoint, error) {
-	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, 15000000, 0, false)
+	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, 15000000, 7500000, false)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func closeBtcChannel(ctx context.Context, ln *lntest.NetworkHarness, node *lntes
 }
 
 func openLtcChannel(ctx context.Context, ln *lntest.NetworkHarness, srcNode, destNode *lntest.HarnessNode) (*lnrpc.ChannelPoint, error) {
-	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, 15000000, 0, false)
+	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, 15000000, 7500000, false)
 	if err != nil {
 		return nil, err
 	}

--- a/test/simulation/lntest/harness.go
+++ b/test/simulation/lntest/harness.go
@@ -190,7 +190,7 @@ func (n *NetworkHarness) SetUp(lndArgs []string) error {
 	addrReq := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	clients := []lnrpc.LightningClient{n.Alice, n.Bob}
+	clients := []lnrpc.LightningClient{n.Alice, n.Bob, n.Carol}
 	for _, client := range clients {
 		for i := 0; i < 10; i++ {
 			resp, err := client.NewAddress(ctxb, addrReq)
@@ -253,8 +253,14 @@ func (n *NetworkHarness) SetUp(lndArgs []string) error {
 		}
 	}
 
-	// Finally, make a connection between both of the nodes.
+	// Finally, make connections between the nodes.
 	if err := n.ConnectNodes(ctxb, n.Alice, n.Bob); err != nil {
+		return err
+	}
+	if err := n.ConnectNodes(ctxb, n.Bob, n.Carol); err != nil {
+		return err
+	}
+	if err := n.ConnectNodes(ctxb, n.Carol, n.Dave); err != nil {
 		return err
 	}
 

--- a/test/simulation/xud_test.go
+++ b/test/simulation/xud_test.go
@@ -54,13 +54,19 @@ func TestIntegration(t *testing.T) {
 	t.Logf("Running %v integration tests", len(integrationTestCases))
 
 	// Open channels from both directions on each chain.
-	aliceBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+	aliceBobBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
 	ht.assert.NoError(err)
-	aliceLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+	aliceBobLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
 	ht.assert.NoError(err)
-	bobBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Alice.LndBtcNode)
+
+	bobCarolBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Carol.LndBtcNode)
 	ht.assert.NoError(err)
-	bobLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Alice.LndLtcNode)
+	bobCarolLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Carol.LndLtcNode)
+	ht.assert.NoError(err)
+
+	carolDavidBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, xudNetwork.Dave.LndBtcNode)
+	ht.assert.NoError(err)
+	carolDavidLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, xudNetwork.Dave.LndLtcNode)
 	ht.assert.NoError(err)
 
 	initialStates := make(map[int]*xudrpc.GetInfoResponse)
@@ -107,13 +113,17 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// Close all channels, mostly in order to verify there are no pending HTLCs (which would require force-close).
-	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBtcChanPoint, false)
+	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBobBtcChanPoint, false)
 	ht.assert.NoError(err)
-	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceLtcChanPoint, false)
+	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceBobLtcChanPoint, false)
 	ht.assert.NoError(err)
-	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, bobBtcChanPoint, false)
+	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, bobCarolBtcChanPoint, false)
 	ht.assert.NoError(err)
-	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, bobLtcChanPoint, false)
+	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, bobCarolLtcChanPoint, false)
+	ht.assert.NoError(err)
+	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, carolDavidBtcChanPoint, false)
+	ht.assert.NoError(err)
+	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, carolDavidLtcChanPoint, false)
 	ht.assert.NoError(err)
 }
 


### PR DESCRIPTION
This adds a simulation test case for multi-hop swaps. Pairs of LTC & BTC channels are established between Alice & Bob, Bob & Carol, and Carol & Dave. Then a swap is performed between Alice & Dave.

This also modifies the channel setup to use a single channel with balance on both sides rather than two unbalanced channels to better resemble how channels are constructed during live usage.