### PR TITLE
fix: don't allow new connections while pool closes

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -466,6 +466,10 @@ class Pool extends EventEmitter {
    * routine is complete
    */
   private openPeer = async (peer: Peer, expectedNodePubKey?: string, retryConnecting = false): Promise<void> => {
+    if (this.disconnecting || !this.connected) {
+      // if we are disconnected or disconnecting, don't open new connections
+      throw errors.POOL_CLOSED;
+    }
     this.bindPeer(peer);
 
     try {


### PR DESCRIPTION
This fix prevents the p2p pool from accepting or initiating new connections while it is closing or after it has closed. This prevents the possibility for race conditions which was affecting the Pool test suite.