### PR TITLE
feat(lnd): automatically unlock wallet on restart

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -18,8 +18,10 @@ import path from 'path';
 interface LndClient {
   on(event: 'connectionVerified', listener: (swapClientInfo: SwapClientInfo) => void): this;
   on(event: 'htlcAccepted', listener: (rHash: string, amount: number) => void): this;
+  on(event: 'locked', listener: () => void): this;
   emit(event: 'connectionVerified', swapClientInfo: SwapClientInfo): boolean;
   emit(event: 'htlcAccepted', rHash: string, amount: number): boolean;
+  emit(event: 'locked'): boolean;
 }
 
 const MAXFEE = 0.03;
@@ -387,7 +389,11 @@ class LndClient extends SwapClient {
           this.walletUnlocker = new WalletUnlockerClient(this.uri, this.credentials);
           this.lightning.close();
           this.lightning = undefined;
-          await this.setStatus(ClientStatus.WaitingUnlock);
+
+          if (!this.isWaitingUnlock()) {
+            await this.setStatus(ClientStatus.WaitingUnlock);
+            this.emit('locked');
+          }
         } else {
           const errStr = typeof(err) === 'string' ? err : JSON.stringify(err);
           this.logger.error(`could not verify connection at ${this.uri}, error: ${errStr}, retrying in ${LndClient.RECONNECT_TIMER} ms`);

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -100,6 +100,10 @@ abstract class SwapClient extends EventEmitter {
   }
 
   protected setStatus = async (status: ClientStatus): Promise<void> => {
+    if (this.status === status) {
+      return;
+    }
+
     this.logger.info(`${this.constructor.name} status: ${ClientStatus[status]}`);
     this.status = status;
     await this.setTimers();

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -40,6 +40,7 @@ class SwapClientManager extends EventEmitter {
   /** A map between currencies and all swap clients */
   public swapClients = new Map<string, SwapClient>();
   public raidenClient: RaidenClient;
+  private walletPassword?: string;
 
   constructor(
     private config: Config,
@@ -128,6 +129,8 @@ class SwapClientManager extends EventEmitter {
    * Initializes wallets with seed and password.
    */
   public initWallets = async (walletPassword: string, seedMnemonic: string[]) => {
+    this.walletPassword = walletPassword;
+
     // loop through swap clients to find locked lnd clients
     const initWalletPromises: Promise<any>[] = [];
     const createdLndWallets: string[] = [];
@@ -136,7 +139,7 @@ class SwapClientManager extends EventEmitter {
         const initWalletPromise = swapClient.initWallet(walletPassword, seedMnemonic).then(() => {
           createdLndWallets.push(swapClient.currency);
         }).catch((err) => {
-          this.loggers.lnd.debug(`could not initialize ${swapClient.currency} client: ${err.message}`);
+          swapClient.logger.debug(`could not initialize wallet: ${err.message}`);
         });
         initWalletPromises.push(initWalletPromise);
       }
@@ -154,6 +157,8 @@ class SwapClientManager extends EventEmitter {
    * @returns an array of currencies for each lnd client that was unlocked
    */
   public unlockWallets = async (walletPassword: string) => {
+    this.walletPassword = walletPassword;
+
     // loop through swap clients to find locked lnd clients
     const unlockWalletPromises: Promise<any>[] = [];
     const unlockedLndClients: string[] = [];
@@ -163,7 +168,7 @@ class SwapClientManager extends EventEmitter {
         const unlockWalletPromise = swapClient.unlockWallet(walletPassword).then(() => {
           unlockedLndClients.push(swapClient.currency);
         }).catch((err) => {
-          this.loggers.lnd.debug(`could not unlock ${swapClient.currency} client: ${err.message}`);
+          swapClient.logger.debug(`could not unlock wallet: ${err.message}`);
         });
         unlockWalletPromises.push(unlockWalletPromise);
       }
@@ -334,6 +339,11 @@ class SwapClientManager extends EventEmitter {
         // lnd clients emit htlcAccepted evented we must handle
         swapClient.on('htlcAccepted', (rHash, amount) => {
           this.emit('htlcAccepted', swapClient, rHash, amount, currency);
+        });
+        swapClient.on('locked', () => {
+          if (this.walletPassword) {
+            swapClient.unlockWallet(this.walletPassword).catch(swapClient.logger.error);
+          }
         });
       }
     }

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -126,7 +126,7 @@ describe('Swaps.SwapClientManager', () => {
     swapClientManager = new SwapClientManager(config, loggers, unitConverter);
     await swapClientManager.init(db.models);
     expect(swapClientManager['swapClients'].size).toEqual(3);
-    expect(onListenerMock).toHaveBeenCalledTimes(5);
+    expect(onListenerMock).toHaveBeenCalledTimes(7);
     expect(swapClientManager.get('BTC')).not.toBeUndefined();
     expect(swapClientManager.get('LTC')).not.toBeUndefined();
     expect(swapClientManager.get('WETH')).not.toBeUndefined();
@@ -146,7 +146,7 @@ describe('Swaps.SwapClientManager', () => {
     swapClientManager = new SwapClientManager(config, loggers, unitConverter);
     await swapClientManager.init(db.models);
     expect(swapClientManager['swapClients'].size).toEqual(2);
-    expect(onListenerMock).toHaveBeenCalledTimes(4);
+    expect(onListenerMock).toHaveBeenCalledTimes(6);
     expect(swapClientManager.get('BTC')).not.toBeUndefined();
     expect(swapClientManager.get('LTC')).not.toBeUndefined();
     await swapClientManager.close();
@@ -160,7 +160,7 @@ describe('Swaps.SwapClientManager', () => {
     swapClientManager = new SwapClientManager(config, loggers, unitConverter);
     await swapClientManager.init(db.models);
     expect(swapClientManager['swapClients'].size).toEqual(1);
-    expect(onListenerMock).toHaveBeenCalledTimes(2);
+    expect(onListenerMock).toHaveBeenCalledTimes(3);
     expect(swapClientManager.get('BTC')).not.toBeUndefined();
     await swapClientManager.close();
     expect(closeMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This adds a `locked` event to `LndClient` which is emitted when the client transitions to `WaitingUnlock` status. If `xud` is using a master password, it will attempt to unlock lnd when it handles the `locked` event.

Closes #1196.