### PR TITLE
docs: add grpc server proxy license

### DIFF
--- a/lib/grpc/serverProxy.ts
+++ b/lib/grpc/serverProxy.ts
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2019 Echo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // code taken from https://github.com/echo-health/node-grpc-interceptors with some adjustments
 
 import grpc from 'grpc';


### PR DESCRIPTION
The repository we're using code from for the grpc server proxy recently added a license, so I've added it to the header of the file that's based off of that repository. See https://github.com/echo-health/node-grpc-interceptors/issues/16.