### PR TITLE
feat: $10 mainnet order size limits

### DIFF
--- a/lib/constants/limits.ts
+++ b/lib/constants/limits.ts
@@ -1,9 +1,9 @@
 /** Order size limits denominated in satoshis. */
 const limits: { [currency: string]: number } = {
-  BTC : 42949,
-  LTC : 50000,
-  WETH : 2000000,
-  DAI : 500000000,
+  BTC: 100000,
+  LTC: 15000000,
+  WETH: 5000000,
+  DAI: 1000000000,
 };
 
 export default limits;


### PR DESCRIPTION
This modifies the order size limits for all currencies to equal approximately $10 USD for use on mainnet.

Closes #1230.