### PR TITLE
fix(p2p): handshake race conditions

### DIFF
--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
-import P2PRepository from './P2PRepository';
-import { NodeInstance, NodeFactory, ReputationEventInstance } from '../db/types';
-import { Address } from './types';
-import addressUtils from '../utils/addressUtils';
 import { ReputationEvent } from '../constants/enums';
+import { NodeFactory, NodeInstance, ReputationEventInstance } from '../db/types';
+import addressUtils from '../utils/addressUtils';
+import P2PRepository from './P2PRepository';
+import { Address } from './types';
 
 export const reputationEventWeight = {
   [ReputationEvent.ManualBan]: Number.NEGATIVE_INFINITY,
@@ -95,12 +95,13 @@ class NodeList extends EventEmitter {
   }
 
   /**
-   * Create a Node in the database.
+   * Persists a node to the database and adds it to the node list.
    */
-  public createNode = async (nodeFactory: NodeFactory): Promise<NodeInstance> => {
-    const node = await this.repository.addNode(nodeFactory);
-    this.nodes.set(node.nodePubKey, node);
-    return node;
+  public createNode = async (nodeFactory: NodeFactory) => {
+    const node = await this.repository.addNodeIfNotExists(nodeFactory);
+    if (node) {
+      this.nodes.set(node.nodePubKey, node);
+    }
   }
 
   /**

--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -1,6 +1,5 @@
-import Bluebird from 'bluebird';
 import { Models } from '../db/DB';
-import { NodeInstance, ReputationEventInstance, ReputationEventFactory, NodeFactory, ReputationEventAttributes, NodeAttributes } from '../db/types';
+import { NodeAttributes, NodeFactory, NodeInstance, ReputationEventAttributes, ReputationEventFactory, ReputationEventInstance } from '../db/types';
 
 class P2PRepository {
 
@@ -26,8 +25,21 @@ class P2PRepository {
     });
   }
 
-  public addNode = (node: NodeFactory): Bluebird<NodeInstance> => {
-    return this.models.Node.create(<NodeAttributes>node);
+  /**
+   * Adds a node to the database if it doesn't already exist.
+   * @returns the created node instance, or undefined if it already existed.
+   */
+  public addNodeIfNotExists = async (node: NodeFactory) => {
+    try {
+      const createdNode = await this.models.Node.create(<NodeAttributes>node);
+      return createdNode;
+    } catch (err) {
+      if (err.name === 'SequelizeUniqueConstraintError') {
+        return undefined;
+      } else {
+        throw err;
+      }
+    }
   }
 
   public addReputationEvent = async (event: ReputationEventFactory) => {

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -87,7 +87,7 @@ describe('Database', () => {
   });
 
   it('should add a node', async () => {
-    await p2pRepo.addNode({
+    await p2pRepo.addNodeIfNotExists({
       nodePubKey: peerPubKey,
       addresses: [],
     });


### PR DESCRIPTION
Closes #1309.

This commit makes several changes to address potential race conditions in the case where two peers attempt connections to each other simultaneously.

The key fix is that the p2p pool no longer prunes recently closed peers from the list of active peers by node pub key alone. This could result in scenarios where a pending connection that is closed causes an active connection to be discarded. Instead, only peers that are active get removed from the list when they are closed. Additionally, pending outbound and inbound peers are no longer removed from their respective lists upon the peers being closed. Rather, the `addOutbound` and `addInbound` methods - which currently add pending peers to their lists - now also remove peers from the list if they are no longer pending.

The `openPeer` method now resolves immediately after the target peer becomes active rather than waiting for followup tasks such as updating the database and sending a `GetNodes` packet. These tasks are now called and awaited separately.

Another race condition is prevented whereby handshakes may be completed on two simultaneous socket connections without being detected in the `validatePeer` method that is called after a handshake begins and the node pub key for the inbound peer is established but before it completes. In this case, both peers cannot close the "duplicate" connection or else they may wind up closing both of them. The approach implemented here arbitrarily picks the peer with the higher node pubkey to close the socket when it encounters a duplicate, while the other peer waits briefly to see if the already established connection is closed.

Lastly there are some fixes/enhancements to the Pool tests, ensuring that we wait for inbound connections to complete before we check them.