### PR TITLE
feat(cli): better messages when unlock/create fail

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -137,7 +137,7 @@ class Xud extends EventEmitter {
         throw new Error('rpc server cannot be disabled when xud is locked');
       }
       if (this.rpcServer) {
-        this.rpcServer.grpcInitService.disabled = true;
+        this.rpcServer.grpcInitService.disable();
       }
 
       this.logger.info(`Local nodePubKey is ${nodeKey.pubKey}`);

--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -39,7 +39,13 @@ export const callback = (argv: Arguments, formatOutput?: Function, displayJson?:
           console.error(`could not connect to xud at ${argv.rpchost}:${argv.rpcport}, is xud running?`);
         }
       } else if (error.code === status.UNIMPLEMENTED && error.message.includes('xud is locked')) {
-        console.error("xud is locked, run 'xucli unlock' or 'xucli create' then try again");
+        console.error("xud is locked, run 'xucli unlock', 'xucli create', or 'xucli restore' then try again");
+      } else if (error.code === status.UNIMPLEMENTED && error.message.includes('xud node cannot be created because it already exists')) {
+        console.error("an xud node already exists, try unlocking it with 'xucli unlock'");
+      } else if (error.code === status.UNIMPLEMENTED && error.message.includes('xud node cannot be unlocked because it does not exist')) {
+        console.error("no xud node exists to unlock, try creating one with 'xucli create' or 'xucli restore'");
+      } else if (error.code === status.UNIMPLEMENTED && error.message.includes('xud init service is disabled')) {
+        console.error("xud is running and unlocked, try checking its status with 'xucli getinfo'");
       } else {
         console.error(`${error.name}: ${error.message}`);
       }

--- a/lib/grpc/GrpcInitService.ts
+++ b/lib/grpc/GrpcInitService.ts
@@ -5,13 +5,19 @@ import * as xudrpc from '../proto/xudrpc_pb';
 import getGrpcError from './getGrpcError';
 
 class GrpcInitService {
-  public disabled = false;
+  private disabled = false;
   private initService?: InitService;
 
   constructor() {}
 
-  public setInitService(initService: InitService) {
+  public setInitService = (initService: InitService) => {
     this.initService = initService;
+  }
+
+  /** Disables the grpc initialization service once xud has been intialized. */
+  public disable = () => {
+    this.disabled = true;
+    this.initService = undefined;
   }
 
   /**

--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -56,7 +56,8 @@ const getGrpcError = (err: any) => {
     case serviceErrorCodes.PENDING_CALL_CONFLICT:
       code = status.RESOURCE_EXHAUSTED;
       break;
-    case serviceErrorCodes.UNIMPLEMENTED:
+    case serviceErrorCodes.NODE_ALREADY_EXISTS:
+    case serviceErrorCodes.NODE_DOES_NOT_EXIST:
       code = status.UNIMPLEMENTED;
       break;
     case p2pErrorCodes.POOL_CLOSED:

--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -61,7 +61,7 @@ class InitService extends EventEmitter {
     const { password } = args;
 
     if (!this.nodeKeyExists) {
-      throw errors.UNIMPLEMENTED;
+      throw errors.NODE_DOES_NOT_EXIST;
     }
     await this.prepareCall();
 
@@ -131,7 +131,7 @@ class InitService extends EventEmitter {
 
   private newWalletValidation = (password: string) => {
     if (this.nodeKeyExists) {
-      throw errors.UNIMPLEMENTED;
+      throw errors.NODE_ALREADY_EXISTS;
     }
     if (password.length < 8) {
       // lnd requires 8+ character passwords, so we must as well

--- a/lib/service/errors.ts
+++ b/lib/service/errors.ts
@@ -4,9 +4,10 @@ const codesPrefix = errorCodesPrefix.SERVICE;
 const errorCodes = {
   INVALID_ARGUMENT: codesPrefix.concat('.1'),
   NOMATCHING_MODE_IS_REQUIRED: codesPrefix.concat('.2'),
-  UNIMPLEMENTED: codesPrefix.concat('.3'),
+  NODE_ALREADY_EXISTS: codesPrefix.concat('.3'),
   PENDING_CALL_CONFLICT: codesPrefix.concat('.4'),
   OPEN_CHANNEL_FAILURE: codesPrefix.concat('.5'),
+  NODE_DOES_NOT_EXIST: codesPrefix.concat('.6'),
 };
 
 const errors = {
@@ -18,9 +19,9 @@ const errors = {
     message: 'nomatching mode is required',
     code: errorCodes.NOMATCHING_MODE_IS_REQUIRED,
   }),
-  UNIMPLEMENTED: {
-    message: 'call is not supported by the current state of xud',
-    code: errorCodes.UNIMPLEMENTED,
+  NODE_ALREADY_EXISTS: {
+    message: 'xud node cannot be created because it already exists',
+    code: errorCodes.NODE_ALREADY_EXISTS,
   },
   PENDING_CALL_CONFLICT: {
     message: 'a pending call is ongoing that conflicts with this call',
@@ -30,6 +31,10 @@ const errors = {
     message: `failed to open channel with nodePubKey: ${nodePubKey}, currency: ${currency}, amount: ${amount}, message: ${message}`,
     code: errorCodes.OPEN_CHANNEL_FAILURE,
   }),
+  NODE_DOES_NOT_EXIST: {
+    message: 'xud node cannot be unlocked because it does not exist',
+    code: errorCodes.NODE_DOES_NOT_EXIST,
+  },
 };
 
 export { errorCodes };


### PR DESCRIPTION
This displays better error messages when `xucli unlock`, `xucli create`, or `xucli restore` calls fail due to an xud node not existing or already existing. Instead of the generic `call is not supported by the current state of xud` message being printed, a more helpful message is printed informing the user of the state of xud and which call should be tried instead.

This also returns an error when a wallet that is already unlocked is attempted to be unlocked again.

Closes #1370.