### PR TITLE
feat(swaps): improved remote error handling

### DIFF
--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -125,6 +125,8 @@ export enum SwapFailureReason {
   DealTimedOut = 11,
   /** The swap failed due to an unrecognized error. */
   UnknownError = 12,
+  /** The swap failed due to an error or unexpected behavior on behalf of the remote peer. */
+  RemoteError = 12,
 }
 
 export enum DisconnectionReason {

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -695,13 +695,19 @@ class Swaps extends EventEmitter {
     try {
       await makerSwapClient.sendPayment(deal);
     } catch (err) {
-      this.failDeal(deal, SwapFailureReason.SendPaymentFailure, err.message);
-      await this.sendErrorToPeer({
-        peer,
-        rHash,
-        failureReason: SwapFailureReason.SendPaymentFailure,
-        errorMessage: err.message,
-      });
+      if (err.code === errors.PAYMENT_REJECTED) {
+        // if the maker rejected our payment, the swap failed due to an error on their side
+        // and we don't need to send them a SwapFailedPacket
+        this.failDeal(deal, SwapFailureReason.RemoteError, err.message);
+      } else {
+        this.failDeal(deal, SwapFailureReason.SendPaymentFailure, err.message);
+        await this.sendErrorToPeer({
+          peer,
+          rHash,
+          failureReason: SwapFailureReason.SendPaymentFailure,
+          errorMessage: err.message,
+        });
+      }
       return;
     }
 
@@ -1041,11 +1047,21 @@ class Swaps extends EventEmitter {
     const deal = this.getDeal(rHash);
     // TODO: penalize for unexpected swap failed packets
     if (!deal) {
-      this.logger.warn(`received swap failed packet for unknown deal with payment hash ${rHash}`);
-      return;
-    }
-    if (deal.state !== SwapState.Active) {
-      this.logger.warn(`received swap failed packet for inactive deal with payment hash ${rHash}`);
+      const dealInstance = await this.repository.getSwapDeal(rHash);
+      if (dealInstance) {
+        if (dealInstance.state === SwapState.Error && dealInstance.failureReason === SwapFailureReason.RemoteError) {
+          const errorMessageWithReason = `${SwapFailureReason[failureReason]} - ${errorMessage}`;
+          // update the error message for this saved deal to include the reason it failed
+          dealInstance.errorMessage = dealInstance.errorMessage ?
+            `${dealInstance.errorMessage}; ${errorMessageWithReason}` :
+            errorMessageWithReason;
+          await dealInstance.save();
+        } else {
+          this.logger.warn(`received unexpected swap failed packet for deal with payment hash ${rHash}`);
+        }
+      } else {
+        this.logger.warn(`received swap failed packet for unknown deal with payment hash ${rHash}`);
+      }
       return;
     }
 

--- a/lib/swaps/errors.ts
+++ b/lib/swaps/errors.ts
@@ -5,6 +5,8 @@ const errorCodes = {
   SWAP_CLIENT_NOT_FOUND: codesPrefix.concat('.1'),
   SWAP_CLIENT_NOT_CONFIGURED: codesPrefix.concat('.2'),
   PAYMENT_HASH_NOT_FOUND: codesPrefix.concat('.3'),
+  PAYMENT_ERROR: codesPrefix.concat('.4'),
+  PAYMENT_REJECTED: codesPrefix.concat('.4'),
 };
 
 const errors = {
@@ -20,6 +22,14 @@ const errors = {
     message: `deal for rHash ${rHash} not found`,
     code: errorCodes.PAYMENT_HASH_NOT_FOUND,
   }),
+  PAYMENT_ERROR: (message: string) => ({
+    message,
+    code: errorCodes.PAYMENT_ERROR,
+  }),
+  PAYMENT_REJECTED: {
+    message: 'the recipient rejected our payment for the swap',
+    code: errorCodes.PAYMENT_REJECTED,
+  },
 };
 
 export { errorCodes, errors };

--- a/test/jest/__snapshots__/LndClient.spec.ts.snap
+++ b/test/jest/__snapshots__/LndClient.spec.ts.snap
@@ -6,7 +6,12 @@ exports[`LndClient openChannel it throws when openchannel fails 1`] = `[Error: o
 
 exports[`LndClient openChannel it throws when timeout reached 1`] = `[Error: connectPeerAddreses failed]`;
 
-exports[`LndClient sendPayment it rejects upon sendPaymentSync error 1`] = `[Error: error!]`;
+exports[`LndClient sendPayment it rejects upon sendPaymentSync error 1`] = `
+Object {
+  "code": "7.4",
+  "message": "error!",
+}
+`;
 
 exports[`LndClient sendPayment it resolves upon maker success 1`] = `"20300a5ebc7875aca7d07fe00b1375da33cadbf2dc8703d9a29e33202c38de38"`;
 


### PR DESCRIPTION
This improves the way swap errors are communicated between participants of a swap. Previously, any error during an attempt to send payment was communicated to the peer via a `SwapFailedPacket`. However, in cases where the maker to taker (2nd leg) payment fails, the maker will reject the 1st leg payment because they were unable to acquire the preimage. This results in two near-simultaneous payment errors on both peers, who send `SwapFailedPacket`s to each other for already failed deals which results in an undesirable `received swap failed packet for unknown deal` log messages.

This change detects an lnd payment that failed due to being rejected (`UnknownPaymentHash` error message) and skips sending the `SwapFailedPacket`. Instead it fails the swap due to a new `RemoteError` swap failure reason, and updates the error details of the failed swap if it receives a `SwapFailedPacket` for swaps with this failure reason.