### PR TITLE
feat(rpc): wrong password error for unlock

### DIFF
--- a/lib/service/InitService.ts
+++ b/lib/service/InitService.ts
@@ -70,6 +70,12 @@ class InitService extends EventEmitter {
       this.emit('nodekey', nodeKey);
 
       return this.swapClientManager.unlockWallets(password);
+    } catch (err) {
+      if (err.code === 'ERR_OSSL_EVP_BAD_DECRYPT') {
+        throw errors.INVALID_ARGUMENT('password is incorrect');
+      } else {
+        throw err;
+      }
     } finally {
       this.pendingCall = false;
     }


### PR DESCRIPTION
This returns an `INVALID_ARGUMENT` error indicating the password was wrong when node key decryption fails during the `UnlockNode` call. Previously, an `UNKNOWN` error with a cryptic message was returned.