### PR TITLE
feat: use seedutil to generate mnemonic

### DIFF
--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import NodeKey from '../nodekey/NodeKey';
 import swapErrors from '../swaps/errors';
 import SwapClientManager from '../swaps/SwapClientManager';
-import { decipher } from '../utils/seedutil';
+import { decipher, generate } from '../utils/seedutil';
 import errors from './errors';
 
 interface InitService {
@@ -32,7 +32,7 @@ class InitService extends EventEmitter {
     await this.prepareCall();
 
     try {
-      const seedMnemonic = await this.swapClientManager.genSeed();
+      const seedMnemonic = await generate();
 
       // we use the deciphered seed (without the salt and extra fields that make up the enciphered seed)
       // to generate an xud nodekey from the same seed used for wallets

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
 import { EventEmitter } from 'events';
+import { promises as fs } from 'fs';
 import Config from '../Config';
 import { SwapClientType } from '../constants/enums';
 import { Models } from '../db/DB';
@@ -149,28 +149,6 @@ class SwapClientManager extends EventEmitter {
     } catch (currency) {
       throw lndErrors.UNAVAILABLE(currency, ClientStatus.Disconnected);
     }
-  }
-
-  /**
-   * Generates a cryptographically random 24 word seed mnemonic from an lnd client.
-   */
-  public genSeed = async () => {
-    const lndClients = this.getLndClientsMap().values();
-    // loop through swap clients until we find an lnd client awaiting unlock
-    for (const lndClient of lndClients) {
-      if (lndClient.isWaitingUnlock()) {
-        try {
-          const seed = await lndClient.genSeed();
-          return seed;
-        } catch (err) {
-          lndClient.logger.error('could not generate seed', err);
-        }
-      }
-    }
-
-    // TODO: use seedutil tool to generate a seed instead of throwing error
-    // when we can't generate one with lnd
-    throw errors.SWAP_CLIENT_WALLET_NOT_CREATED('could not generate aezeed');
   }
 
   /**

--- a/lib/utils/seedutil.ts
+++ b/lib/utils/seedutil.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { exec as childProcessExec } from 'child_process';
 import { promisify } from 'util';
 
@@ -49,4 +50,16 @@ async function decipher(mnemonic: string[]) {
   return Buffer.from(decipheredSeed, 'hex');
 }
 
-export { keystore, encipher, decipher };
+async function generate() {
+  const { stdout, stderr } = await exec('./seedutil/seedutil generate');
+
+  if (stderr) {
+    throw new Error(stderr);
+  }
+
+  const mnemonic = stdout.trim().split(' ');
+  assert.equal(mnemonic.length, 24, 'seedutil did not generate mnemonic of exactly 24 words');
+  return mnemonic;
+}
+
+export { keystore, encipher, decipher, generate };

--- a/seedutil/SeedUtil.spec.ts
+++ b/seedutil/SeedUtil.spec.ts
@@ -132,6 +132,17 @@ describe('SeedUtil decipher', () => {
   });
 });
 
+describe('SeedUtil generate', () => {
+  test('it prints a 24 word mnemonic which can be deciphered', async () => {
+    const cmd = './seedutil/seedutil generate';
+    const mnemonic = await executeCommand(cmd);
+    expect(mnemonic.split(' ')).toHaveLength(24);
+
+    const cmd2 = `./seedutil/seedutil decipher ${mnemonic}`;
+    await executeCommand(cmd2);
+  });
+});
+
 describe('SeedUtil keystore', () => {
   beforeEach(async () => {
     await deleteDir(DEFAULT_KEYSTORE_PATH);


### PR DESCRIPTION
This changes adds the functionality to seedutil to generate a random 24 word mnemonic, which then replaces lnd for the purposes of generating the seed and mnemonic for a new xud node. This removes a dependency and allows xud to create a node without the help of lnd.

Closes #1253.