### PR TITLE
feat(swapclient): update capacity on channelbalance

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -143,12 +143,7 @@ class LndClient extends SwapClient {
   }
 
   protected updateCapacity = async () => {
-    try {
-      this.maximumOutboundAmount = (await this.channelBalance()).balance;
-    } catch (e) {
-      // TODO: Mark client as disconnected
-      this.logger.error(`failed to fetch channelbalance: ${e}`);
-    }
+    await this.channelBalance().catch(err => this.logger.error('failed to update maximum outbound capacity', err));
   }
 
   private unaryCall = <T, U>(methodName: Exclude<keyof LightningClient, ClientMethods>, params: T): Promise<U> => {
@@ -532,13 +527,14 @@ class LndClient extends SwapClient {
     return this.unaryCall<lndrpc.WalletBalanceRequest, lndrpc.WalletBalanceResponse>('walletBalance', new lndrpc.WalletBalanceRequest());
   }
 
-  /**
-   * Returns the total balance available across all channels.
-   */
   public channelBalance = async (): Promise<lndrpc.ChannelBalanceResponse.AsObject> => {
     const channelBalanceResponse = await this.unaryCall<lndrpc.ChannelBalanceRequest, lndrpc.ChannelBalanceResponse>(
       'channelBalance', new lndrpc.ChannelBalanceRequest(),
     );
+    if (this.maximumOutboundAmount !== channelBalanceResponse.getBalance()) {
+      this.maximumOutboundAmount = channelBalanceResponse.getBalance();
+      this.logger.debug(`new outbound capacity: ${this.maximumOutboundAmount}`);
+    }
     return channelBalanceResponse.toObject();
   }
 

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -67,7 +67,8 @@ abstract class SwapClient extends EventEmitter {
   public abstract get minutesPerBlock(): number;
 
   /**
-   * Returns the total balance available across all channels.
+   * Returns the total balance available across all channels and updates the maximum
+   * outbound capacity.
    * @param currency the currency whose balance to query for, otherwise all/any
    * currencies supported by this client are included in the balance.
    */

--- a/test/jest/RaidenClient.spec.ts
+++ b/test/jest/RaidenClient.spec.ts
@@ -80,6 +80,7 @@ describe('RaidenClient', () => {
     raidenLogger = new Logger({});
     raidenLogger.info = jest.fn();
     raidenLogger.error = jest.fn();
+    raidenLogger.debug = jest.fn();
     unitConverter = new UnitConverter();
     unitConverter.init();
   });


### PR DESCRIPTION
This modifies the logic around updating the maximum outbound capacity for a swap client to occur every time the channel balance is fetched, regardless of whether `channelbalance` was called by the timer to periodically update capacity or via an `xud` gRPC request. This will give us slightly more up-to-date cached balance values without needing to make any additional calls to the swap clients.