### PR TITLE
refactor(swaps): change getRoutes to getRoute

### DIFF
--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -212,7 +212,7 @@ class RaidenClient extends SwapClient {
     // not implemented, raiden does not use invoices
   }
 
-  public getRoutes = async (units: number, destination: string, currency: string) => {
+  public getRoute = async (units: number, destination: string, currency: string) => {
     // a query routes call is not currently provided by raiden
 
     /** A placeholder route value that assumes a fixed lock time of 100 Raiden's blocks. */
@@ -229,17 +229,17 @@ class RaidenClient extends SwapClient {
           const balance = channel.balance;
           if (balance >= units) {
             this.logger.debug(`found a direct channel for ${currency} to ${destination} with ${balance} balance`);
-            return [placeholderRoute];
+            return placeholderRoute;
           } else {
             this.logger.warn(`direct channel found for ${currency} to ${destination} with balance of ${balance} is insufficient for ${units})`);
-            return []; // we have a direct channel but it doesn't have enough balance, return no routes
+            return undefined; // we have a direct channel but it doesn't have enough balance, return no route
           }
         }
       }
       this.logger.warn(`no direct channel found for ${currency} to ${destination}`);
-      return []; // no direct channels, return no routes
+      return undefined; // no direct channels, return no route
     } else {
-      return [placeholderRoute];
+      return placeholderRoute;
     }
   }
 

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -145,7 +145,7 @@ abstract class SwapClient extends EventEmitter {
    * @param destination the identifier for the receiving node
    * @returns routes
    */
-  public abstract async getRoutes(units: number, destination: string, currency: string, finalCltvDelta?: number): Promise<Route[]>;
+  public abstract async getRoute(units: number, destination: string, currency: string, finalCltvDelta?: number): Promise<Route | undefined>;
 
   /**
    * @param units the amount of the invoice denominated in the smallest units supported by its currency

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -150,7 +150,7 @@ describe('Swaps', () => {
     });
 
     test('it rejects upon 0 maker to taker routes found', async () => {
-      lndBtc.getRoutes = jest.fn().mockReturnValue([]);
+      lndBtc.getRoute = jest.fn().mockReturnValue(undefined);
       swapClientManager.get = jest.fn().mockImplementation((currency) => {
         if (currency === takerCurrency) {
           return lndBtc;
@@ -176,9 +176,9 @@ describe('Swaps', () => {
     });
 
     test('it rejects upon failed getHeight request', async () => {
-      lndBtc.getRoutes = jest.fn().mockReturnValue([
-        { getTotalTimeLock: () => 1543845 },
-      ]);
+      lndBtc.getRoute = jest.fn().mockReturnValue({
+        getTotalTimeLock: () => 1543845,
+      });
       swapClientManager.get = jest.fn().mockImplementation((currency) => {
         if (currency === takerCurrency) {
           return lndBtc;
@@ -207,9 +207,9 @@ describe('Swaps', () => {
       lndLtc.addInvoice = jest.fn().mockImplementation(() => {
         throw new Error('addInvoice failure');
       });
-      lndBtc.getRoutes = jest.fn().mockReturnValue([
-        { getTotalTimeLock: () => 1543845 },
-      ]);
+      lndBtc.getRoute = jest.fn().mockReturnValue({
+        getTotalTimeLock: () => 1543845,
+      });
       lndBtc.getHeight = jest.fn().mockReturnValue(1543701);
       swapClientManager.get = jest.fn().mockImplementation((currency) => {
         if (currency === takerCurrency) {
@@ -237,9 +237,9 @@ describe('Swaps', () => {
 
     test('it accepts deal', async () => {
       const peerLndBtcPubKey = '02d9fb6c41686b7bee95958bde0ada72c249b8fa9928987c93d839225d6883e6c0';
-      lndBtc.getRoutes = jest.fn().mockReturnValue([
-        { getTotalTimeLock: () => 1543845 },
-      ]);
+      lndBtc.getRoute = jest.fn().mockReturnValue({
+        getTotalTimeLock: () => 1543845,
+      });
       lndBtc.getHeight = jest.fn().mockReturnValue(1543701);
       Object.defineProperty(lndBtc, 'minutesPerBlock', {
         get: () => { return 10; },
@@ -270,7 +270,7 @@ describe('Swaps', () => {
       peer.sendPacket = jest.fn();
       const dealAccepted = await swaps.acceptDeal(orderToAccept, swapRequestPacket, peer);
       expect(dealAccepted).toEqual(true);
-      expect(lndBtc.getRoutes).toHaveBeenCalledWith(
+      expect(lndBtc.getRoute).toHaveBeenCalledWith(
         1000,
         peerLndBtcPubKey,
         takerCurrency,


### PR DESCRIPTION
This refactors the `getRoutes` call to `getRoute` to match the behavior of lnd which only returns a single route at most for the `QueryRoutes` call.