### PR TITLE
fix(swapclientmanager): catch genseed errors

### DIFF
--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -113,7 +113,8 @@ class SwapClientManager extends EventEmitter {
     for (const swapClient of this.swapClients.values()) {
       if (isLndClient(swapClient) && swapClient.isWaitingUnlock()) {
         try {
-          return swapClient.genSeed();
+          const seed = await swapClient.genSeed();
+          return seed;
         } catch (err) {
           swapClient.logger.error('could not generate seed', err);
         }


### PR DESCRIPTION
This fixes the error handling around the call to `genSeed` to actually catch errors thrown from the method. Previously, the method returned before any error could be caught.