### PR TITLE
chore: move .tsbuildinfo to dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ typings/
 
 # Typescript compilation output
 dist/
-.tsbuildinfo
 
 # Optional npm cache directory
 .npm

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "files": [
     "npm-shrinkwrap.json",
     "bin",
-    "dist",
+    "dist/**/!(.tsbuildinfo)",
     "tasks",
     ".env",
     "README.md",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "lib": ["dom","ES2017"],
     "declaration": true,
     "incremental": true,
-    "tsBuildInfoFile": ".tsbuildinfo",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
 
     /* Additional Checks */
     "noUnusedLocals": true,                   /* Report errors on unused locals. */


### PR DESCRIPTION
When one executes `rm -r dist` and runs `npm run compile` afterwards the compilation did not work because the `.tsbuildinfo` file was not located in the dist folder.

This PR moves the file into the `dist` folder while still ignoring it when packing the tar archive that is published to NPM.