### PR TITLE
feat(swaps): raiden claims recovered swap payments

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -900,6 +900,16 @@ class Swaps extends EventEmitter {
 
     this.logger.debug(`handleResolveRequest starting with hash ${rHash}`);
 
+    // first check if we have recovered this deal from a previous swap attempt
+    const recoveredSwap = this.swapRecovery.recoveredPreimageSwaps.get(rHash);
+    if (recoveredSwap && recoveredSwap.rPreimage) {
+      recoveredSwap.state = SwapState.Recovered;
+      recoveredSwap.save().catch(this.logger.error);
+      this.swapRecovery.recoveredPreimageSwaps.delete(rHash);
+      this.logger.info(`handleResolveRequest returning recovered preimage ${recoveredSwap.rPreimage} for hash ${rHash}`);
+      return recoveredSwap.rPreimage;
+    }
+
     const deal = this.getDeal(rHash);
 
     if (deal) {


### PR DESCRIPTION
Closes #1251.

This adds logic to track recovered swap preimages for claiming raiden payments. A proposed change to raiden has it continuously attempt to resolve a hash until it gets a response - if xud crashes during or before the first attempt then raiden will continue trying until xud comes back online. When it does, xud will check if it has recovered the preimage and return it to raiden if so, effectively claiming the payment and preventing loss of funds.