### PR TITLE
refactor(cli): handle stream error event

### DIFF
--- a/lib/cli/commands/streamorders.ts
+++ b/lib/cli/commands/streamorders.ts
@@ -51,7 +51,7 @@ const streamOrders = (argv: Arguments<any>) =>  {
   // since they'll be thrown for three of subscriptions in the corresponding cases, catching once is enough.
   ordersSubscription.on('end', reconnect.bind(undefined, argv));
   ordersSubscription.on('error', (err: Error) => {
-    console.log(`Unexpected error occured: ${JSON.stringify(err)}, trying to reconnect`);
+    console.warn(`Unexpected error occured: ${err.message}, trying to reconnect`);
     ensureConnection(argv);
   });
 

--- a/lib/cli/placeorder.ts
+++ b/lib/cli/placeorder.ts
@@ -95,6 +95,10 @@ export const placeOrderHandler = (argv: Arguments<any>, side: OrderSide) => {
         console.log('no matches found');
       }
     });
+    subscription.on('error', (err) => {
+      process.exitCode = 1;
+      console.error(err.message);
+    });
   } else {
     loadXudClient(argv).placeOrderSync(request, callback(argv, formatPlaceOrderOutput));
   }


### PR DESCRIPTION
This sets a handler for the error event with streaming gRPC calls to explicitly set the exit code to 1 and log a tidier message, similar to what we do with regular request/response calls.