### PR TITLE
 feat: disable raiden currencies w/out direct chan 

### DIFF
--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -135,6 +135,8 @@ export enum SwapFailureReason {
   RemoteError = 13,
   /** The swap failed because of a system or xud crash while the swap was being executed. */
   Crash = 14,
+  /** A swap was attempted between an invalid matching of orders */
+  InvalidOrders = 15,
 }
 
 export enum DisconnectionReason {

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1080,7 +1080,7 @@ class Swaps extends EventEmitter {
         // something is wrong with swaps for this currency with this peer
         if (failedCurrency) {
           try {
-            this.pool.getPeer(deal.peerPubKey).disableCurrency(failedCurrency);
+            this.pool.getPeer(deal.peerPubKey).deactivateCurrency(failedCurrency);
           } catch (err) {
             this.logger.debug(`could not disable currency ${failedCurrency} for peer ${deal.peerPubKey}`);
           }

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -30,7 +30,6 @@ const getMockPool = (sandbox: sinon.SinonSandbox) => {
 
 const getMockSwaps = (sandbox: sinon.SinonSandbox) => {
   const swaps = sandbox.createStubInstance(Swaps) as any;
-  swaps.isPairSupported = () => true;
   const lndBTC = sandbox.createStubInstance(LndClient) as any;
   const lndLTC = sandbox.createStubInstance(LndClient) as any;
   swaps.swapClientManager = sandbox.createStubInstance(SwapClientManager) as any;

--- a/test/integration/Swaps.spec.ts
+++ b/test/integration/Swaps.spec.ts
@@ -185,13 +185,13 @@ describe('Swaps.Integration', () => {
         pairId: INVALID_PAIR_ID,
       };
       expect(swaps.executeSwap(invalidMakerOrder, validTakerOrder()))
-        .to.eventually.be.rejected.and.equal(SwapFailureReason.SwapClientNotSetup);
+        .to.eventually.be.rejected.and.equal(SwapFailureReason.InvalidOrders);
       const invalidTakerOrder = {
         ...validTakerOrder(),
         pairId: INVALID_PAIR_ID,
       };
       expect(swaps.executeSwap(validMakerOrder(), invalidTakerOrder))
-        .to.eventually.be.rejected.and.equal(SwapFailureReason.SwapClientNotSetup);
+        .to.eventually.be.rejected.and.equal(SwapFailureReason.InvalidOrders);
     });
 
     it('will reject if unable to retrieve routes', async () => {

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -44,6 +44,7 @@ jest.mock('../../lib/db/DB', () => {
 });
 const advertisedPairs = ['LTC/BTC', 'WETH/BTC'];
 const mockActivatePair = jest.fn();
+const mockActivateCurrency = jest.fn();
 const mockGetIdentifier = jest.fn(() => 'pubkeyoraddress');
 const tokenIdentifiers: any = {
   BTC: 'bitcoin-regtest',
@@ -52,11 +53,17 @@ const tokenIdentifiers: any = {
 const mockPeerGetTokenIdentifer = jest.fn((currency: string) => tokenIdentifiers[currency]);
 jest.mock('../../lib/p2p/Peer', () => {
   return jest.fn().mockImplementation(() => {
+    let currencyActive = false;
     return {
       advertisedPairs,
       activatePair: mockActivatePair,
+      activateCurrency: (currency: string) => {
+        mockActivateCurrency(currency);
+        currencyActive = true;
+      },
       disabledCurrencies: new Map(),
       isPairActive: () => false,
+      isCurrencyActive: () => currencyActive,
       getTokenIdentifier: mockPeerGetTokenIdentifer,
       getIdentifier: mockGetIdentifier,
     };
@@ -73,7 +80,14 @@ jest.mock('../../lib/p2p/Pool', () => {
   });
 });
 jest.mock('../../lib/swaps/Swaps');
-jest.mock('../../lib/swaps/SwapClientManager');
+jest.mock('../../lib/swaps/SwapClientManager', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      // temporary mock while raiden direct channel checks are required
+      hasRouteToPeer: jest.fn().mockReturnValue(true),
+    };
+  });
+});
 jest.mock('../../lib/Logger');
 jest.mock('../../lib/nodekey/NodeKey');
 const mockedNodeKey = <jest.Mock<NodeKey>><any>NodeKey;
@@ -149,9 +163,13 @@ describe('OrderBook', () => {
   test('nosanityswaps enabled adds pairs and requests orders', async () => {
     orderbook['nosanityswaps'] = true;
     await orderbook['verifyPeerPairs'](peer);
+    expect(mockActivateCurrency).toHaveBeenCalledTimes(3);
+    expect(mockActivateCurrency).toHaveBeenCalledWith('BTC');
+    expect(mockActivateCurrency).toHaveBeenCalledWith('LTC');
+    expect(mockActivateCurrency).toHaveBeenCalledWith('WETH');
     expect(mockActivatePair).toHaveBeenCalledTimes(2);
-    expect(mockActivatePair).toHaveBeenCalledWith(advertisedPairs[0], expect.any(Number), expect.anything());
-    expect(mockActivatePair).toHaveBeenCalledWith(advertisedPairs[1], expect.any(Number), expect.anything());
+    expect(mockActivatePair).toHaveBeenCalledWith(advertisedPairs[0]);
+    expect(mockActivatePair).toHaveBeenCalledWith(advertisedPairs[1]);
   });
 
   test('isPeerCurrencySupported returns true for a known currency with matching identifiers', async () => {

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -212,7 +212,6 @@ describe('OrderBook', () => {
       price: 0.01,
       isBuy: false,
     };
-    swaps.isPairSupported = jest.fn().mockReturnValue(true);
     swaps.swapClientManager.get = jest.fn().mockReturnValue({
       maximumOutboundCapacity: () => quantity,
     });
@@ -229,7 +228,6 @@ describe('OrderBook', () => {
       price: 0.01,
       isBuy: false,
     };
-    swaps.isPairSupported = jest.fn().mockReturnValue(true);
     swaps.swapClientManager.get = jest.fn().mockReturnValue({
       maximumOutboundCapacity: () => quantity,
     });


### PR DESCRIPTION
Closes #1027.

This PR attempts to ensure that we have a direct channel with peers for raiden currencies before exchanging orders with that peer for any pairs involving that currency.

When a peer advertises a trading pair, either via initial handshake or on a node state update, we check that we have a direct channel for any raiden currencies before activating advertised pairs. If the trading pair is not activated, then we do not send or accept orders for that pair with the peer.

An existing timer with an interval of one minute is used for each peer to periodically check if inactive currencies and pairs can be activated by performing the same checks described above, including the direct channel check for raiden currencies.

It also reworks the error handling logic for swaps to identify a particular currency that caused the error when applicable. This allows us to deactivate that currency, such that if a swap fails due to `NoRouteFound` (meaning no direct channel) with a raiden currency we can disable that currency right away.

Some examples of how this logic may work:

1. Handshake with peer advertises BTC/WETH
2. A direct channel is not found for WETH
3. BTC/WETH is disabled, no orders are broadcasted to the peer or accepted from that peer to the order book.
4. Later, a direct channel for WETH is opened and the periodic check detects it.
5. BTC/WETH is enabled, a `GetOrders` packet is sent for BTC/WETH, and new orders are transmitted as they arrive.

or

1. Handshake with peer advertises BTC/WETH.
2. A direct channel is found for WETH
3. A `GetOrders` packet is sent for BTC/WETH, and new orders are transmitted as they arrive.
4. A WETH payment fails due to `NoRouteFound` (meaning no direct channel).
5. BTC/WETH is disabled for that peer, all existing orders from that peer are removed from the order book and new orders are no longer broadcast or accepted.