### PR TITLE
fix(orderbook): xud crashes upon receiving a NodeStateUpdatePac…

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -827,8 +827,10 @@ class Pool extends EventEmitter {
     });
 
     peer.on('pairDropped', (pairId) => {
-      // drop all orders for trading pairs that are no longer supported
-      this.emit('peer.pairDropped', peer.nodePubKey!, pairId);
+      // drop all orders for trading pairs that exist and are no longer supported
+      if (this.nodeState.pairs.includes(pairId)) {
+        this.emit('peer.pairDropped', peer.nodePubKey!, pairId);
+      }
     });
 
     peer.on('verifyPairs', () => {


### PR DESCRIPTION
Fix for https://github.com/ExchangeUnion/xud/issues/1128

Cause: OrderBook::getTradingPair throws an error that was not caught anywhere.
In this PR it is caught and logged in removePeerPair. (I'm not sure if this is the most accurate place for that).