### PR TITLE
fix(lnd): wait for macaroon before wallet created

### DIFF
--- a/lib/nodekey/NodeKey.ts
+++ b/lib/nodekey/NodeKey.ts
@@ -64,25 +64,6 @@ class NodeKey {
     }
   }
 
-  /**
-   * Loads a node key from a file or creates one if none exists. See [[fromFile]] and [[generate]].
-   */
-  public static load = async (path: string): Promise<NodeKey> => {
-    let nodeKey: NodeKey;
-    try {
-      nodeKey = await NodeKey.fromFile(path);
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        // node key file does not exist, so create one
-        nodeKey = await NodeKey.generate();
-        await nodeKey.toFile(path);
-      } else {
-        throw err;
-      }
-    }
-    return nodeKey;
-  }
-
   public static getPath = (xudir: string, instanceId = 0) => {
     return instanceId > 0
       ? `${xudir}/nodekey_${instanceId}.dat`

--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -19,6 +19,10 @@ class InitService extends EventEmitter {
 
   public createNode = async (args: { password: string }) => {
     const { password } = args;
+    if (password.length < 8) {
+      // lnd requires 8+ character passwords, so we must as well
+      throw errors.INVALID_ARGUMENT('password must be at least 8 characters');
+    }
     if (this.nodeKeyExists) {
       throw errors.UNIMPLEMENTED;
     }


### PR DESCRIPTION
This fixes the logic around initializing `LndClient` for a new lnd instance (before wallet creation) and new xud instance (before node key creation). The lnd macaroon file is not created until after its wallet is created, so we relax the check that disables the client if a macaroon is not found during initialization. Instead, we mark the client as `WaitingUnlock` and wait for a successful xud `CreateNode` call to initialize the lnd wallet. After we've successfully loaded the admin macaroon, we then continue with attempting to verify the connection.

I've tested this manually and the create & unlock calls are now interacting with lnd as expected.