### PR TITLE
refactor(cli): rename balance to getbalance

### DIFF
--- a/lib/cli/commands/getbalance.ts
+++ b/lib/cli/commands/getbalance.ts
@@ -36,7 +36,7 @@ const displayBalances = (balances: GetBalanceResponse.AsObject) => {
   console.log(table.toString());
 };
 
-export const command = 'balance [currency]';
+export const command = 'getbalance [currency]';
 
 export const describe = 'get total balance for a given currency';
 


### PR DESCRIPTION
As per discussion in https://github.com/ExchangeUnion/xud/pull/1180, the `balance` command is renamed as `getbalance`.