### PR TITLE
chore: update testnet seeds

### DIFF
--- a/lib/db/seeds/testnet.ts
+++ b/lib/db/seeds/testnet.ts
@@ -3,8 +3,11 @@ import { SwapClientType } from '../../constants/enums';
 
 const nodes = [
   {
-    nodePubKey: '03640f9e41cf77349ef29ed84ab02671dfc0a76963b8e84209cdeab4c9639ace0b',
-    addresses: [{ host: 'xud1.testnet.exchangeunion.com', port: 18885 }],
+    nodePubKey: '037a74737630bb5a9979762b2163ef9f95c81e00caf347bacc17f16991cdbb61f7',
+    addresses: [
+      { host: 'xud1.testnet.exchangeunion.com', port: 18885 },
+      { host: 'pso32ae2l5nyh3clgee2nj2hgpmcnluhaqibjm2r2fjcsn4gclxfmrid.onion', port: 18885 },
+    ],
   },
 ] as db.NodeAttributes[];
 
@@ -15,13 +18,13 @@ const currencies = [
     id: 'WETH',
     swapClient: SwapClientType.Raiden,
     decimalPlaces: 18,
-    tokenAddress: '0xc778417e063141139fce010982780140aa0cd5ab',
+    tokenAddress: '0xc778417E063141139Fce010982780140Aa0cD5Ab',
   },
   {
     id: 'DAI',
     swapClient: SwapClientType.Raiden,
     decimalPlaces: 18,
-    tokenAddress: '0xad6d458402f60fd3bd25163575031acdce07538d',
+    tokenAddress: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
   },
 ] as db.CurrencyAttributes[];
 


### PR DESCRIPTION
This commit updates the public key and listening uris of our testnet
node that has been migrated to latest docker changes.

In addition I changed DAI and WETH contract addresses to EIP55 format
since it was causing xud's channelbalance calls to fail.