### PR TITLE
test: use dynamic ports for simulation tests

### DIFF
--- a/test/simulation/go.mod
+++ b/test/simulation/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ltcsuite/ltcutil v0.0.0-20190507133322-23cdfa9fcc3d
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/roasbeef/btcd v0.0.0-20180418012700-a03db407e40d
 	github.com/roasbeef/btcutil v0.0.0-20180406014609-dfb640c57141
 	github.com/stretchr/testify v1.3.0

--- a/test/simulation/go.sum
+++ b/test/simulation/go.sum
@@ -144,6 +144,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/roasbeef/btcd v0.0.0-20180418012700-a03db407e40d h1:3p7ZK0clyDVNQL3a5q4jTaTDv5YzW4AxkdftpBZxsrU=

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -15,17 +15,13 @@ import (
 	"github.com/ExchangeUnion/xud-simulation/lntest"
 	"github.com/ExchangeUnion/xud-simulation/xudrpc"
 	"github.com/go-errors/errors"
+	"github.com/phayes/freeport"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
-var (
-	numActiveNodes int32
-	baseP2PPort    = 40000
-	baseRPCPort    = 30000
-	baseHTTPPort   = 35000
-)
+var numActiveNodes int32
 
 type nodeConfig struct {
 	DataDir     string
@@ -138,9 +134,18 @@ func newNode(name string, xudPath string, noBalanceChecks bool) (*HarnessNode, e
 	cfg.LogPath = fmt.Sprintf("./temp/logs/xud-%s-%d.log", name, epoch)
 
 	cfg.TLSCertPath = filepath.Join(cfg.DataDir, "tls.cert")
-	cfg.P2PPort = baseP2PPort + nodeNum
-	cfg.RPCPort = baseRPCPort + nodeNum
-	cfg.HTTPPort = baseHTTPPort + nodeNum
+	cfg.P2PPort, err = freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+	cfg.RPCPort, err = freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+	cfg.HTTPPort, err = freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
 
 	return &HarnessNode{
 		Cfg:  &cfg,


### PR DESCRIPTION
This dynamically selects unused ports for the lnd and xud nodes used during the simulation tests. This should reduce the likelihood of tests failing due to other running processes on the machine.