### PR TITLE
refactor(p2p): check socket on send

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -356,8 +356,8 @@ class Peer extends EventEmitter {
   }
 
   public sendPacket = async (packet: Packet): Promise<void> => {
+    const data = await this.framer.frame(packet, this.outEncryptionKey);
     if (this.socket && !this.socket.destroyed) {
-      const data = await this.framer.frame(packet, this.outEncryptionKey);
       try {
         this.socket.write(data);
         this.logger.trace(`Sent ${PacketType[packet.type]} packet to ${this.label}: ${JSON.stringify(packet)}`);


### PR DESCRIPTION
This refactors the code to send packets to peers to check if a socket exists immediately before transmitting. It prevents edge case errors where a socket is destroyed immediately before transmission while the packet data is being framed.