### PR TITLE
fix(peer): logging label/node pub key

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -124,8 +124,9 @@ class Peer extends EventEmitter {
 
   public get label(): string {
     return this.nodePubKey ||
-      this.expectedNodePubKey ? `${this.expectedNodePubKey}@${addressUtils.toString(this.address)}` :
-      addressUtils.toString(this.address);
+      (this.expectedNodePubKey
+      ? `${this.expectedNodePubKey}@${addressUtils.toString(this.address)}`
+      : addressUtils.toString(this.address));
   }
 
   public get addresses(): Address[] | undefined {

--- a/test/jest/Peer.spec.ts
+++ b/test/jest/Peer.spec.ts
@@ -1,0 +1,37 @@
+import { XuNetwork } from '../../lib/constants/enums';
+import Logger, { Level } from '../../lib/Logger';
+import Network from '../../lib/p2p/Network';
+import Peer from '../../lib/p2p/Peer';
+import { Address } from '../../lib/p2p/types';
+import addressUtils from '../../lib/utils/addressUtils';
+
+describe('Peer', () => {
+  const logger = Logger.createLoggers(Level.Warn).p2p;
+  const address: Address = { host: '86.75.30.9', port: 1337 };
+  const addressStr = addressUtils.toString(address);
+  const nodePubKey = '038395febbcecdcb869b95b5fe73419ef2602f640c6bfc88635d99a111015c0822';
+  let peer: Peer;
+
+  beforeAll(async () => {
+    peer = new Peer(logger, address, new Network(XuNetwork.RegTest));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('peer label equals address when node pub key unknown', async () => {
+    expect(peer.label).toEqual(addressStr);
+  });
+
+  test('peer label equals expected node pub key with address when key is unestablished', async () => {
+    peer['expectedNodePubKey'] = nodePubKey;
+    expect(peer.label).toEqual(`${nodePubKey}@${addressStr}`);
+  });
+
+  test('peer label equals established node pub key', async () => {
+    const nodePubKey = '038395febbcecdcb869b95b5fe73419ef2602f640c6bfc88635d99a111015c0822';
+    peer['_nodePubKey'] = nodePubKey;
+    expect(peer.label).toEqual(nodePubKey);
+  });
+});


### PR DESCRIPTION
This fixes a bug with how peers were labeled in the logs. The ternary operator that determined whether to log the pub key or the address was not evaluating as expected. This also adds test cases to prevent regression bugs in the future.

@kilrau This fixes the `undefined` you were seeing when peer pub keys were being logged.