### PR TITLE
fix: reconnect log message

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -515,7 +515,7 @@ class Peer extends EventEmitter {
         }
 
         this.logger.debug(
-          `Connection attempt #${retries + 1} to ${this.label}` +
+          `Connection attempt #${retries + 1} to ${this.label} ` +
           `failed: ${err.message}. retrying in ${retryDelay / 1000} sec...`,
         );
 


### PR DESCRIPTION
This adds a space between the peer's label and the word "failed" in the logging output.