### PR TITLE
feat(rpc): notify when xud is starting

### DIFF
--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -9,6 +9,7 @@ interface InitService {
   emit(event: 'nodekey', nodeKey: NodeKey): boolean;
 }
 
+/** A class containing the methods available for a locked, uninitialized instance of xud. */
 class InitService extends EventEmitter {
   /** Whether there is a pending `CreateNode` or `UnlockNode` call. */
   public pendingCall = false;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -70,9 +70,11 @@ const argChecks = {
   },
 };
 
-/** Class containing the available RPC methods for XUD */
+/** A class containing the available RPC methods for an unlocked, running instance of xud. */
 class Service {
   public shutdown: () => void;
+  /** Whether the service is disabled - in other words whether xud is locked. */
+  public disabled = false;
   private orderBook: OrderBook;
   private swapClientManager: SwapClientManager;
   private pool: Pool;


### PR DESCRIPTION
This changes the xud initialization procedure to start the grpc server immediately and have it return an `UNAVAILABLE` error with the message 'xud is starting' until all components have finished initializing and xud is ready to handle rpc calls. It also enhances the xucli output somewhat in cases where xud is locked or starting.

Closes #1258.