### PR TITLE
feat(swaps): add flexibility to second leg route

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -459,9 +459,8 @@ class LndClient extends SwapClient {
         destination: deal.takerPubKey!,
         amount: deal.takerAmount,
         finalCltvDelta: deal.takerCltvDelta,
-        // Enforcing the maximum duration/length of the payment by
-        // specifying the cltvLimit.
-        // TODO: investigate why we need to add 3 blocks - if not lnd says route not found
+        // Enforcing the maximum duration/length of the payment by specifying
+        // the cltvLimit. We add 3 blocks to offset the block padding set by lnd.
         cltvLimit: deal.takerMaxTimeLock! + 3,
       });
     }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -600,13 +600,14 @@ class Swaps extends EventEmitter {
       const routeLockDuration = routeTotalTimeLock - height;
       const routeLockHours = Math.round(routeLockDuration * takerSwapClient.minutesPerBlock / 60);
       this.logger.debug(`found route to taker with total lock duration of ${routeLockDuration} ${takerCurrency} blocks (~${routeLockHours}h)`);
-      deal.takerMaxTimeLock = routeLockDuration;
+      // Add an additional buffer equal to our final lock to allow for more possible routes.
+      deal.takerMaxTimeLock = routeLockDuration + takerSwapClient.finalLock;
 
       // Here we calculate the minimum lock delta we will expect as maker on the final hop to us on
       // the first leg of the swap. This should ensure a very high probability that the final hop
       // of the payment to us won't expire before our payment to the taker with time leftover to
       // satisfy our finalLock/cltvDelta requirement for the incoming payment swap client.
-      const lockBuffer = Swaps.calculateLockBuffer(routeLockDuration, takerSwapClient.minutesPerBlock, makerSwapClient.minutesPerBlock);
+      const lockBuffer = Swaps.calculateLockBuffer(deal.takerMaxTimeLock, takerSwapClient.minutesPerBlock, makerSwapClient.minutesPerBlock);
       const lockBufferHours = Math.round(lockBuffer * makerSwapClient.minutesPerBlock / 60);
       this.logger.debug(`calculated lock buffer for first leg: ${lockBuffer} ${makerCurrency} blocks (~${lockBufferHours}h)`);
 

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -279,7 +279,7 @@ describe('Swaps Integration', () => {
         swapRequestBody.takerCltvDelta,
       );
       expect(lndLtc.addInvoice).toHaveBeenCalledTimes(1);
-      const expectedMakerCltvDelta = 1445;
+      const expectedMakerCltvDelta = 1641;
       expect(lndLtc.addInvoice).toHaveBeenCalledWith(
         swapRequestBody.rHash,
         swapRequestBody.proposedQuantity,


### PR DESCRIPTION
This adds a buffer to the `takerMaxTimeLock` equal to our `finalLock` value, which by default is 40 blocks on BTC, which may open the possibility of using alternate routes with slightly longer lock times should payment using the first route we found fail.


Closes #1165.