### PR TITLE
feat(rpc): create error if clients misconfigured

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -164,7 +164,7 @@ class Xud extends EventEmitter {
         shutdown: this.beginShutdown,
       });
 
-      if (!this.swapClientManager.raidenClient.isDisabled()) {
+      if (this.swapClientManager.raidenClient.isOperational()) {
         this.httpServer = new HttpServer(loggers.http, this.service);
         await this.httpServer.listen(
           this.config.http.port,

--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -46,6 +46,7 @@ const getGrpcError = (err: any) => {
     case serviceErrorCodes.NOMATCHING_MODE_IS_REQUIRED:
     case orderErrorCodes.INSUFFICIENT_OUTBOUND_BALANCE:
     case swapErrorCodes.SWAP_CLIENT_NOT_FOUND:
+    case swapErrorCodes.SWAP_CLIENT_MISCONFIGURED:
       code = status.FAILED_PRECONDITION;
       break;
     case lndErrorCodes.UNAVAILABLE:

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -101,7 +101,7 @@ class LndClient extends SwapClient {
       this.logger.debug(`loaded tls cert from ${certpath}`);
     } catch (err) {
       this.logger.error(`could not load tls cert from ${certpath}, is lnd installed?`);
-      await this.setStatus(ClientStatus.Disabled);
+      await this.setStatus(ClientStatus.Misconfigured);
       return;
     }
 
@@ -110,11 +110,11 @@ class LndClient extends SwapClient {
       try {
         await this.loadMacaroon();
       } catch (err) {
-        if (!awaitingCreate) {
+        if (!awaitingCreate || err.code !== 'ENOENT') {
           // unless we are waiting for the xud nodekey and lnd wallet to be created
           // we expect the macaroon to exist and disable this client otherwise
-          this.logger.error(`expected macaroon not found at ${macaroonpath}`);
-          await this.setStatus(ClientStatus.Disabled);
+          this.logger.error(`could not load admin macaroon from ${macaroonpath}`);
+          await this.setStatus(ClientStatus.Misconfigured);
           return;
         }
       }
@@ -148,7 +148,7 @@ class LndClient extends SwapClient {
 
   private unaryCall = <T, U>(methodName: Exclude<keyof LightningClient, ClientMethods>, params: T): Promise<U> => {
     return new Promise((resolve, reject) => {
-      if (this.isDisabled()) {
+      if (!this.isOperational()) {
         reject(errors.DISABLED);
         return;
       }
@@ -176,7 +176,7 @@ class LndClient extends SwapClient {
 
   private unaryInvoiceCall = <T, U>(methodName: Exclude<keyof InvoicesClient, ClientMethods>, params: T): Promise<U> => {
     return new Promise((resolve, reject) => {
-      if (this.isDisabled()) {
+      if (!this.isOperational()) {
         reject(errors.DISABLED);
         return;
       }
@@ -196,7 +196,7 @@ class LndClient extends SwapClient {
 
   private unaryWalletUnlockerCall = <T, U>(methodName: Exclude<keyof WalletUnlockerClient, ClientMethods>, params: T): Promise<U> => {
     return new Promise((resolve, reject) => {
-      if (this.isDisabled()) {
+      if (!this.isOperational()) {
         reject(errors.DISABLED);
         return;
       }
@@ -219,7 +219,7 @@ class LndClient extends SwapClient {
     let version: string | undefined;
     let alias: string | undefined;
     let status = 'Ready';
-    if (this.isDisabled()) {
+    if (!this.isOperational()) {
       status = errors.DISABLED(this.currency).message;
     } else if (this.isDisconnected()) {
       status = errors.UNAVAILABLE(this.currency, this.status).message;
@@ -313,7 +313,7 @@ class LndClient extends SwapClient {
   }
 
   protected verifyConnection = async () => {
-    if (this.isDisabled()) {
+    if (!this.isOperational()) {
       throw(errors.DISABLED);
     }
 
@@ -871,7 +871,7 @@ class LndClient extends SwapClient {
       this.watchMacaroonResolve = undefined;
     }
 
-    if (!this.isDisabled()) {
+    if (this.isOperational()) {
       await this.setStatus(ClientStatus.Disconnected);
     }
   }

--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -1,7 +1,8 @@
-import errors from '../service/errors';
 import { EventEmitter } from 'events';
-import SwapClientManager from '../swaps/SwapClientManager';
 import NodeKey from '../nodekey/NodeKey';
+import swapErrors from '../swaps/errors';
+import SwapClientManager from '../swaps/SwapClientManager';
+import errors from './errors';
 import assert = require('assert');
 
 interface InitService {
@@ -25,6 +26,9 @@ class InitService extends EventEmitter {
     }
     if (this.nodeKeyExists) {
       throw errors.UNIMPLEMENTED;
+    }
+    if (this.swapClientManager.misconfiguredClientLabels.length > 0) {
+      throw swapErrors.SWAP_CLIENT_MISCONFIGURED(this.swapClientManager.misconfiguredClientLabels);
     }
     if (this.pendingCall) {
       throw errors.PENDING_CALL_CONFLICT;

--- a/lib/swaps/errors.ts
+++ b/lib/swaps/errors.ts
@@ -9,6 +9,7 @@ const errorCodes = {
   PAYMENT_REJECTED: codesPrefix.concat('.5'),
   INVALID_RESOLVE_REQUEST: codesPrefix.concat('.6'),
   SWAP_CLIENT_WALLET_NOT_CREATED: codesPrefix.concat('.7'),
+  SWAP_CLIENT_MISCONFIGURED: codesPrefix.concat('.8'),
 };
 
 const errors = {
@@ -39,6 +40,10 @@ const errors = {
   SWAP_CLIENT_WALLET_NOT_CREATED: (message: string) => ({
     message,
     code: errorCodes.SWAP_CLIENT_WALLET_NOT_CREATED,
+  }),
+  SWAP_CLIENT_MISCONFIGURED: (clientLabels: string[]) => ({
+    message: `the following swap clients are misconfigured: ${clientLabels.join(', ')}`,
+    code: errorCodes.SWAP_CLIENT_MISCONFIGURED,
   }),
 };
 

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -39,6 +39,8 @@ jest.mock('../../lib/lndclient/LndClient', () => {
       pubKey: mockLndPubKey,
       type: SwapClientType.Lnd,
       isDisabled: () => false,
+      isOperational: () => true,
+      isMisconfigured: () => false,
       getLndInfo: lndInfoMock,
       close: closeMock,
       openChannel: mockLndOpenChannel,
@@ -58,6 +60,8 @@ jest.mock('../../lib/raidenclient/RaidenClient', () => {
       type: SwapClientType.Raiden,
       address: mockRaidenAddress,
       isDisabled: () => mockRaidenClientIsDisabled,
+      isOperational: () => !mockRaidenClientIsDisabled,
+      isMisconfigured: () => false,
       close: closeMock,
       openChannel: mockRaidenOpenChannel,
     };


### PR DESCRIPTION
Closes #1287 using the approach described below:

> 1. Wait briefly for tls.cert to be created if it is not found immediately upon start and this is the first time xud is being run (pending the create call).
> 
> 2. Fail all calls to create xud if we have a client enabled in the configuration but which could not be initialized.
