### PR TITLE
feat(config): add maxlimits options

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -47,6 +47,11 @@ const { argv } = require('yargs')
       type: 'boolean',
       default: undefined,
     },
+    maxlimits: {
+      describe: 'Whether to use max channel sizes as trading limits',
+      type: 'boolean',
+      default: undefined,
+    },
     noencrypt: {
       describe: 'Whether to disable nodekey encryption',
       type: 'boolean',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -33,7 +33,8 @@ class Config {
   public nomatching = false;
   /** Whether a password should not be used to encrypt the xud key and underlying wallets. */
   public noencrypt = true; // TODO: enable encryption by default
-
+  /** Whether to use the maximum network channel sizes as trading limits. */
+  public maxlimits = false;
   /**
    * Whether to disable sanity swaps that verify that the orders can possibly be swapped
    * before adding trading pairs as active.

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -166,6 +166,7 @@ class Xud extends EventEmitter {
         swaps: this.swaps,
         nosanityswaps: this.config.nosanityswaps,
         nobalancechecks: this.config.nobalancechecks,
+        maxlimits: this.config.maxlimits,
       });
       initPromises.push(this.orderBook.init());
 

--- a/lib/constants/limits.ts
+++ b/lib/constants/limits.ts
@@ -1,9 +1,15 @@
-/** Order size limits denominated in satoshis. */
-const limits: { [currency: string]: number } = {
+/** Mainnet order size limits denominated in satoshis. */
+export const limits: { [currency: string]: number }  = {
   BTC: 100000,
   LTC: 15000000,
   WETH: 5000000,
   DAI: 1000000000,
 };
 
-export default limits;
+/** The maximum network channel sizes for each currency denominated in satoshis. */
+export const maxLimits: { [currency: string]: number } = {
+  BTC: 16777216, // 4294967 sat payment limit lifted as of 2019
+  LTC: 16777216 * 60, // lnd uses fixed 60 to 1 btc conversion rate
+  WETH: 11579208923731619542357098500868790785326998466564056403945758400791,
+  DAI: 11579208923731619542357098500868790785326998466564056403945758400791,
+};

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -73,7 +73,7 @@ const errors = {
     code: errorCodes.MIN_QUANTITY_VIOLATED,
   }),
   EXCEEDING_LIMIT: (currency: string, amount: number, limit: number) => ({
-    message: `outbound amount ${amount} is exceeding limit of ${limit} set for ${currency}`,
+    message: `order amount ${amount} is exceeding limit of ${limit} set for ${currency}`,
     code: errorCodes.EXCEEDING_LIMIT,
   }),
   QUANTITY_ON_HOLD: (localId: string, holdQuantity: number) => ({

--- a/sample-xud.conf
+++ b/sample-xud.conf
@@ -32,6 +32,7 @@ initdb = true
 instanceid = 0
 logdateformat = "DD/MM/YYYY HH:mm:ss.SSS"
 loglevel = "debug"
+maxlimits = false
 network = "simnet"
 nobalancechecks = false
 noencrypt = true

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -150,7 +150,7 @@ describe('OrderBook', () => {
   });
 
   it('should not add a new own order with a duplicated localId', async () => {
-    const order: orders.OwnOrder = createOwnOrder(100, 10, false);
+    const order: orders.OwnOrder = createOwnOrder(0.01, 10, false);
 
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 
@@ -167,13 +167,13 @@ describe('OrderBook', () => {
 
   it('should place order with quantity higher than min quantity', async () => {
     orderBook['thresholds'] = { minQuantity : 10000 };
-    const order: orders.OwnOrder = createOwnOrder(100, 1000000, false);
+    const order: orders.OwnOrder = createOwnOrder(0.01, 1000000, false);
 
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
   });
 
   it('should throw error if the order quantity exceeds min quantity', async () => {
-    const order: orders.OwnOrder = createOwnOrder(100, 100, false);
+    const order: orders.OwnOrder = createOwnOrder(0.01, 100, false);
 
     await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
   });
@@ -217,37 +217,37 @@ describe('nomatching OrderBook', () => {
   });
 
   it('should should not accept market orders', () => {
-    const order = createOwnOrder(100, 10, true);
+    const order = createOwnOrder(0.01, 10, true);
     expect(orderBook.placeMarketOrder(order)).to.be.rejected;
   });
 
   it('should accept but not match limit orders', async () => {
-    const buyOrder = createOwnOrder(100, 10, true);
+    const buyOrder = createOwnOrder(0.01, 10, true);
     const buyOrderResult = await orderBook.placeLimitOrder(buyOrder);
     expect(buyOrderResult.remainingOrder!.localId).to.be.equal(buyOrder.localId);
     expect(buyOrderResult.remainingOrder!.quantity).to.be.equal(buyOrder.quantity);
 
-    const sellOrder = createOwnOrder(100, 10, false);
+    const sellOrder = createOwnOrder(0.01, 10, false);
     const sellOrderResult = await orderBook.placeLimitOrder(sellOrder);
     expect(sellOrderResult.remainingOrder!.localId).to.be.equal(sellOrder.localId);
     expect(sellOrderResult.remainingOrder!.quantity).to.be.equal(sellOrder.quantity);
   });
 
   it('should not place the same order twice', async () => {
-    const order = createOwnOrder(100, 10, true);
+    const order = createOwnOrder(0.01, 10, true);
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
     await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
   });
 
   it('should not remove the same order twice', async () => {
-    const order = createOwnOrder(100, 10, true);
+    const order = createOwnOrder(0.01, 10, true);
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
   });
 
   it('should allow own order partial removal, but should not find the order localId after it was fully removed', async () => {
-    const order = createOwnOrder(100, 10, true);
+    const order = createOwnOrder(0.01, 10, true);
     const { remainingOrder } = await orderBook.placeLimitOrder(order);
 
     orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 1);
@@ -257,7 +257,7 @@ describe('nomatching OrderBook', () => {
   });
 
   it('should allow own order partial removal, but should not find the order id after it was fully removed', async () => {
-    const order = createOwnOrder(100, 10, true);
+    const order = createOwnOrder(0.01, 10, true);
     const { remainingOrder } = await orderBook.placeLimitOrder(order);
 
     orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 1);

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -235,11 +235,11 @@ describe('TradingPair.removePeerOrders', () => {
     const firstPeerPubKey = '026a848ebd1792001ff10c6e212f6077aec5669af3de890e1ae196b4e9730d75b9';
     const secondPeerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345';
 
-    const firstHostOrders = [createPeerOrder(100, 5, false, ms(), firstPeerPubKey),
-      createPeerOrder(100, 5, false, ms(), firstPeerPubKey)];
+    const firstHostOrders = [createPeerOrder(0.01, 5, false, ms(), firstPeerPubKey),
+      createPeerOrder(0.01, 5, false, ms(), firstPeerPubKey)];
     tp.addPeerOrder(firstHostOrders[0]);
     tp.addPeerOrder(firstHostOrders[1]);
-    tp.addPeerOrder(createPeerOrder(100, 5, false, ms(), secondPeerPubKey));
+    tp.addPeerOrder(createPeerOrder(0.01, 5, false, ms(), secondPeerPubKey));
     expect(tp.getPeersOrders().sellArray.length).to.equal(3);
 
     const removedOrders = tp.removePeerOrders(firstPeerPubKey);
@@ -248,7 +248,7 @@ describe('TradingPair.removePeerOrders', () => {
     expect(tp.queues!.sellQueue.size).to.equal(1);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const matchingResult = tp.match(createOwnOrder(100, 15, true));
+    const matchingResult = tp.match(createOwnOrder(0.01, 15, true));
     expect(matchingResult.remainingOrder).to.not.be.undefined;
     expect(matchingResult.remainingOrder!.quantity).to.equal(10);
   });
@@ -287,7 +287,7 @@ describe('TradingPair queues and maps integrity', () => {
   beforeEach(init);
 
   it('queue and map should both remove an own order', () => {
-    const ownOrder = createOwnOrder(100, 10, false);
+    const ownOrder = createOwnOrder(0.01, 10, false);
     tp.addOwnOrder(ownOrder);
     expect(tp.ownOrders.sellMap.size).to.equal(1);
     expect(tp.queues!.sellQueue.size).to.be.equal(1);
@@ -297,7 +297,7 @@ describe('TradingPair queues and maps integrity', () => {
   });
 
   it('queue and map should both remove a peer order', () => {
-    const peerOrder = createPeerOrder(100, 10, false);
+    const peerOrder = createPeerOrder(0.01, 10, false);
     tp['addPeerOrder'](peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
     expect(tp.queues!.sellQueue.size).to.be.equal(1);
@@ -308,7 +308,7 @@ describe('TradingPair queues and maps integrity', () => {
   });
 
   it('queue and map should have the same order instance after a partial peer order removal', () => {
-    const peerOrder = createPeerOrder(100, 10, false, ms());
+    const peerOrder = createPeerOrder(0.01, 10, false, ms());
     tp.addPeerOrder(peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
@@ -323,11 +323,11 @@ describe('TradingPair queues and maps integrity', () => {
   });
 
   it('queue and map should have the same order instance after a partial match / maker order split', () => {
-    const peerOrder = createPeerOrder(100, 10, false, ms());
+    const peerOrder = createPeerOrder(0.01, 10, false, ms());
     tp.addPeerOrder(peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const ownOrder = createOwnOrder(100, 3, true);
+    const ownOrder = createOwnOrder(0.01, 3, true);
     const matchingResult = tp.match(ownOrder);
     expect(matchingResult.remainingOrder).to.be.undefined;
 
@@ -338,11 +338,11 @@ describe('TradingPair queues and maps integrity', () => {
   });
 
   it('queue and map should both have the maker order removed after a full match', () => {
-    const peerOrder = createPeerOrder(100, 10, false, ms());
+    const peerOrder = createPeerOrder(0.01, 10, false, ms());
     tp.addPeerOrder(peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const ownOrder = createOwnOrder(100, 10, true);
+    const ownOrder = createOwnOrder(0.01, 10, true);
     const matchingResult = tp.match(ownOrder);
     expect(matchingResult.remainingOrder).to.be.undefined;
 


### PR DESCRIPTION
This adds a new `maxlimits` config option that overrides the hardcoded mainnet limits when set to true. In place of the mainnet limits, the maximum channel size for a currency's respective network is used as the maximum order size. These higher limits are now also enforced on non-mainnet networks regardless of the `maxlimits` value.

Closes #1304.