### PR TITLE
feat(cli): set exit code 1 on errored calls

### DIFF
--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -49,6 +49,7 @@ interface GrpcResponse {
 export const callback = (argv: Arguments, formatOutput?: Function, displayJson?: Function) => {
   return (error: Error | null, response: GrpcResponse) => {
     if (error) {
+      process.exitCode = 1;
       console.error(`${error.name}: ${error.message}`);
     } else {
       const responseObj = response.toObject();


### PR DESCRIPTION
This sets an exit code of 1 on errored calls to indicate failure and differentiate from the default successful exit code of 0.