### PR TITLE
fix(p2p): remove error event from Peer

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -246,8 +246,7 @@ class Peer extends EventEmitter {
       expectedNodePubKey?: string,
       /** Whether to retry to connect upon failure. */
       retryConnecting?: boolean,
-    }):
-    Promise<packets.SessionInitPacket> => {
+    }): Promise<packets.SessionInitPacket> => {
     assert(!this.opening);
     assert(!this.opened);
     assert(!this.closed);
@@ -302,7 +301,7 @@ class Peer extends EventEmitter {
     if (this.socket) {
       if (!this.socket.destroyed) {
         if (reason !== undefined) {
-          this.logger.debug(`Peer (${ this.label }): closing socket. reason: ${DisconnectionReason[reason]}`);
+          this.logger.debug(`Peer (${this.label}): closing socket. reason: ${DisconnectionReason[reason]}`);
           this.sentDisconnectionReason = reason;
           await this.sendPacket(new packets.DisconnectingPacket({ reason, payload: reasonPayload }));
         }

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -300,13 +300,13 @@ class Peer extends EventEmitter {
     this.opened = false;
 
     if (this.socket) {
-      if (reason !== undefined) {
-        this.logger.debug(`Peer (${ this.label }): closing socket. reason: ${DisconnectionReason[reason]}`);
-        this.sentDisconnectionReason = reason;
-        await this.sendPacket(new packets.DisconnectingPacket({ reason, payload: reasonPayload }));
-      }
-
       if (!this.socket.destroyed) {
+        if (reason !== undefined) {
+          this.logger.debug(`Peer (${ this.label }): closing socket. reason: ${DisconnectionReason[reason]}`);
+          this.sentDisconnectionReason = reason;
+          await this.sendPacket(new packets.DisconnectingPacket({ reason, payload: reasonPayload }));
+        }
+
         this.socket.destroy();
       }
       delete this.socket;

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -846,14 +846,6 @@ class Pool extends EventEmitter {
       this.emit('peer.nodeStateUpdate', peer);
     });
 
-    peer.on('error', (err) => {
-      // The only situation in which the node should be connected to itself is the
-      // reachability check of the advertised addresses and we don't have to log that
-      if (peer.nodePubKey !== this.nodePubKey) {
-        this.logger.error(`Peer (${peer.label}): error: ${err.message}`);
-      }
-    });
-
     peer.once('close', () => this.handlePeerClose(peer));
 
     peer.on('reputation', async (event) => {

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -869,17 +869,17 @@ class Pool extends EventEmitter {
       this.pendingOutboundPeers.delete(peer.expectedNodePubKey);
     }
 
-    if (!peer.active) {
-      return;
-    }
-
     if (peer.nodePubKey) {
       this.pendingOutboundPeers.delete(peer.nodePubKey);
       this.peers.delete(peer.nodePubKey);
     }
-    this.emit('peer.close', peer.nodePubKey);
     peer.removeAllListeners();
+
+    if (!peer.active) {
+      return;
+    }
     peer.active = false;
+    this.emit('peer.close', peer.nodePubKey);
 
     const shouldReconnect =
       (peer.sentDisconnectionReason === undefined || peer.sentDisconnectionReason === DisconnectionReason.ResponseStalling) &&

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -822,9 +822,7 @@ class Pool extends EventEmitter {
       this.logger.error(err);
     });
 
-    this.server!.on('connection', async (socket) => {
-      await this.handleSocket(socket);
-    });
+    this.server!.on('connection', this.handleSocket);
   }
 
   private bindPeer = (peer: Peer) => {


### PR DESCRIPTION
This removes the `error` event from `Peer`. Previously it was only used to log the error from the listener in `Pool`, however this was unnecessary and instead the logging can be done directly from `Peer`.

This simplifies the code and also resolves a mysterious crash condition where an unhandled error from `Peer` would crash xud after a failed inbound connection & timeout via tor.

Closes #1129 - the same issue addressed by https://github.com/ExchangeUnion/xud/pull/1291.

This also includes several changes made in the course of trying to debug/resolve the aforementioned crash. Although they didn't resolve the issue, I still consider them useful refactoring/cleanup of existing p2p code.