### PR TITLE
fix(rpc/lnd): lnd already unlocked

### DIFF
--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -263,7 +263,8 @@ class SwapClientManager extends EventEmitter {
             swapClient.logger.debug(`could not unlock wallet: ${err.message}`);
           });
           unlockWalletPromises.push(unlockWalletPromise);
-        } else if (!swapClient.isDisconnected()) {
+        } else if (swapClient.isDisconnected() || swapClient.isMisconfigured() || swapClient.isNotInitialized()) {
+          // if the swap client is not connected, we treat it as locked since lnd will likely be locked when it comes online
           lockedLndClients.push(swapClient.currency);
         }
       }


### PR DESCRIPTION
This fixes the clients that get added to the `lockedLnd` list in the `UnlockNode` response. Previously, lnd clients that were already unlocked were added to this list. This makes it so those are not added, instead only clients where the unlock call fails or those where the call can't be made are added to the list.