### PR TITLE
fix: log error message reason correctly

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -907,9 +907,9 @@ class Swaps extends EventEmitter {
     }
 
     if (errorMessage) {
-      this.logger.debug(`deal ${deal.rHash} failed due to ${SwapFailureReason[failureReason]}`);
-    } else {
       this.logger.debug(`deal ${deal.rHash} failed due to ${SwapFailureReason[failureReason]}: ${errorMessage}`);
+    } else {
+      this.logger.debug(`deal ${deal.rHash} failed due to ${SwapFailureReason[failureReason]}`);
     }
 
     switch (failureReason) {


### PR DESCRIPTION
This is a minor fix for logging the swap failure error message. The logic on whether to log the error message was backwards, logging it only when undefined.