### PR TITLE
feat(swapclient): heartbeat

### DIFF
--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -129,7 +129,6 @@ class RaidenClient extends SwapClient {
         this.maximumOutboundAmounts.set(currency, balance);
       });
     } catch (e) {
-      // TODO: Mark client as disconnected
       this.logger.error(`failed to fetch channelbalances: ${e}`);
     }
   }
@@ -391,7 +390,10 @@ class RaidenClient extends SwapClient {
         }
       });
 
-      req.on('error', (err) => {
+      req.on('error', (err: any) => {
+        if (err.code === 'ECONNREFUSED') {
+          this.disconnect().catch(this.logger.error);
+        }
         this.logger.error(err);
         reject(err);
       });

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -65,8 +65,8 @@ abstract class SwapClient extends EventEmitter {
   private updateCapacityTimer?: NodeJS.Timer;
   /** The maximum amount of time we will wait for the connection to be verified during initialization. */
   private static INITIALIZATION_TIME_LIMIT = 5000;
-  /** Time in milliseconds between updating the maximum outbound capacity */
-  private static CAPACITY_REFRESH_INTERVAL = 60000;
+  /** Time in milliseconds between updating the maximum outbound capacity. */
+  private static CAPACITY_REFRESH_INTERVAL = 3000;
 
   constructor(public logger: Logger) {
     super();


### PR DESCRIPTION
This commit shortens the interval for the outbound capacity check timer from 60 to 3 seconds and sets the client as disconnected any time a call fails due to an unreachable server. This makes the capacity checks act like a heartbeat, checking that the server is reachable every few seconds even in the absence of any other activity.

Previously, we had used a dummy server -> client streaming call and listened for the `error` event on the lnd side, however with newer versions of lnd and grpc this is no longer a reliable way to tell when lnd has gone down.

This also closes #1090 where lnd would get stuck in the `WaitingUnlock` state if it is stopped while xud is running and comes back online in the locked state.
