### PR TITLE
refactor(lndclient): strict method types

### DIFF
--- a/lib/lndclient/types.ts
+++ b/lib/lndclient/types.ts
@@ -29,3 +29,6 @@ export type Chain = {
   network: string,
   chain: string,
 };
+
+export type ClientMethods = 'close' | 'waitForReady' | 'makeClientStreamRequest' | 'makeBidiStreamRequest'
+  | 'makeServerStreamRequest' | 'makeUnaryRequest';


### PR DESCRIPTION
This restricts the `unaryCall` functions to only accept supported method names for their respective client. Previously it was possible to pass arbitrary strings as the method name to `unaryCall`.