### PR TITLE
fix(cli): executeswap don't set undefined quantity

### DIFF
--- a/lib/cli/commands/executeswap.ts
+++ b/lib/cli/commands/executeswap.ts
@@ -36,6 +36,8 @@ export const handler = (argv: Arguments) => {
   const request = new ExecuteSwapRequest();
   request.setOrderId(argv.order_id);
   request.setPairId(argv.pair_id);
-  request.setQuantity(coinsToSats(argv.quantity));
+  if (argv.quantity) {
+    request.setQuantity(coinsToSats(argv.quantity));
+  }
   loadXudClient(argv).executeSwap(request, callback(argv, displaySwapSuccess));
 };


### PR DESCRIPTION
The `coinsToSats` method expects a number, but when a quantity is not defined as a command argument then it gets passed `undefined` and returns `NaN`. Instead, we should not call this method when `quantity` is not defined and leave it as its default value on the gRPC call.

Fixes #1175.