### PR TITLE
fix(p2p): prevent xud from crashing when connecting to peer times out

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -171,6 +171,9 @@ class GrpcService {
       case p2pErrorCodes.POOL_CLOSED:
         code = status.ABORTED;
         break;
+      case p2pErrorCodes.RESPONSE_TIMEOUT:
+        code = status.DEADLINE_EXCEEDED;
+        break;
     }
 
     // return a grpc error with the code if we've assigned one, otherwise pass along the caught error as UNKNOWN

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -580,7 +580,7 @@ class Peer extends EventEmitter {
         const request = PacketType[parseInt(packetId, 10)] || packetId;
         const err = errors.RESPONSE_TIMEOUT(request);
         this.emitError(err.message);
-        entry.reject(err.message);
+        entry.reject(err);
         await this.close(DisconnectionReason.ResponseStalling, packetId);
       }
     }


### PR DESCRIPTION
Fix for https://github.com/ExchangeUnion/xud/issues/1129

xud was crashing because GrpcService::getGrpcError requires an error object that should have code and message properties, but got a string instead.