### PR TITLE
feat(cli): enhance create output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -235,7 +235,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| password | [string](#string) |  | The password in utf-8 with which to encrypt the new xud node key as well as underlying client wallets such as lnd. |
+| password | [string](#string) |  | The password in utf-8 with which to encrypt the new xud node key as well as any uninitialized underlying wallets. |
 
 
 
@@ -250,7 +250,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| seed_mnemonic | [string](#string) | repeated |  |
+| seed_mnemonic | [string](#string) | repeated | The 24 word mnemonic to recover the xud identity key and underlying wallets |
 | initialized_lnds | [string](#string) | repeated | The list of lnd clients that were initialized. |
 | initialized_raiden | [bool](#bool) |  | Whether raiden was initialized. |
 
@@ -1188,8 +1188,8 @@
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateNode | [CreateNodeRequest](#xudrpc.CreateNodeRequest) | [CreateNodeResponse](#xudrpc.CreateNodeResponse) |  |
-| UnlockNode | [UnlockNodeRequest](#xudrpc.UnlockNodeRequest) | [UnlockNodeResponse](#xudrpc.UnlockNodeResponse) |  |
+| CreateNode | [CreateNodeRequest](#xudrpc.CreateNodeRequest) | [CreateNodeResponse](#xudrpc.CreateNodeResponse) | Creates an xud identity node key and underlying wallets. The node key and wallets are derived from a single seed and encrypted using a single password provided as a parameter to the call. |
+| UnlockNode | [UnlockNodeRequest](#xudrpc.UnlockNodeRequest) | [UnlockNodeResponse](#xudrpc.UnlockNodeResponse) | Unlocks and decrypts the xud node key and any underlying wallets. |
 
  
 

--- a/lib/cli/commands/create.ts
+++ b/lib/cli/commands/create.ts
@@ -1,7 +1,7 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudInitClient } from '../command';
-import { CreateNodeRequest } from '../../proto/xudrpc_pb';
 import readline from 'readline';
+import { Arguments } from 'yargs';
+import { CreateNodeRequest, CreateNodeResponse } from '../../proto/xudrpc_pb';
+import { callback, loadXudInitClient } from '../command';
 
 export const command = 'create';
 
@@ -9,23 +9,52 @@ export const describe = 'create an xud node';
 
 export const builder = {};
 
+const formatOutput = (response: CreateNodeResponse.AsObject) => {
+  if (response.seedMnemonicList.length === 24) {
+    const WORDS_PER_ROW = 4;
+    const numberedMnemonic = response.seedMnemonicList.map((value, index) => {
+      return `${index >= 9 ? '' : ' '}${index + 1}. ${value.padEnd(10)}`;
+    });
+    console.log('----------------------BEGIN XUD SEED---------------------');
+    for (let n = 0; n < response.seedMnemonicList.length / WORDS_PER_ROW; n += 1) {
+      console.log(numberedMnemonic.slice(n * WORDS_PER_ROW, (n + 1) * WORDS_PER_ROW).join(' '));
+    }
+    console.log('-----------------------END XUD SEED----------------------\n');
+
+    if (response.initializedLndsList.length) {
+      console.log(`The following lnd wallets were initialized: ${response.initializedLndsList.join(', ')}`);
+    }
+    if (response.initializedRaiden) {
+      console.log('The wallet for raiden was initialized');
+    }
+
+    console.log(`
+Please write down your 24 word mnemonic. It will allow you to recover your xud
+key and funds for the initialized wallets listed above should you forget your
+password or lose your device. Keep it somewhere safe, it is your ONLY backup.
+    `);
+  } else {
+    console.log('xud was initialized without a seed because no wallets could be initialized.');
+  }
+};
+
 export const handler = (argv: Arguments) => {
   const rl = readline.createInterface({
     input: process.stdin,
     terminal: true,
   });
 
-  process.stdout.write('Enter master xud password: ');
+  console.log('You are creating an xud key and underlying wallets secured by a single password.');
+  process.stdout.write('Enter a password: ');
   rl.question('', (password1) => {
-    process.stdout.write('\n');
-    process.stdout.write('Re-enter password: ');
+    process.stdout.write('\nRe-enter password: ');
     rl.question('', (password2) => {
-      process.stdout.write('\n');
+      process.stdout.write('\n\n');
       rl.close();
       if (password1 === password2) {
         const request = new CreateNodeRequest();
-        request.setPassword(argv.password);
-        loadXudInitClient(argv).createNode(request, callback(argv));
+        request.setPassword(password1);
+        loadXudInitClient(argv).createNode(request, callback(argv, formatOutput));
       } else {
         console.log('Passwords do not match, please try again');
       }

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -770,7 +770,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "title": "The 24 word mnemonic to recover the xud identity key and underlying wallets"
         },
         "initialized_lnds": {
           "type": "array",

--- a/lib/proto/xudrpc_grpc_pb.js
+++ b/lib/proto/xudrpc_grpc_pb.js
@@ -589,6 +589,9 @@ function deserialize_xudrpc_UnlockNodeResponse(buffer_arg) {
 
 
 var XudInitService = exports.XudInitService = {
+  // Creates an xud identity node key and underlying wallets. The node key and
+  // wallets are derived from a single seed and encrypted using a single
+  // password provided as a parameter to the call. 
   createNode: {
     path: '/xudrpc.XudInit/CreateNode',
     requestStream: false,
@@ -600,6 +603,7 @@ var XudInitService = exports.XudInitService = {
     responseSerialize: serialize_xudrpc_CreateNodeResponse,
     responseDeserialize: deserialize_xudrpc_CreateNodeResponse,
   },
+  // Unlocks and decrypts the xud node key and any underlying wallets. 
   unlockNode: {
     path: '/xudrpc.XudInit/UnlockNode',
     requestStream: false,

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -25,17 +25,22 @@ import "annotations.proto";
 package xudrpc;
 
 service XudInit {
+  /* Creates an xud identity node key and underlying wallets. The node key and
+   * wallets are derived from a single seed and encrypted using a single
+   * password provided as a parameter to the call. */
   rpc CreateNode(CreateNodeRequest) returns (CreateNodeResponse) { }
 
+  /* Unlocks and decrypts the xud node key and any underlying wallets. */
   rpc UnlockNode(UnlockNodeRequest) returns (UnlockNodeResponse) { }
 }
 
 message CreateNodeRequest {
   // The password in utf-8 with which to encrypt the new xud node key as well
-  // as underlying client wallets such as lnd.
+  // as any uninitialized underlying wallets.
   string password = 1;
 }
 message CreateNodeResponse {
+  // The 24 word mnemonic to recover the xud identity key and underlying wallets
   repeated string seed_mnemonic = 1;
   // The list of lnd clients that were initialized.
   repeated string initialized_lnds = 2;


### PR DESCRIPTION
Closes #1210.

This improves the output of the `xucli create` command to provide clearer information to the user about how they should proceed and the outcome of the command.

Below is sample output:

```console
$ ./xucli create
You are creating an xud key and underlying wallets secured by a single password.
Enter a password: 
Re-enter password: 

----------------------BEGIN XUD SEED---------------------
 1. able        2. desk        3. online      4. that      
 5. skill       6. clap        7. color       8. this      
 9. figure     10. cage       11. torch      12. main      
13. screen     14. angle      15. hour       16. sail      
17. zoo        18. off        19. push       20. ancient   
21. bubble     22. pitch      23. involve    24. endless   
-----------------------END XUD SEED----------------------

The following lnd wallets were initialized: BTC

Please write down your 24 word mnemonic. It will allow you to recover your xud
key and funds for the initialized wallets listed above should you forget your
password or lose your device. Keep it somewhere safe, it is your ONLY backup.
```