### PR TITLE
feat: different gRPC & HTTP port depending on active network

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -91,11 +91,11 @@ class Config {
     this.rpc = {
       disable: false,
       host: 'localhost',
-      port: 8886,
+      port: this.getDefaultRpcPort(),
     };
     this.http = {
       host: 'localhost',
-      port: 8887,
+      port: this.getDefaultHttpPort(),
     };
     this.webproxy = {
       disable: true,
@@ -197,6 +197,8 @@ class Config {
     this.logpath = this.getDefaultLogPath();
     this.dbpath = this.getDefaultDbPath();
     this.p2p.port = this.getDefaultP2pPort();
+    this.rpc.port = this.getDefaultRpcPort();
+    this.http.port = this.getDefaultHttpPort();
     this.setDefaultMacaroonPaths();
 
     if (configProps) {
@@ -279,6 +281,36 @@ class Config {
         return 28885;
       case XuNetwork.RegTest:
         return 38885;
+      default:
+        throw new Error('unrecognized network');
+    }
+  }
+
+  private getDefaultRpcPort = () => {
+    switch (this.network) {
+      case XuNetwork.MainNet:
+        return 8886;
+      case XuNetwork.TestNet:
+        return 18886;
+      case XuNetwork.SimNet:
+        return 28886;
+      case XuNetwork.RegTest:
+        return 38886;
+      default:
+        throw new Error('unrecognized network');
+    }
+  }
+
+  private getDefaultHttpPort = () => {
+    switch (this.network) {
+      case XuNetwork.MainNet:
+        return 8887;
+      case XuNetwork.TestNet:
+        return 18887;
+      case XuNetwork.SimNet:
+        return 28887;
+      case XuNetwork.RegTest:
+        return 38887;
       default:
         throw new Error('unrecognized network');
     }

--- a/test/jest/Config.spec.ts
+++ b/test/jest/Config.spec.ts
@@ -6,6 +6,16 @@ const TESTNET_P2P_PORT = 18885;
 const SIMNET_P2P_PORT = 28885;
 const REGTEST_P2P_PORT = 38885;
 
+const MAINNET_RPC_PORT = 8886;
+const TESTNET_RPC_PORT = 18886;
+const SIMNET_RPC_PORT = 28886;
+const REGTEST_RPC_PORT = 38886;
+
+const MAINNET_HTTP_PORT = 8887;
+const TESTNET_HTTP_PORT = 18887;
+const SIMNET_HTTP_PORT = 28887;
+const REGTEST_HTTP_PORT = 38887;
+
 describe('Config', () => {
   let config: Config;
 
@@ -21,21 +31,29 @@ describe('Config', () => {
     await config.load({ mainnet: true });
     expect(config.network).toEqual(XuNetwork.MainNet);
     expect(config.p2p.port).toEqual(MAINNET_P2P_PORT);
+    expect(config.rpc.port).toEqual(MAINNET_RPC_PORT);
+    expect(config.http.port).toEqual(MAINNET_HTTP_PORT);
 
     const testnetConfig = new Config();
     await testnetConfig.load({ testnet: true });
     expect(testnetConfig.network).toEqual(XuNetwork.TestNet);
     expect(testnetConfig.p2p.port).toEqual(TESTNET_P2P_PORT);
+    expect(testnetConfig.rpc.port).toEqual(TESTNET_RPC_PORT);
+    expect(testnetConfig.http.port).toEqual(TESTNET_HTTP_PORT);
 
     const simnetConfig = new Config();
     await simnetConfig.load({ simnet: true });
     expect(simnetConfig.network).toEqual(XuNetwork.SimNet);
     expect(simnetConfig.p2p.port).toEqual(SIMNET_P2P_PORT);
+    expect(simnetConfig.rpc.port).toEqual(SIMNET_RPC_PORT);
+    expect(simnetConfig.http.port).toEqual(SIMNET_HTTP_PORT);
 
     const regtestConfig = new Config();
     await regtestConfig.load({ regtest: true });
     expect(regtestConfig.network).toEqual(XuNetwork.RegTest);
     expect(regtestConfig.p2p.port).toEqual(REGTEST_P2P_PORT);
+    expect(regtestConfig.rpc.port).toEqual(REGTEST_RPC_PORT);
+    expect(regtestConfig.http.port).toEqual(REGTEST_HTTP_PORT);
   });
 
   test('arg network value overrides config values', async () => {


### PR DESCRIPTION
resolves #1239 :flushed: 