### PR TITLE
feat(rpc): unlock returns list of locked wallets

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1107,6 +1107,7 @@
 | ----- | ---- | ----- | ----------- |
 | unlocked_lnds | [string](#string) | repeated | The list of lnd clients that were unlocked. |
 | unlocked_raiden | [bool](#bool) |  | Whether raiden was unlocked. |
+| locked_lnds | [string](#string) | repeated | The list of lnd clients that could not be unlocked. |
 
 
 
@@ -1177,16 +1178,16 @@
 | ListPairs | [ListPairsRequest](#xudrpc.ListPairsRequest) | [ListPairsResponse](#xudrpc.ListPairsResponse) | Gets a list of this nodes suported trading pairs. |
 | ListPeers | [ListPeersRequest](#xudrpc.ListPeersRequest) | [ListPeersResponse](#xudrpc.ListPeersResponse) | Gets a list of connected peers. |
 | ListTrades | [ListTradesRequest](#xudrpc.ListTradesRequest) | [ListTradesResponse](#xudrpc.ListTradesResponse) |  |
-| PlaceOrder | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderEvent](#xudrpc.PlaceOrderEvent) | Adds an order to the order book. If price is zero or unspecified a market order will get added. |
+| PlaceOrder | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderEvent](#xudrpc.PlaceOrderEvent) stream | Adds an order to the order book. If price is zero or unspecified a market order will get added. |
 | PlaceOrderSync | [PlaceOrderRequest](#xudrpc.PlaceOrderRequest) | [PlaceOrderResponse](#xudrpc.PlaceOrderResponse) | The synchronous non-streaming version of PlaceOrder. |
 | ExecuteSwap | [ExecuteSwapRequest](#xudrpc.ExecuteSwapRequest) | [SwapSuccess](#xudrpc.SwapSuccess) | Execute a swap on a maker peer order |
 | RemoveCurrency | [RemoveCurrencyRequest](#xudrpc.RemoveCurrencyRequest) | [RemoveCurrencyResponse](#xudrpc.RemoveCurrencyResponse) | Removes a currency from the list of supported currencies. Only currencies that are not in use for any currently supported trading pairs may be removed. Once removed, the currency can no longer be used for any supported trading pairs. |
 | RemovePair | [RemovePairRequest](#xudrpc.RemovePairRequest) | [RemovePairResponse](#xudrpc.RemovePairResponse) | Removes a trading pair from the list of currently supported trading pair. This call will effectively cancel any standing orders for that trading pair. Peers are informed when a pair is no longer supported so that they will know to stop sending orders for it. |
 | DiscoverNodes | [DiscoverNodesRequest](#xudrpc.DiscoverNodesRequest) | [DiscoverNodesResponse](#xudrpc.DiscoverNodesResponse) | Discover nodes from a specific peer and apply new connections |
 | Shutdown | [ShutdownRequest](#xudrpc.ShutdownRequest) | [ShutdownResponse](#xudrpc.ShutdownResponse) | Begin gracefully shutting down xud. |
-| SubscribeOrders | [SubscribeOrdersRequest](#xudrpc.SubscribeOrdersRequest) | [OrderUpdate](#xudrpc.OrderUpdate) | Subscribes to orders being added to and removed from the order book. This call allows the client to maintain an up-to-date view of the order book. For example, an exchange that wants to show its users a real time view of the orders available to them would subscribe to this streaming call to be alerted as new orders are added and expired orders are removed. |
-| SubscribeSwaps | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapSuccess](#xudrpc.SwapSuccess) | Subscribes to completed swaps. By default, only swaps that are initiated by a remote peer are transmitted unless a flag is set to include swaps initiated by the local node. This call allows the client to get real-time notifications when its orders are filled by a peer. It can be used for tracking order executions, updating balances, and informing a trader when one of their orders is settled through the Exchange Union network. |
-| SubscribeSwapFailures | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapFailure](#xudrpc.SwapFailure) | Subscribes to failed swaps. By default, only swaps that are initiated by a remote peer are transmitted unless a flag is set to include swaps initiated by the local node. This call allows the client to get real-time notifications when swap attempts are failing. It can be used for status monitoring, debugging, and testing purposes. |
+| SubscribeOrders | [SubscribeOrdersRequest](#xudrpc.SubscribeOrdersRequest) | [OrderUpdate](#xudrpc.OrderUpdate) stream | Subscribes to orders being added to and removed from the order book. This call allows the client to maintain an up-to-date view of the order book. For example, an exchange that wants to show its users a real time view of the orders available to them would subscribe to this streaming call to be alerted as new orders are added and expired orders are removed. |
+| SubscribeSwaps | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapSuccess](#xudrpc.SwapSuccess) stream | Subscribes to completed swaps. By default, only swaps that are initiated by a remote peer are transmitted unless a flag is set to include swaps initiated by the local node. This call allows the client to get real-time notifications when its orders are filled by a peer. It can be used for tracking order executions, updating balances, and informing a trader when one of their orders is settled through the Exchange Union network. |
+| SubscribeSwapFailures | [SubscribeSwapsRequest](#xudrpc.SubscribeSwapsRequest) | [SwapFailure](#xudrpc.SwapFailure) stream | Subscribes to failed swaps. By default, only swaps that are initiated by a remote peer are transmitted unless a flag is set to include swaps initiated by the local node. This call allows the client to get real-time notifications when swap attempts are failing. It can be used for status monitoring, debugging, and testing purposes. |
 
 
 <a name="xudrpc.XudInit"></a>

--- a/lib/cli/commands/unlock.ts
+++ b/lib/cli/commands/unlock.ts
@@ -1,6 +1,6 @@
 import { Arguments } from 'yargs';
 import { callback, loadXudInitClient } from '../command';
-import { UnlockNodeRequest } from '../../proto/xudrpc_pb';
+import { UnlockNodeRequest, UnlockNodeResponse } from '../../proto/xudrpc_pb';
 import readline from 'readline';
 
 export const command = 'unlock';
@@ -8,6 +8,16 @@ export const command = 'unlock';
 export const describe = 'unlock local xud node';
 
 export const builder = {};
+
+const formatOutput = (response: UnlockNodeResponse.AsObject) => {
+  console.log('xud was unlocked succesfully');
+  if (response.unlockedLndsList.length) {
+    console.log(`The following wallets were unlocked: ${response.unlockedLndsList.join(', ')}`);
+  }
+  if (response.lockedLndsList.length) {
+    console.log(`The following wallets could not be unlocked: ${response.lockedLndsList.join(', ')}`);
+  }
+};
 
 export const handler = (argv: Arguments) => {
   const rl = readline.createInterface({
@@ -24,7 +34,7 @@ export const handler = (argv: Arguments) => {
     const client = loadXudInitClient(argv);
     // wait up to 3 seconds for rpc server to listen before call in case xud was just started
     client.waitForReady(Date.now() + 3000, () => {
-      client.unlockNode(request, callback(argv));
+      client.unlockNode(request, callback(argv, formatOutput));
     });
   });
 };

--- a/lib/grpc/GrpcInitService.ts
+++ b/lib/grpc/GrpcInitService.ts
@@ -64,9 +64,10 @@ class GrpcInitService {
       return;
     }
     try {
-      const unlockedLndClients = await this.initService.unlockNode(call.request.toObject());
+      const unlockNodeResult = await this.initService.unlockNode(call.request.toObject());
       const response = new xudrpc.UnlockNodeResponse();
-      response.setUnlockedLndsList(unlockedLndClients);
+      response.setUnlockedLndsList(unlockNodeResult.unlockedLndClients);
+      response.setLockedLndsList(unlockNodeResult.lockedLndClients);
 
       callback(null, response);
     } catch (err) {

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -1529,6 +1529,13 @@
           "type": "boolean",
           "format": "boolean",
           "description": "Whether raiden was unlocked."
+        },
+        "locked_lnds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of lnd clients that could not be unlocked."
         }
       }
     }

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -90,6 +90,11 @@ export class UnlockNodeResponse extends jspb.Message {
     getUnlockedRaiden(): boolean;
     setUnlockedRaiden(value: boolean): void;
 
+    clearLockedLndsList(): void;
+    getLockedLndsList(): Array<string>;
+    setLockedLndsList(value: Array<string>): void;
+    addLockedLnds(value: string, index?: number): string;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): UnlockNodeResponse.AsObject;
@@ -105,6 +110,7 @@ export namespace UnlockNodeResponse {
     export type AsObject = {
         unlockedLndsList: Array<string>,
         unlockedRaiden: boolean,
+        lockedLndsList: Array<string>,
     }
 }
 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -618,7 +618,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.xudrpc.UnlockNodeResponse.repeatedFields_ = [1];
+proto.xudrpc.UnlockNodeResponse.repeatedFields_ = [1,3];
 
 
 
@@ -650,7 +650,8 @@ proto.xudrpc.UnlockNodeResponse.prototype.toObject = function(opt_includeInstanc
 proto.xudrpc.UnlockNodeResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     unlockedLndsList: jspb.Message.getRepeatedField(msg, 1),
-    unlockedRaiden: jspb.Message.getFieldWithDefault(msg, 2, false)
+    unlockedRaiden: jspb.Message.getFieldWithDefault(msg, 2, false),
+    lockedLndsList: jspb.Message.getRepeatedField(msg, 3)
   };
 
   if (includeInstance) {
@@ -695,6 +696,10 @@ proto.xudrpc.UnlockNodeResponse.deserializeBinaryFromReader = function(msg, read
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setUnlockedRaiden(value);
       break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addLockedLnds(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -735,6 +740,13 @@ proto.xudrpc.UnlockNodeResponse.serializeBinaryToWriter = function(message, writ
   if (f) {
     writer.writeBool(
       2,
+      f
+    );
+  }
+  f = message.getLockedLndsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      3,
       f
     );
   }
@@ -784,6 +796,35 @@ proto.xudrpc.UnlockNodeResponse.prototype.getUnlockedRaiden = function() {
 /** @param {boolean} value */
 proto.xudrpc.UnlockNodeResponse.prototype.setUnlockedRaiden = function(value) {
   jspb.Message.setProto3BooleanField(this, 2, value);
+};
+
+
+/**
+ * repeated string locked_lnds = 3;
+ * @return {!Array<string>}
+ */
+proto.xudrpc.UnlockNodeResponse.prototype.getLockedLndsList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 3));
+};
+
+
+/** @param {!Array<string>} value */
+proto.xudrpc.UnlockNodeResponse.prototype.setLockedLndsList = function(value) {
+  jspb.Message.setField(this, 3, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ */
+proto.xudrpc.UnlockNodeResponse.prototype.addLockedLnds = function(value, opt_index) {
+  jspb.Message.addToRepeatedField(this, 3, value, opt_index);
+};
+
+
+proto.xudrpc.UnlockNodeResponse.prototype.clearLockedLndsList = function() {
+  this.setLockedLndsList([]);
 };
 
 

--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -36,6 +36,7 @@ class InitService extends EventEmitter {
     }
 
     this.pendingCall = true;
+
     // wait briefly for all lnd instances to be available
     await this.swapClientManager.waitForLnd();
 
@@ -79,6 +80,9 @@ class InitService extends EventEmitter {
     }
 
     this.pendingCall = true;
+
+    // wait briefly for all lnd instances to be available
+    await this.swapClientManager.waitForLnd();
 
     const nodeKey = await NodeKey.fromFile(this.nodeKeyPath, password);
     this.emit('nodekey', nodeKey);

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -58,6 +58,8 @@ message UnlockNodeResponse {
   repeated string unlocked_lnds = 1;
   // Whether raiden was unlocked.
   bool unlocked_raiden = 2;
+  // The list of lnd clients that could not be unlocked.
+  repeated string locked_lnds = 3;
 }
 
 service Xud {


### PR DESCRIPTION
This adds a response parameter for the `UnlockNode` call to include a list of enabled wallets that could not be unlocked. It also uses the existing `waitForLnd` method to wait briefly for lnd clients to come online which will help ensure lnd gets unlocked in cases where it is started near simultaneously with xud. Finally it enhances the `xucli unlock` output.

Closes #1319.