### PR TITLE
feat: create eth keystore with master seed

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -148,6 +148,10 @@ const { argv } = require('yargs')
       type: 'boolean',
       default: undefined,
     },
+    'raiden.keystorepath': {
+      describe: 'Path containing keystore dir',
+      type: 'string',
+    },
     'raiden.port': {
       describe: 'Port for raiden REST service',
       type: 'number',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -47,24 +47,28 @@ class Config {
 
   constructor() {
     const platform = os.platform();
-    let lndDefaultDatadir;
+    let lndDefaultDatadir: string;
+    let raidenDefaultKeystorePath: string;
     switch (platform) {
       case 'win32': { // windows
         const homeDir = process.env.LOCALAPPDATA!;
         this.xudir = path.join(homeDir, 'Xud');
         lndDefaultDatadir = path.join(homeDir, 'Lnd');
+        raidenDefaultKeystorePath = path.join(homeDir, 'Ethereum');
         break;
       }
       case 'darwin': { // mac
         const homeDir = process.env.HOME!;
         this.xudir = path.join(homeDir, '.xud');
         lndDefaultDatadir = path.join(homeDir, 'Library', 'Application Support', 'Lnd');
+        raidenDefaultKeystorePath = path.join(homeDir, 'Library', 'Ethereum');
         break;
       }
       default: { // linux
         const homeDir = process.env.HOME!;
         this.xudir = path.join(homeDir, '.xud');
         lndDefaultDatadir = path.join(homeDir, '.lnd');
+        raidenDefaultKeystorePath = path.join(homeDir, '.ethereum');
         break;
       }
     }
@@ -126,6 +130,7 @@ class Config {
       disable: false,
       host: 'localhost',
       port: 5001,
+      keystorepath: raidenDefaultKeystorePath,
     };
   }
 

--- a/lib/cli/commands/create.ts
+++ b/lib/cli/commands/create.ts
@@ -25,14 +25,15 @@ const formatOutput = (response: CreateNodeResponse.AsObject) => {
       console.log(`The following lnd wallets were initialized: ${response.initializedLndsList.join(', ')}`);
     }
     if (response.initializedRaiden) {
-      console.log('The wallet for raiden was initialized.');
+      console.log('The keystore for raiden was initialized.');
     }
 
     console.log(`
 Please write down your 24 word mnemonic. It will allow you to recover your xud
 node key and on-chain funds for the initialized wallets listed above should you
-forget your password or lose your device. Off-chain funds are NOT recovered with
-it and are secured separately. Keep it somewhere safe, it is your ONLY backup.
+forget your password or lose your device. Off-chain funds in channels can NOT
+be recovered with it and must be backed up and recovered separately. Keep it
+somewhere safe, it is your ONLY backup in case of data loss.
     `);
   } else {
     console.log('xud was initialized without a seed because no wallets could be initialized.');
@@ -45,7 +46,10 @@ export const handler = (argv: Arguments) => {
     terminal: true,
   });
 
-  console.log('You are creating an xud node key and underlying wallets. All secured by a single password.');
+  console.log(`
+You are creating an xud node key and underlying wallets. All will be secured by
+a single password provided below.
+  `);
   process.stdout.write('Enter a password: ');
   rl.question('', (password1) => {
     process.stdout.write('\nRe-enter password: ');

--- a/lib/grpc/GrpcInitService.ts
+++ b/lib/grpc/GrpcInitService.ts
@@ -34,7 +34,7 @@ class GrpcInitService {
    */
   public createNode: grpc.handleUnaryCall<xudrpc.CreateNodeRequest, xudrpc.CreateNodeResponse> = async (call, callback) => {
     try {
-      const { mnemonic, initializedLndWallets } = await this.initService.createNode(call.request.toObject());
+      const { mnemonic, initializedLndWallets, initializedRaiden } = await this.initService.createNode(call.request.toObject());
       const response = new xudrpc.CreateNodeResponse();
       if (mnemonic) {
         response.setSeedMnemonicList(mnemonic);
@@ -42,6 +42,7 @@ class GrpcInitService {
       if (initializedLndWallets) {
         response.setInitializedLndsList(initializedLndWallets);
       }
+      response.setInitializedRaiden(initializedRaiden);
 
       callback(null, response);
     } catch (err) {

--- a/lib/raidenclient/types.ts
+++ b/lib/raidenclient/types.ts
@@ -6,6 +6,7 @@ export type RaidenClientConfig = {
   disable: boolean;
   host: string;
   port: number;
+  keystorepath: string;
 };
 
 /** General information about the state of this raiden client. */

--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -33,6 +33,7 @@ class InitService extends EventEmitter {
     this.pendingCall = true;
     const seed = await this.swapClientManager.genSeed();
     let initializedLndWallets: string[] | undefined;
+    let initializedRaiden = false;
     let nodeKey: NodeKey;
 
     if (seed) {
@@ -48,9 +49,11 @@ class InitService extends EventEmitter {
       nodeKey = new NodeKey(privKey);
 
       // use this seed to init any lnd wallets that are uninitialized
-      initializedLndWallets = await this.swapClientManager.initWallets(password, seed.cipherSeedMnemonicList);
+      const initWalletResult = await this.swapClientManager.initWallets(password, seed.cipherSeedMnemonicList);
+      initializedLndWallets = initWalletResult.initializedLndWallets;
+      initializedRaiden = initWalletResult.initializedRaiden;
     } else {
-      // we couldn't generate a seed externally, so we must create one locally
+      // we couldn't generate a seed externally, so we must create a nodekey from scratch
       nodeKey = await NodeKey.generate();
     }
 
@@ -58,6 +61,7 @@ class InitService extends EventEmitter {
     this.emit('nodekey', nodeKey);
     return {
       initializedLndWallets,
+      initializedRaiden,
       mnemonic: seed ? seed.cipherSeedMnemonicList : undefined,
     };
   }

--- a/lib/utils/seedutil.ts
+++ b/lib/utils/seedutil.ts
@@ -1,0 +1,26 @@
+import { exec as childProcessExec } from 'child_process';
+import { promisify } from 'util';
+
+/** A promisified wrapped for the NodeJS `child_process.exec` method. */
+const exec = promisify(childProcessExec);
+
+/**
+ * Attempts to execute the seedutil tool which will generate an ethereum keystore
+ * according to a given mnemonic and password at the specified path
+ * @param mnemonic the 24 seed recovery mnemonic
+ * @param password the password to protect the keystore
+ * @param path the path in which to create the keystore directory
+ */
+const seedutil = async (mnemonic: string[], password: string, path: string) => {
+  const { stdout, stderr } = await exec(`./seedutil/seedutil -pass=${password} -path=${path} ${mnemonic.join(' ')}`);
+
+  if (stderr) {
+    throw new Error(stderr);
+  }
+
+  if (!stdout.includes('Keystore created')) {
+    throw new Error(stdout);
+  }
+};
+
+export default seedutil;

--- a/seedutil/README.md
+++ b/seedutil/README.md
@@ -1,11 +1,19 @@
 # seedutil
+
 This utility is used to derive an Ethereum keystore file from [aezeed](https://github.com/lightningnetwork/lnd/tree/master/aezeed) generated mnemonic seed.
 
 ## Build
+
 `npm run compile:seedutil`
 
 ## Usage
-It is recommended to use this tool on the command line ONLY for development purposes.
-`seedutil [twenty four recovery words separated by space] [optional password] [optional keystore path]`
 
-[Tests](/test/jest/SeedUtil.spec.ts)
+It is recommended to use this tool on the command line ONLY for development purposes.
+
+`seedutil [-pass=encryption password] [-path=optional/keystore/path] [-aezeedpass=optional_seed_pass] <twenty four recovery words separated by spaces>`
+
+By default the `keystore` folder will be created in the execution directory and the aezeed password will be `aezeed`.
+
+## Tests
+
+`npm run test:seedutil`

--- a/seedutil/SeedUtil.spec.ts
+++ b/seedutil/SeedUtil.spec.ts
@@ -1,5 +1,5 @@
 import { exec } from 'child_process';
-import { promises as fs, existsSync } from 'fs';
+import { promises as fs, existsSync, lstatSync } from 'fs';
 
 const executeCommand = (cmd: string): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -25,7 +25,11 @@ const deleteDir = async (path: string) => {
       const files = await fs.readdir(path);
       const deletePromises: Promise<void>[] = [];
       files.forEach((file) => {
-        deletePromises.push(fs.unlink(`${path}/${file}`));
+        if (lstatSync(`${path}/${file}`).isDirectory()) { // recurse
+          deletePromises.push(deleteDir(`${path}/${file}`));
+        } else { // delete file
+          deletePromises.push(fs.unlink(`${path}/${file}`));
+        }
       });
       await Promise.all(deletePromises);
       // delete directory
@@ -38,10 +42,13 @@ const deleteDir = async (path: string) => {
 
 const SUCCESS_KEYSTORE_CREATED = 'Keystore created';
 const ERRORS = {
-  INVALID_MNEMONIC_LENGTH: 'expecting 24-word mnemonic seed separated by a space',
-  INVALID_SEED_OR_PASSWORD: 'invalid seed or password',
+  INVALID_ARGS_LENGTH: 'expecting password and 24-word mnemonic seed separated by spaces',
+  MISSING_ENCRYPTION_PASSWORD: 'expecting encryption password',
+  INVALID_AEZEED: 'invalid aezeed',
   KEYSTORE_FILE_ALREADY_EXISTS: 'account already exists',
 };
+
+const PASSWORD = 'wasspord';
 
 const VALID_SEED = {
   seedPassword: 'mysecretpassword',
@@ -54,6 +61,16 @@ const VALID_SEED = {
   ethAddress: '23ccdcd149bd433d64987ffebbc88ac909842303',
 };
 
+const VALID_SEED_NO_PASS = {
+  seedWords: [
+    'abstract', 'swear', 'air', 'swamp', 'carpet', 'that',
+    'retire', 'pool', 'produce', 'food', 'join', 'inform',
+    'giraffe', 'local', 'region', 'anchor', 'march', 'advice',
+    'blanket', 'quick', 'farm', 'mandate', 'shell', 'lens',
+  ],
+  ethAddress: 'e650ced4be22e305bd133a0b7f8e50b9c5568c57',
+};
+
 const DEFAULT_KEYSTORE_PATH = `${process.cwd()}/seedutil/keystore`;
 
 describe('SeedUtil', () => {
@@ -63,23 +80,23 @@ describe('SeedUtil', () => {
 
   test('it errors with no arguments', async () => {
     await expect(executeCommand('./seedutil/seedutil'))
-      .rejects.toThrow(ERRORS.INVALID_MNEMONIC_LENGTH);
+      .rejects.toThrow(ERRORS.INVALID_ARGS_LENGTH);
   });
 
   test('it errors with 23 words', async () => {
-    const cmd = `./seedutil/seedutil ${VALID_SEED.seedWords.slice(0, 22).join(' ')}`;
+    const cmd = `./seedutil/seedutil ${VALID_SEED.seedWords.slice(0, 23).join(' ')}`;
     await expect(executeCommand(cmd))
-      .rejects.toThrow(ERRORS.INVALID_MNEMONIC_LENGTH);
+      .rejects.toThrow(ERRORS.INVALID_ARGS_LENGTH);
   });
 
-  test('it errors with 24 words and invalid password', async () => {
+  test('it errors with 24 words and invalid aezeed password', async () => {
     const cmd = `./seedutil/seedutil ${VALID_SEED.seedWords.join(' ')}`;
     await expect(executeCommand(cmd))
-      .rejects.toThrow(ERRORS.INVALID_SEED_OR_PASSWORD);
+      .rejects.toThrow(ERRORS.INVALID_AEZEED);
   });
 
-  test('it succeeds with 24 words, valid password', async () => {
-    const cmd = `./seedutil/seedutil ${VALID_SEED.seedWords.join(' ')} ${VALID_SEED.seedPassword}`;
+  test('it succeeds with 24 words, valid aezeed password', async () => {
+    const cmd = `./seedutil/seedutil  -aezeedpass=${VALID_SEED.seedPassword} ${VALID_SEED.seedWords.join(' ')}`;
     await expect(executeCommand(cmd))
       .resolves.toMatch(SUCCESS_KEYSTORE_CREATED);
     // Read our keystore file
@@ -95,9 +112,35 @@ describe('SeedUtil', () => {
       .rejects.toThrow(ERRORS.KEYSTORE_FILE_ALREADY_EXISTS);
   });
 
+  test('it succeeds with 24 words, no aezeed password', async () => {
+    const cmd = `./seedutil/seedutil ${VALID_SEED_NO_PASS.seedWords.join(' ')}`;
+    await expect(executeCommand(cmd))
+      .resolves.toMatch(SUCCESS_KEYSTORE_CREATED);
+    // Read our keystore file
+    const files = await fs.readdir(DEFAULT_KEYSTORE_PATH);
+    expect(files.length).toEqual(1);
+    const keyStorePath = `${DEFAULT_KEYSTORE_PATH}/${files[0]}`;
+    const keyStoreObj = JSON.parse(await fs.readFile(keyStorePath, 'utf8'));
+    // verify that the derived ETH address matches
+    expect(keyStoreObj.address).toEqual(VALID_SEED_NO_PASS.ethAddress);
+  });
+
+  test('it succeeds with 24 word and encryption password', async () => {
+    const cmd = `./seedutil/seedutil -pass=${PASSWORD} ${VALID_SEED_NO_PASS.seedWords.join(' ')}`;
+    await expect(executeCommand(cmd))
+      .resolves.toMatch(SUCCESS_KEYSTORE_CREATED);
+    // Read our keystore file
+    const files = await fs.readdir(DEFAULT_KEYSTORE_PATH);
+    expect(files.length).toEqual(1);
+    const keyStorePath = `${DEFAULT_KEYSTORE_PATH}/${files[0]}`;
+    const keyStoreObj = JSON.parse(await fs.readFile(keyStorePath, 'utf8'));
+    // verify that the derived ETH address matches
+    expect(keyStoreObj.address).toEqual(VALID_SEED_NO_PASS.ethAddress);
+  });
+
   test('it allows custom keystore save path', async () => {
     const CUSTOM_PATH = `${process.cwd()}/seedutil/custom`;
-    const cmd = `./seedutil/seedutil ${VALID_SEED.seedWords.join(' ')} ${VALID_SEED.seedPassword} ${CUSTOM_PATH}`;
+    const cmd = `./seedutil/seedutil -path=${CUSTOM_PATH} -aezeedpass=${VALID_SEED.seedPassword} ${VALID_SEED.seedWords.join(' ')}`;
     await expect(executeCommand(cmd))
       .resolves.toMatch(SUCCESS_KEYSTORE_CREATED);
     // cleanup custom path

--- a/test/jest/RaidenClient.spec.ts
+++ b/test/jest/RaidenClient.spec.ts
@@ -76,6 +76,7 @@ describe('RaidenClient', () => {
       disable: false,
       host: '127.0.0.1',
       port: 1234,
+      keystorepath: '',
     };
     raidenLogger = new Logger({});
     raidenLogger.info = jest.fn();

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -111,6 +111,7 @@ describe('Swaps.SwapClientManager', () => {
       disable: false,
       host: 'localhost',
       port: 1234,
+      keystorepath: '',
     };
     config.debug = {
       raidenDirectChannelChecks: true,


### PR DESCRIPTION
Closes #1242.

This commit uses the seed generated during the `CreateNode` call to create the raiden/ethereuem keystore along with the lnd wallets. This is the final step to having a single recovery seed and a single encryption password for all lnd and raiden wallets.

A new configuration option `raiden.keystorepath` specifies where xud should create the keystore directory. 

@reliveyy You should pass in this new option to `xud` when creating the wallets in docker. We will still need to figure out the best approach to ensuring the seedutil binary is available through non-docker installations. For dev/testing purposes if you have Go installed you can just use `npm run compile:seedutil`.
