### PR TITLE
chore: disable Travis builds with latest node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "node"
   - "lts/*"
 
 cache:


### PR DESCRIPTION
Since the update to Node `v13.0.1` on the `node` version on Travis, our builds have been failing because that node version is incompatible with a gRPC dependency.

This PR causes Travis to just execute on the LTS version of node. Maybe we should document somewhere that we are just working with/testing on the latest Node LTS?
