### PR TITLE
feat: show git commit hash in version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ test/simulation/go
 # seedutil go directory and compiled binary
 seedutil/go
 seedutil/seedutil
+
+# Version file generated in build process
+lib/Version.ts

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -12,6 +12,7 @@ import SwapClientManager from '../swaps/SwapClientManager';
 import { OrderSidesArrays } from '../orderbook/TradingPair';
 import { SwapSuccess, SwapFailure, ResolveRequest } from '../swaps/types';
 import { errors as swapsErrors } from '../swaps/errors';
+import commitHash from '../Version';
 
 /**
  * The components required by the API service layer.
@@ -269,7 +270,7 @@ class Service {
       nodePubKey,
       uris,
       numPairs,
-      version: this.version,
+      version: `${this.version}${commitHash}`,
       numPeers: this.pool.peerCount,
       orders: {
         peer: peerOrdersCount,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "config": "gulp config.create",
+    "postinstall": "npm run precompile",
+    "precompile": "node parseGitCommit.js",
     "compile": "tsc && cross-os postcompile",
     "compile:seedutil": "(cd seedutil && export PATH=\"$PWD/go/bin:$PATH\" && GOPATH=$PWD/go GO111MODULE=on go build -v)",
     "compile:watch": "tsc -w",
@@ -40,6 +42,7 @@
     "test:jest:watch": "jest --watch",
     "typedoc": "typedoc --out typedoc --module commonjs --target es6 lib --readme none",
     "preversion": "npm run lintNoFix && npm test && npm run compile",
+    "postversion": "npm run compile",
     "version": "npm run config && npm run changelog && git add sample-xud.conf CHANGELOG.md && npm run typedoc"
   },
   "cross-os": {

--- a/parseGitCommit.js
+++ b/parseGitCommit.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const childProcess = require('child_process');
+
+const executeCommand = (command) => {
+  return childProcess.execSync(command, { encoding: 'utf8' });
+};
+
+const getCommitHash = () => {
+  const result = executeCommand('git reflog --decorate -1');
+
+  // Do not show the commit hash if that commit is also a tag
+  const tag = result.match(/tag\:\s[a-zA-Z0-9\-\.]+\,/g);
+  if (tag && tag.length > 0) {
+    return '';
+  } else {
+    return result.match(/[a-z0-9]+\s\(HEAD/g)[0].slice(0, -6);
+  }
+};
+
+const isDirty = () => {
+  const result = executeCommand('git status --short');
+  return result.length > 0;  
+};
+
+const versionFilePath = `${__dirname}/lib/Version.ts`;
+
+try {
+  fs.unlinkSync(versionFilePath);
+} catch (error) {}
+
+const commitHash = getCommitHash();
+
+fs.writeFileSync(versionFilePath, `export default '${commitHash === '' ? '' : '-' + commitHash}${isDirty() ? '-dirty' : ''}';\n`);


### PR DESCRIPTION
Closes #1171 

I created a new script (`parseGitCommit.js`) that will be executed before the `compile` NPM script. It parses the latest git commit hash (if that commit doesn't also tag a release) and whether there are uncommitted changes in the working directory and writes a corresponding string into `lib/Version.ts`.

For example the `version` in `xucli getinfo -j` could look like: `1.0.0-testnet.1-9a03442c-dirty`