### PR TITLE
fix(swapclient): continue reconnection attempts

### DIFF
--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -120,9 +120,13 @@ abstract class SwapClient extends EventEmitter {
       }
       if (this.status !== ClientStatus.Disabled) {
         if (!this.reconnectionTimer) {
-          this.reconnectionTimer = setTimeout(this.verifyConnection, SwapClient.RECONNECT_TIMER);
-        } else {
-          this.reconnectionTimer.refresh();
+          this.reconnectionTimer = setTimeout(async () => {
+            await this.verifyConnection();
+            if (!this.isConnected() && this.reconnectionTimer) {
+              // if we were still not able to verify the connection, schedule another attempt
+              this.reconnectionTimer.refresh();
+            }
+          }, SwapClient.RECONNECT_TIMER);
         }
       }
     }


### PR DESCRIPTION
Closes #1240.

This fixes the logic around rescheduling reconnection attempts to ensure that they continue should the previous attempt to verify the connection fail.