### PR TITLE
feat(cli): hide password input

### DIFF
--- a/lib/cli/commands/create.ts
+++ b/lib/cli/commands/create.ts
@@ -1,20 +1,34 @@
 import { Arguments } from 'yargs';
 import { callback, loadXudInitClient } from '../command';
 import { CreateNodeRequest } from '../../proto/xudrpc_pb';
+import readline from 'readline';
 
-export const command = 'create <password>';
+export const command = 'create';
 
 export const describe = 'create an xud node';
 
-export const builder = {
-  password: {
-    description: 'password to encrypt xud key and wallets',
-    type: 'string',
-  },
-};
+export const builder = {};
 
 export const handler = (argv: Arguments) => {
-  const request = new CreateNodeRequest();
-  request.setPassword(argv.password);
-  loadXudInitClient(argv).createNode(request, callback(argv));
+  const rl = readline.createInterface({
+    input: process.stdin,
+    terminal: true,
+  });
+
+  process.stdout.write('Enter master xud password: ');
+  rl.question('', (password1) => {
+    process.stdout.write('\n');
+    process.stdout.write('Re-enter password: ');
+    rl.question('', (password2) => {
+      process.stdout.write('\n');
+      rl.close();
+      if (password1 === password2) {
+        const request = new CreateNodeRequest();
+        request.setPassword(argv.password);
+        loadXudInitClient(argv).createNode(request, callback(argv));
+      } else {
+        console.log('Passwords do not match, please try again');
+      }
+    });
+  });
 };

--- a/lib/cli/commands/unlock.ts
+++ b/lib/cli/commands/unlock.ts
@@ -1,20 +1,26 @@
 import { Arguments } from 'yargs';
 import { callback, loadXudInitClient } from '../command';
 import { UnlockNodeRequest } from '../../proto/xudrpc_pb';
+import readline from 'readline';
 
-export const command = 'unlock <password>';
+export const command = 'unlock';
 
 export const describe = 'unlock an xud node';
 
-export const builder = {
-  password: {
-    description: 'password to decrypt xud key and wallets',
-    type: 'string',
-  },
-};
+export const builder = {};
 
 export const handler = (argv: Arguments) => {
-  const request = new UnlockNodeRequest();
-  request.setPassword(argv.password);
-  loadXudInitClient(argv).unlockNode(request, callback(argv));
+  const rl = readline.createInterface({
+    input: process.stdin,
+    terminal: true,
+  });
+
+  process.stdout.write('Enter master xud password: ');
+  rl.question('', (password) => {
+    process.stdout.write('\n');
+    rl.close();
+    const request = new UnlockNodeRequest();
+    request.setPassword(password);
+    loadXudInitClient(argv).unlockNode(request, callback(argv));
+  });
 };


### PR DESCRIPTION
This prompts the user for a password without displaying it on the screen or saving it to the command history for the `CreateNode` and `UnlockNode` calls via the cli.

The wording for the prompts is currently pretty basic, I'm open to suggestions on how to make it more comprehensive or clear.