### PR TITLE
test(simulation): extend context wait time

### DIFF
--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -253,13 +253,13 @@ func (hn *HarnessNode) ConnectRPC(useMacs bool) (*grpc.ClientConn, error) {
 	}
 
 	tlsCreds, err := credentials.NewClientTLSFromFile(hn.Cfg.TLSCertPath, "")
-	for tries := 3; tries > 0; tries-- {
+	for tries := 5; tries > 0; tries-- {
 		if err == nil {
-		    break;
+			break
 		}
 
 		fmt.Printf("Failed to read TLS certificate: %v, remaining tries: %v\n", err, tries-1)
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 		tlsCreds, err = credentials.NewClientTLSFromFile(hn.Cfg.TLSCertPath, "")
 	}
 


### PR DESCRIPTION
This further extends the wait before the context times out to prevent test flakiness.

Testing this on Travis has had pretty good results so far.