### PR TITLE
feat: wait for lnd on create call

### DIFF
--- a/lib/grpc/GrpcInitService.ts
+++ b/lib/grpc/GrpcInitService.ts
@@ -1,33 +1,11 @@
 /* tslint:disable no-null-keyword */
-import grpc, { status } from 'grpc';
-import * as xudrpc from '../proto/xudrpc_pb';
-import { errorCodes as serviceErrorCodes } from '../service/errors';
+import grpc from 'grpc';
 import InitService from 'lib/service/InitService';
+import * as xudrpc from '../proto/xudrpc_pb';
+import getGrpcError from './getGrpcError';
 
 class GrpcInitService {
   constructor(private initService: InitService) {}
-
-  private getGrpcError = (err: any) => {
-    // if we recognize this error, use a proper gRPC ServiceError with a descriptive and appropriate code
-    let code: grpc.status | undefined;
-    switch (err.code) {
-      case serviceErrorCodes.PENDING_CALL_CONFLICT:
-        code = status.RESOURCE_EXHAUSTED;
-        break;
-      case serviceErrorCodes.UNIMPLEMENTED:
-        code = status.UNIMPLEMENTED;
-        break;
-    }
-
-    // return a grpc error with the code if we've assigned one, otherwise pass along the caught error as UNKNOWN
-    const grpcError: grpc.ServiceError = {
-      code: code || status.UNKNOWN,
-      message: err.message,
-      name: err.name,
-    };
-
-    return grpcError;
-  }
 
   /**
    * See [[InitService.createNode]]
@@ -46,7 +24,7 @@ class GrpcInitService {
 
       callback(null, response);
     } catch (err) {
-      callback(this.getGrpcError(err), null);
+      callback(getGrpcError(err), null);
     }
     this.initService.pendingCall = false;
   }
@@ -62,7 +40,7 @@ class GrpcInitService {
 
       callback(null, response);
     } catch (err) {
-      callback(this.getGrpcError(err), null);
+      callback(getGrpcError(err), null);
     }
     this.initService.pendingCall = false;
   }

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -19,9 +19,19 @@ class GrpcServer {
   constructor(private logger: Logger) {
     this.server = serverProxy(new grpc.Server());
 
-    this.server.use((ctx: any, next: any) => {
+    this.server.use(async (ctx: any, next: any) => {
       logger.debug(`received call ${ctx.service.path}`);
-      next();
+
+      await next();
+
+      const status = ctx.status || ctx.call.status;
+      if (!status) {
+        logger.debug(`unknown status for call ${ctx.service.path}`);
+      } else if (status.code !== 0) {
+        logger.error(`call ${ctx.service.path} errored with code ${status.details.code}: ${status.details.message}`);
+      } else {
+        logger.trace(`call ${ctx.service.path} succeeded`);
+      }
     });
   }
 

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -31,7 +31,7 @@ class GrpcServer {
   }
 
   public addXudService = (service: Service) => {
-    this.grpcService = new GrpcService(this.logger, service);
+    this.grpcService = new GrpcService(service);
     this.server.addService(XudService, this.grpcService);
   }
 

--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -1,0 +1,80 @@
+import { errorCodes as orderErrorCodes } from '../orderbook/errors';
+import { errorCodes as serviceErrorCodes } from '../service/errors';
+import { errorCodes as p2pErrorCodes } from '../p2p/errors';
+import { errorCodes as swapErrorCodes } from '../swaps/errors';
+import { errorCodes as lndErrorCodes } from '../lndclient/errors';
+import grpc, { status }  from 'grpc';
+
+/**
+ * Convert an internal xud error type into a gRPC error.
+ * @param err an error object that should have code and message properties
+ * @return a gRPC error with a gRPC status code
+ */
+const getGrpcError = (err: any) => {
+  // if we recognize this error, use a proper gRPC ServiceError with a descriptive and appropriate code
+  let code: grpc.status | undefined;
+  switch (err.code) {
+    case serviceErrorCodes.INVALID_ARGUMENT:
+    case p2pErrorCodes.ATTEMPTED_CONNECTION_TO_SELF:
+    case p2pErrorCodes.UNEXPECTED_NODE_PUB_KEY:
+    case orderErrorCodes.MIN_QUANTITY_VIOLATED:
+    case orderErrorCodes.QUANTITY_DOES_NOT_MATCH:
+    case orderErrorCodes.EXCEEDING_LIMIT:
+      code = status.INVALID_ARGUMENT;
+      break;
+    case orderErrorCodes.PAIR_DOES_NOT_EXIST:
+    case p2pErrorCodes.NODE_UNKNOWN:
+    case orderErrorCodes.LOCAL_ID_DOES_NOT_EXIST:
+    case orderErrorCodes.ORDER_NOT_FOUND:
+      code = status.NOT_FOUND;
+      break;
+    case orderErrorCodes.DUPLICATE_ORDER:
+    case p2pErrorCodes.NODE_ALREADY_CONNECTED:
+    case p2pErrorCodes.NODE_ALREADY_BANNED:
+    case p2pErrorCodes.ALREADY_CONNECTING:
+    case orderErrorCodes.CURRENCY_ALREADY_EXISTS:
+    case orderErrorCodes.PAIR_ALREADY_EXISTS:
+      code = status.ALREADY_EXISTS;
+      break;
+    case p2pErrorCodes.NOT_CONNECTED:
+    case p2pErrorCodes.NODE_NOT_BANNED:
+    case p2pErrorCodes.NODE_IS_BANNED:
+    case lndErrorCodes.DISABLED:
+    case orderErrorCodes.CURRENCY_DOES_NOT_EXIST:
+    case orderErrorCodes.CURRENCY_CANNOT_BE_REMOVED:
+    case orderErrorCodes.MARKET_ORDERS_NOT_ALLOWED:
+    case serviceErrorCodes.NOMATCHING_MODE_IS_REQUIRED:
+    case orderErrorCodes.INSUFFICIENT_OUTBOUND_BALANCE:
+    case swapErrorCodes.SWAP_CLIENT_NOT_FOUND:
+      code = status.FAILED_PRECONDITION;
+      break;
+    case lndErrorCodes.UNAVAILABLE:
+    case p2pErrorCodes.COULD_NOT_CONNECT:
+      code = status.UNAVAILABLE;
+      break;
+    case serviceErrorCodes.PENDING_CALL_CONFLICT:
+      code = status.RESOURCE_EXHAUSTED;
+      break;
+    case serviceErrorCodes.UNIMPLEMENTED:
+      code = status.UNIMPLEMENTED;
+      break;
+    case p2pErrorCodes.POOL_CLOSED:
+      code = status.ABORTED;
+      break;
+    case p2pErrorCodes.RESPONSE_TIMEOUT:
+      code = status.DEADLINE_EXCEEDED;
+      break;
+      break;
+  }
+
+  // return a grpc error with the code if we've assigned one, otherwise pass along the caught error as UNKNOWN
+  const grpcError: grpc.ServiceError = {
+    code: code || status.UNKNOWN,
+    message: err.message,
+    name: err.name,
+  };
+
+  return grpcError;
+};
+
+export default getGrpcError;

--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -64,6 +64,8 @@ const getGrpcError = (err: any) => {
     case p2pErrorCodes.RESPONSE_TIMEOUT:
       code = status.DEADLINE_EXCEEDED;
       break;
+    case swapErrorCodes.SWAP_CLIENT_WALLET_NOT_CREATED:
+      code = status.INTERNAL;
       break;
   }
 

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -320,6 +320,7 @@ class LndClient extends SwapClient {
         this.walletUnlocker = new WalletUnlockerClient(this.uri, this.credentials);
         await LndClient.waitForClientReady(this.walletUnlocker);
         await this.setStatus(ClientStatus.WaitingUnlock);
+        this.emit('locked');
 
         if (this.reconnectionTimer) {
           // we don't need scheduled attempts to retry the connection while waiting on the wallet
@@ -383,7 +384,7 @@ class LndClient extends SwapClient {
           }
         } else {
           await this.setStatus(ClientStatus.OutOfSync);
-          this.logger.warn(`lnd is out of sync with chain, retrying in ${LndClient.RECONNECT_TIMER} ms`);
+          this.logger.warn(`lnd is out of sync with chain, retrying in ${LndClient.RECONNECT_TIME_LIMIT} ms`);
         }
       } catch (err) {
         if (err.code === grpc.status.UNIMPLEMENTED) {
@@ -398,7 +399,7 @@ class LndClient extends SwapClient {
           }
         } else {
           const errStr = typeof(err) === 'string' ? err : JSON.stringify(err);
-          this.logger.error(`could not verify connection at ${this.uri}, error: ${errStr}, retrying in ${LndClient.RECONNECT_TIMER} ms`);
+          this.logger.error(`could not verify connection at ${this.uri}, error: ${errStr}, retrying in ${LndClient.RECONNECT_TIME_LIMIT} ms`);
           await this.disconnect();
         }
       }

--- a/lib/lndclient/errors.ts
+++ b/lib/lndclient/errors.ts
@@ -3,23 +3,23 @@ import { ClientStatus } from '../swaps/SwapClient';
 
 const codesPrefix = errorCodesPrefix.LND;
 const errorCodes = {
-  LND_IS_DISABLED: codesPrefix.concat('.1'),
-  LND_IS_UNAVAILABLE: codesPrefix.concat('.2'),
-  LND_HAS_NO_ACTIVE_CHANNELS: codesPrefix.concat('.3'),
+  DISABLED: codesPrefix.concat('.1'),
+  UNAVAILABLE: codesPrefix.concat('.2'),
+  NO_ACTIVE_CHANNELS: codesPrefix.concat('.3'),
 };
 
 const errors = {
-  LND_IS_DISABLED: {
-    message: 'lnd is disabled',
-    code: errorCodes.LND_IS_DISABLED,
-  },
-  LND_IS_UNAVAILABLE: (status: ClientStatus) => ({
-    message: `lnd is ${ClientStatus[status]}`,
-    code: errorCodes.LND_IS_UNAVAILABLE,
+  DISABLED: (currency: string) => ({
+    message: `lnd-${currency} is disabled`,
+    code: errorCodes.DISABLED,
   }),
-  LND_HAS_NO_ACTIVE_CHANNELS: () => ({
-    message: 'lnd has no active channels',
-    code: errorCodes.LND_HAS_NO_ACTIVE_CHANNELS,
+  UNAVAILABLE: (currency: string, status: ClientStatus) => ({
+    message: `lnd-${currency} is ${ClientStatus[status]}`,
+    code: errorCodes.UNAVAILABLE,
+  }),
+  NO_ACTIVE_CHANNELS: (currency: string) => ({
+    message: `lnd-${currency} has no active channels`,
+    code: errorCodes.NO_ACTIVE_CHANNELS,
   }),
 };
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 import OrderBookRepository from './OrderBookRepository';
 import TradingPair from './TradingPair';
 import errors from './errors';
-import { errors as swapsErrors } from '../swaps/errors';
+import swapsErrors from '../swaps/errors';
 import Pool from '../p2p/Pool';
 import Peer from '../p2p/Peer';
 import Logger from '../Logger';

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -150,7 +150,7 @@ class RaidenClient extends SwapClient {
       await this.setStatus(ClientStatus.ConnectionVerified);
     } catch (err) {
       this.logger.error(
-        `could not verify connection to raiden at ${this.host}:${this.port}, retrying in ${RaidenClient.RECONNECT_TIMER} ms`,
+        `could not verify connection to raiden at ${this.host}:${this.port}, retrying in ${RaidenClient.RECONNECT_TIME_LIMIT} ms`,
         err,
       );
       await this.disconnect();

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1,18 +1,18 @@
-import Pool from '../p2p/Pool';
-import OrderBook from '../orderbook/OrderBook';
+import { OrderSide, SwapClientType, SwapRole } from '../constants/enums';
 import { LndInfo } from '../lndclient/types';
+import OrderBook from '../orderbook/OrderBook';
+import { OrderSidesArrays } from '../orderbook/TradingPair';
+import { Order, OrderPortion, PlaceOrderEvent } from '../orderbook/types';
+import Pool from '../p2p/Pool';
 import { RaidenInfo } from '../raidenclient/types';
-import errors from './errors';
-import { SwapClientType, OrderSide, SwapRole } from '../constants/enums';
+import swapsErrors from '../swaps/errors';
+import SwapClientManager from '../swaps/SwapClientManager';
+import Swaps from '../swaps/Swaps';
+import { ResolveRequest, SwapFailure, SwapSuccess } from '../swaps/types';
 import { parseUri, toUri, UriParts } from '../utils/uriUtils';
 import { sortOrders } from '../utils/utils';
-import { Order, OrderPortion, PlaceOrderEvent } from '../orderbook/types';
-import Swaps from '../swaps/Swaps';
-import SwapClientManager from '../swaps/SwapClientManager';
-import { OrderSidesArrays } from '../orderbook/TradingPair';
-import { SwapSuccess, SwapFailure, ResolveRequest } from '../swaps/types';
-import { errors as swapsErrors } from '../swaps/errors';
 import commitHash from '../Version';
+import errors from './errors';
 
 /**
  * The components required by the API service layer.

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -49,10 +49,10 @@ abstract class SwapClient extends EventEmitter {
    */
   public abstract readonly finalLock: number;
   public abstract readonly type: SwapClientType;
+  /** Time in milliseconds between attempts to recheck connectivity to the client. */
+  public static readonly RECONNECT_TIME_LIMIT = 5000;
   protected status: ClientStatus = ClientStatus.NotInitialized;
   protected reconnectionTimer?: NodeJS.Timer;
-  /** Time in milliseconds between attempts to recheck connectivity to the client. */
-  protected static readonly RECONNECT_TIMER = 5000;
 
   private updateCapacityTimer?: NodeJS.Timer;
   /** The maximum amount of time we will wait for the connection to be verified during initialization. */
@@ -126,7 +126,7 @@ abstract class SwapClient extends EventEmitter {
               // if we were still not able to verify the connection, schedule another attempt
               this.reconnectionTimer.refresh();
             }
-          }, SwapClient.RECONNECT_TIMER);
+          }, SwapClient.RECONNECT_TIME_LIMIT);
         }
       }
     }

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -1,17 +1,18 @@
+import { EventEmitter } from 'events';
 import Config from '../Config';
-import SwapClient from './SwapClient';
+import { SwapClientType } from '../constants/enums';
+import { Models } from '../db/DB';
 import LndClient from '../lndclient/LndClient';
 import { LndInfo } from '../lndclient/types';
-import RaidenClient from '../raidenclient/RaidenClient';
 import { Loggers } from '../Logger';
 import { Currency } from '../orderbook/types';
-import { Models } from '../db/DB';
-import { SwapClientType } from '../constants/enums';
-import { EventEmitter } from 'events';
 import Peer from '../p2p/Peer';
-import { UnitConverter } from '../utils/UnitConverter';
+import RaidenClient from '../raidenclient/RaidenClient';
 import seedutil from '../utils/seedutil';
+import { UnitConverter } from '../utils/UnitConverter';
 import errors from './errors';
+import SwapClient, { ClientStatus } from './SwapClient';
+import lndErrors from '../lndclient/errors';
 
 export function isRaidenClient(swapClient: SwapClient): swapClient is RaidenClient {
   return (swapClient.type === SwapClientType.Raiden);
@@ -38,7 +39,7 @@ interface SwapClientManager {
 }
 
 class SwapClientManager extends EventEmitter {
-  /** A map between currencies and all swap clients */
+  /** A map between currencies and all enabled swap clients */
   public swapClients = new Map<string, SwapClient>();
   public raidenClient: RaidenClient;
   private walletPassword?: string;
@@ -106,23 +107,62 @@ class SwapClientManager extends EventEmitter {
   }
 
   /**
+   * Checks to make sure all enabled lnd instances are available and waits
+   * up to a short time for them to become available in case they are not.
+   * Throws an error if any lnd clients remain unreachable.
+   */
+  public waitForLnd = async () => {
+    const lndClients = this.getLndClientsMap().values();
+    const lndAvailablePromises: Promise<void>[] = [];
+    for (const lndClient of lndClients) {
+      lndAvailablePromises.push(new Promise<void>((resolve, reject) => {
+        if (lndClient.isDisconnected() || lndClient.isNotInitialized()) {
+          const onAvailable = () => {
+            clearTimeout(timer);
+            lndClient.removeListener('locked', onAvailable);
+            lndClient.removeListener('connectionVerified', onAvailable);
+            resolve();
+          };
+          lndClient.once('connectionVerified', onAvailable);
+          lndClient.once('locked', onAvailable);
+          const timer = setTimeout(() => {
+            lndClient.removeListener('connectionVerified', onAvailable);
+            lndClient.removeListener('locked', onAvailable);
+            reject(lndClient.currency);
+          }, SwapClient.RECONNECT_TIME_LIMIT);
+        } else {
+          resolve();
+        }
+      }));
+    }
+
+    try {
+      await Promise.all(lndAvailablePromises);
+    } catch (currency) {
+      throw lndErrors.UNAVAILABLE(currency, ClientStatus.Disconnected);
+    }
+  }
+
+  /**
    * Generates a cryptographically random 24 word seed mnemonic from an lnd client.
    */
   public genSeed = async () => {
+    const lndClients = this.getLndClientsMap().values();
     // loop through swap clients until we find an lnd client awaiting unlock
-    for (const swapClient of this.swapClients.values()) {
-      if (isLndClient(swapClient) && swapClient.isWaitingUnlock()) {
+    for (const lndClient of lndClients) {
+      if (lndClient.isWaitingUnlock()) {
         try {
-          const seed = await swapClient.genSeed();
+          const seed = await lndClient.genSeed();
           return seed;
         } catch (err) {
-          swapClient.logger.error('could not generate seed', err);
+          lndClient.logger.error('could not generate seed', err);
         }
       }
     }
 
-    // TODO: use seedutil tool to generate a seed
-    return undefined;
+    // TODO: use seedutil tool to generate a seed instead of throwing error
+    // when we can't generate one with lnd
+    throw errors.SWAP_CLIENT_WALLET_NOT_CREATED('could not generate aezeed');
   }
 
   /**
@@ -131,18 +171,23 @@ class SwapClientManager extends EventEmitter {
   public initWallets = async (walletPassword: string, seedMnemonic: string[]) => {
     this.walletPassword = walletPassword;
 
-    // loop through swap clients to find locked lnd clients
+    // loop through swap clients to initialize locked lnd clients
+    const lndClients = this.getLndClientsMap().values();
     const initWalletPromises: Promise<any>[] = [];
     const initializedLndWallets: string[] = [];
     let initializedRaiden = false;
-    for (const swapClient of this.swapClients.values()) {
-      if (isLndClient(swapClient) && swapClient.isWaitingUnlock()) {
-        const initWalletPromise = swapClient.initWallet(walletPassword, seedMnemonic).then(() => {
-          initializedLndWallets.push(swapClient.currency);
-        }).catch((err) => {
-          swapClient.logger.debug(`could not initialize wallet: ${err.message}`);
-        });
-        initWalletPromises.push(initWalletPromise);
+
+    for (const lndClient of lndClients) {
+      if (isLndClient(lndClient)) {
+        if (lndClient.isWaitingUnlock()) {
+          const initWalletPromise = lndClient.initWallet(walletPassword, seedMnemonic).then(() => {
+            initializedLndWallets.push(lndClient.currency);
+          }).catch((err) => {
+            lndClient.logger.error(`could not initialize wallet: ${err.message}`);
+            throw errors.SWAP_CLIENT_WALLET_NOT_CREATED(`could not initialize lnd-${lndClient.currency}: ${err.message}`);
+          });
+          initWalletPromises.push(initWalletPromise);
+        }
       }
     }
 
@@ -154,8 +199,9 @@ class SwapClientManager extends EventEmitter {
       const keystorePromise = seedutil(seedMnemonic, '', keystorepath).then(() => {
         this.raidenClient.logger.info(`created raiden keystore with master seed and empty password in ${keystorepath}`);
         initializedRaiden = true;
-      }).catch(() => {
-        this.raidenClient.logger.warn('could not create keystore');
+      }).catch((err) => {
+        this.raidenClient.logger.error('could not create keystore');
+        throw errors.SWAP_CLIENT_WALLET_NOT_CREATED(`could not create keystore: ${err}`);
       });
       initWalletPromises.push(keystorePromise);
     }

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -4,7 +4,6 @@ import LndClient from '../lndclient/LndClient';
 import { LndInfo } from '../lndclient/types';
 import RaidenClient from '../raidenclient/RaidenClient';
 import { Loggers } from '../Logger';
-import { errors } from './errors';
 import { Currency } from '../orderbook/types';
 import { Models } from '../db/DB';
 import { SwapClientType } from '../constants/enums';
@@ -12,6 +11,7 @@ import { EventEmitter } from 'events';
 import Peer from '../p2p/Peer';
 import { UnitConverter } from '../utils/UnitConverter';
 import seedutil from '../utils/seedutil';
+import errors from './errors';
 
 export function isRaidenClient(swapClient: SwapClient): swapClient is RaidenClient {
   return (swapClient.type === SwapClientType.Raiden);

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -13,7 +13,7 @@ import { SwapDeal, SwapSuccess, SanitySwap, ResolveRequest, Route } from './type
 import { generatePreimageAndHash, setTimeoutPromise } from '../utils/utils';
 import { PacketType } from '../p2p/packets';
 import SwapClientManager from './SwapClientManager';
-import { errors, errorCodes } from './errors';
+import errors, { errorCodes } from './errors';
 import SwapRecovery from './SwapRecovery';
 import poissonQuantile from 'distributions-poisson-quantile';
 

--- a/lib/swaps/errors.ts
+++ b/lib/swaps/errors.ts
@@ -37,4 +37,5 @@ const errors = {
   }),
 };
 
-export { errorCodes, errors };
+export { errorCodes };
+export default errors;

--- a/lib/swaps/errors.ts
+++ b/lib/swaps/errors.ts
@@ -8,6 +8,7 @@ const errorCodes = {
   PAYMENT_ERROR: codesPrefix.concat('.4'),
   PAYMENT_REJECTED: codesPrefix.concat('.5'),
   INVALID_RESOLVE_REQUEST: codesPrefix.concat('.6'),
+  SWAP_CLIENT_WALLET_NOT_CREATED: codesPrefix.concat('.7'),
 };
 
 const errors = {
@@ -34,6 +35,10 @@ const errors = {
   INVALID_RESOLVE_REQUEST: (rHash: string, errorMessage: string) => ({
     message: `invalid resolve request for rHash ${rHash}: ${errorMessage}`,
     code: errorCodes.INVALID_RESOLVE_REQUEST,
+  }),
+  SWAP_CLIENT_WALLET_NOT_CREATED: (message: string) => ({
+    message,
+    code: errorCodes.SWAP_CLIENT_WALLET_NOT_CREATED,
   }),
 };
 

--- a/test/unit/HttpServer.spec.ts
+++ b/test/unit/HttpServer.spec.ts
@@ -7,7 +7,7 @@ import chaiAsPromised = require('chai-as-promised');
 import sinon from 'sinon';
 import Service from '../../lib/service/Service';
 import { ResolveRequest } from '../../lib/swaps/types';
-import { errors } from '../../lib/swaps/errors';
+import errors from '../../lib/swaps/errors';
 
 chai.use(chaiAsPromised);
 chai.use(chaiHttp);


### PR DESCRIPTION
Closes #1252.

This makes the `CreateNode` call wait briefly for all enabled lnd clients to become available. If any lnd clients remain unavailable, the call returns an error.

I did some refactoring around the way grpc errors are handled and logged as well in separate commits.

I'll open a separate issue to track a new status besides `Disabled` for when an lnd client is enabled by the config but is dysfunctional due to an unrecoverable error such as no tls cert or macaroon found.

