### PR TITLE
feat(rpc): add only_own_orders parameter for listorders

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -492,6 +492,7 @@
 | ----- | ---- | ----- | ----------- |
 | pair_id | [string](#string) |  | The trading pair for which to retrieve orders. |
 | include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not. |
+| only_own_orders | [bool](#bool) |  | Whether to return only own orders. |
 | limit | [uint32](#uint32) |  | The maximum number of orders to return from each side of the order book. |
 
 

--- a/lib/cli/commands/listorders.ts
+++ b/lib/cli/commands/listorders.ts
@@ -78,7 +78,7 @@ const displayTables = (orders: ListOrdersResponse.AsObject) => {
   formatOrders(orders).forEach(displayOrdersTable);
 };
 
-export const command = 'listorders [pair_id] [include_own_orders] [limit]';
+export const command = 'listorders [pair_id] [include_own_orders] [only_own_orders] [limit]';
 
 export const describe = 'list orders from the order book';
 
@@ -92,6 +92,11 @@ export const builder = {
     type: 'boolean',
     default: true,
   },
+  only_own_orders: {
+    describe: 'whether to return only own orders',
+    type: 'boolean',
+    default: false,
+  },
   limit: {
     describe: 'max number of orders to return',
     type: 'number',
@@ -104,6 +109,7 @@ export const handler = (argv: Arguments<any>) => {
   const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
   request.setPairId(pairId);
   request.setIncludeOwnOrders(argv.include_own_orders);
+  request.setOnlyOwnOrders(argv.only_own_orders);
   request.setLimit(argv.limit);
   loadXudClient(argv).listOrders(request, callback(argv, displayTables));
 };

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -335,6 +335,14 @@
             "format": "boolean"
           },
           {
+            "name": "only_own_orders",
+            "description": "Whether to return only own orders.",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "format": "boolean"
+          },
+          {
             "name": "limit",
             "description": "The maximum number of orders to return from each side of the order book.",
             "in": "query",

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -651,6 +651,9 @@ export class ListOrdersRequest extends jspb.Message {
     getIncludeOwnOrders(): boolean;
     setIncludeOwnOrders(value: boolean): void;
 
+    getOnlyOwnOrders(): boolean;
+    setOnlyOwnOrders(value: boolean): void;
+
     getLimit(): number;
     setLimit(value: number): void;
 
@@ -669,6 +672,7 @@ export namespace ListOrdersRequest {
     export type AsObject = {
         pairId: string,
         includeOwnOrders: boolean,
+        onlyOwnOrders: boolean,
         limit: number,
     }
 }

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -4413,7 +4413,8 @@ proto.xudrpc.ListOrdersRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     pairId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     includeOwnOrders: jspb.Message.getFieldWithDefault(msg, 2, false),
-    limit: jspb.Message.getFieldWithDefault(msg, 3, 0)
+    onlyOwnOrders: jspb.Message.getFieldWithDefault(msg, 3, false),
+    limit: jspb.Message.getFieldWithDefault(msg, 4, 0)
   };
 
   if (includeInstance) {
@@ -4459,6 +4460,10 @@ proto.xudrpc.ListOrdersRequest.deserializeBinaryFromReader = function(msg, reade
       msg.setIncludeOwnOrders(value);
       break;
     case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setOnlyOwnOrders(value);
+      break;
+    case 4:
       var value = /** @type {number} */ (reader.readUint32());
       msg.setLimit(value);
       break;
@@ -4505,10 +4510,17 @@ proto.xudrpc.ListOrdersRequest.serializeBinaryToWriter = function(message, write
       f
     );
   }
+  f = message.getOnlyOwnOrders();
+  if (f) {
+    writer.writeBool(
+      3,
+      f
+    );
+  }
   f = message.getLimit();
   if (f !== 0) {
     writer.writeUint32(
-      3,
+      4,
       f
     );
   }
@@ -4548,17 +4560,34 @@ proto.xudrpc.ListOrdersRequest.prototype.setIncludeOwnOrders = function(value) {
 
 
 /**
- * optional uint32 limit = 3;
+ * optional bool only_own_orders = 3;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.xudrpc.ListOrdersRequest.prototype.getOnlyOwnOrders = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 3, false));
+};
+
+
+/** @param {boolean} value */
+proto.xudrpc.ListOrdersRequest.prototype.setOnlyOwnOrders = function(value) {
+  jspb.Message.setProto3BooleanField(this, 3, value);
+};
+
+
+/**
+ * optional uint32 limit = 4;
  * @return {number}
  */
 proto.xudrpc.ListOrdersRequest.prototype.getLimit = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
 };
 
 
 /** @param {number} value */
 proto.xudrpc.ListOrdersRequest.prototype.setLimit = function(value) {
-  jspb.Message.setProto3IntField(this, 3, value);
+  jspb.Message.setProto3IntField(this, 4, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -325,8 +325,10 @@ class Service {
   /**
    * Get a map between pair ids and its orders from the order book.
    */
-  public listOrders = (args: { pairId: string, includeOwnOrders: boolean, limit: number }): Map<string, OrderSidesArrays<any>> => {
-    const { pairId, includeOwnOrders, limit } = args;
+  public listOrders = (
+    args: { pairId: string, includeOwnOrders: boolean, onlyOwnOrders: boolean, limit: number },
+    ): Map<string, OrderSidesArrays<any>> => {
+    const { pairId, includeOwnOrders, onlyOwnOrders, limit } = args;
 
     const result = new Map<string, OrderSidesArrays<any>>();
 
@@ -336,9 +338,11 @@ class Service {
         sellArray: [],
       };
 
-      const peerOrders = this.orderBook.getPeersOrders(pairId);
-      orders.buyArray = peerOrders.buyArray;
-      orders.sellArray = peerOrders.sellArray;
+      if (!onlyOwnOrders) {
+        const peerOrders = this.orderBook.getPeersOrders(pairId);
+        orders.buyArray = peerOrders.buyArray;
+        orders.sellArray = peerOrders.sellArray;
+      }
 
       if (includeOwnOrders) {
         const ownOrders = this.orderBook.getOwnOrders(pairId);
@@ -353,7 +357,7 @@ class Service {
 
       if (limit > 0) {
         orders.buyArray = orders.buyArray.slice(0, limit);
-        orders.sellArray = orders.buyArray.slice(0, limit);
+        orders.sellArray = orders.sellArray.slice(0, limit);
       }
       return orders;
     };

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -432,8 +432,10 @@ message ListOrdersRequest {
   string pair_id = 1 [json_name = "pair_id"];
   // Whether own orders should be included in result or not.
   bool include_own_orders = 2 [json_name = "include_own_orders"];
+  // Whether to return only own orders.
+  bool only_own_orders = 3 [json_name = "only_own_orders"];
   // The maximum number of orders to return from each side of the order book.
-  uint32 limit = 3 [json_name = "limit"];
+  uint32 limit = 4 [json_name = "limit"];
 }
 message ListOrdersResponse {
   // A map between pair ids and their buy and sell orders.

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -88,6 +88,7 @@ describe('API Service', () => {
     const args = {
       pairId,
       includeOwnOrders: true,
+      onlyOwnOrders: false,
       limit: 0,
     };
     const orders = service.listOrders(args);


### PR DESCRIPTION
This commit adds an optional `only_own_orders` parameter for the `listorders` command.
The default value for this is `false`.

The commit also fixes a bug that caused a situation where sell orders were displayed instead of buy orders when the limit was set.

Closes #1323