### PR TITLE
chore: run sim tests on version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:seedutil": "jest --rootDir seedutil",
     "test:jest:watch": "jest --watch",
     "typedoc": "typedoc --out typedoc --module commonjs --target es6 lib --readme none",
-    "preversion": "npm run lintNoFix && npm test && npm run compile",
+    "preversion": "npm run lintNoFix && npm test && npm run test:sim",
     "postversion": "npm run compile",
     "version": "npm run config && npm run changelog && git add sample-xud.conf CHANGELOG.md && npm run typedoc"
   },


### PR DESCRIPTION
This runs the full suite of simulation tests before tagging a new version, which also runs the `compile` script that it's replacing.