### PR TITLE
feat(config): exit on invalid config file

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -60,10 +60,12 @@ class Xud extends EventEmitter {
    * @param args optional arguments to override configuration parameters.
    */
   public start = async (args?: { [argName: string]: any }) => {
-    await this.config.load(args);
+    const configFileLoaded = await this.config.load(args);
     const loggers = Logger.createLoggers(this.config.loglevel, this.config.logpath, this.config.instanceid, this.config.logdateformat);
     this.logger = loggers.global;
-    this.logger.info('config loaded');
+    if (configFileLoaded) {
+      this.logger.info('config file loaded');
+    }
 
     try {
       this.db = new DB(loggers.db, this.config.dbpath);


### PR DESCRIPTION
This commit makes `xud` exit during initialization if it encounters a config file that cannot be parsed properly as TOML. Previously, `xud` would silently error due to any syntax error in the config file and start up without any of settings from the file, potentially leading to confusion and unintended actions.