### PR TITLE
refactor(db): addOrderIfNotExists

### DIFF
--- a/lib/orderbook/OrderBookRepository.ts
+++ b/lib/orderbook/OrderBookRepository.ts
@@ -36,13 +36,15 @@ class OrderbookRepository {
    * @returns the created order instance, or undefined if it already existed
    */
   public addOrderIfNotExists = async (order: db.OrderFactory) => {
-    const count = await this.models.Order.count({
-      where: { id: order.id },
-    });
-    if (count === 0) {
-      return this.models.Order.upsert(order);
-    } else {
-      return undefined;
+    try {
+      const createdOrder = await this.models.Order.create(order);
+      return createdOrder;
+    } catch (err) {
+      if (err.name === 'SequelizeUniqueConstraintError') {
+        return undefined;
+      } else {
+        throw err;
+      }
     }
   }
 

--- a/test/unit/DB.spec.ts
+++ b/test/unit/DB.spec.ts
@@ -135,8 +135,8 @@ describe('Database', () => {
     const sellMarketOrder = createOwnOrder(0, quantity, true);
     await orderBookRepo.addOrderIfNotExists(buyMarketOrder);
     await orderBookRepo.addOrderIfNotExists(sellMarketOrder);
-    const buyOrder = (await db.models.Order.findById(buyMarketOrder.id))!;
-    const sellOrder = (await db.models.Order.findById(sellMarketOrder.id))!;
+    const buyOrder = (await db.models.Order.findByPk(buyMarketOrder.id))!;
+    const sellOrder = (await db.models.Order.findByPk(sellMarketOrder.id))!;
     expect(buyOrder.id).to.equal(buyMarketOrder.id);
     expect(sellOrder.id).to.equal(sellMarketOrder.id);
     expect(buyOrder.price).to.be.null;


### PR DESCRIPTION
This refactors the `addOrderIfNotExists` method to correctly follow its behavior in the method comments by returning the created node and to use only a single db query.