### PR TITLE
refactor: set swap client disconnected on timeout

### DIFF
--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -125,9 +125,10 @@ abstract class SwapClient extends EventEmitter {
     // don't wait longer than the allotted time for the connection to
     // be verified to prevent initialization from hanging
     return new Promise<void>((resolve, reject) => {
-      const verifyTimeout = setTimeout(() => {
+      const verifyTimeout = setTimeout(async () => {
         // we could not verify the connection within the allotted time
         this.logger.info(`could not verify connection within initialization time limit of ${SwapClient.INITIALIZATION_TIME_LIMIT}`);
+        await this.setStatus(ClientStatus.Disconnected);
         resolve();
       }, SwapClient.INITIALIZATION_TIME_LIMIT);
       this.verifyConnection().then(() => {


### PR DESCRIPTION
This explicitly sets the status of a swap client to `Disconnected` after time runs out for the initial connection verification of a swap client. Since we wait to make a call until a swap client is "ready" - which means the grpc client `waitForReady` method finishes in the case of lnd - we won't experience a failed call right away in cases where lnd is simply offline. This means the status would remain at `Initialized` when `Disconnected` is more accurate - at that point we should treat lnd as if it is offline.