### PR TITLE
feat(config): property type and value checking

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -16,6 +16,7 @@ import Service from './service/Service';
 import SwapClientManager from './swaps/SwapClientManager';
 import Swaps from './swaps/Swaps';
 import { UnitConverter } from './utils/UnitConverter';
+import { AssertionError } from 'assert';
 
 const version: string = require('../package.json').version;
 
@@ -64,7 +65,18 @@ class Xud extends EventEmitter {
    * @param args optional arguments to override configuration parameters.
    */
   public start = async (args?: { [argName: string]: any }) => {
-    const configFileLoaded = await this.config.load(args);
+    let configFileLoaded: boolean;
+    try {
+      configFileLoaded = await this.config.load(args);
+    } catch (err) {
+      if (err instanceof AssertionError) {
+        console.error(err.message);
+        process.exit(1);
+      } else {
+        throw err;
+      }
+    }
+
     const loggers = Logger.createLoggers(this.config.loglevel, this.config.logpath, this.config.instanceid, this.config.logdateformat);
     this.logger = loggers.global;
     if (configFileLoaded) {

--- a/test/jest/Config.spec.ts
+++ b/test/jest/Config.spec.ts
@@ -64,4 +64,26 @@ describe('Config', () => {
     expect(config.p2p.port).toEqual(MAINNET_P2P_PORT);
     expect(config.network).toEqual(XuNetwork.TestNet);
   });
+
+  test('it throws an error when a property is assigned the wrong type', async () => {
+    await expect(config.load({ initdb: 23 })).rejects.toThrow('initdb is type number but should be boolean');
+  });
+
+  test('it throws an error when a nested property is assigned the wrong type', async () => {
+    await expect(config.load({ p2p: { listen: 'no' } })).rejects.toThrow('p2p.listen is type string but should be boolean');
+  });
+
+  test('it throws an error when a port property is assigned an invalid value', async () => {
+    await expect(config.load({ p2p: { port: 999999 } })).rejects.toThrow('port must be between 0 and 65535');
+  });
+
+  test('it throws an error when a cltvdelta property is assigned a negative value', async () => {
+    await expect(config.load({ lnd: { BTC: { cltvdelta: -1 } } })).rejects.toThrow('cltvdelta must be a positive number');
+  });
+
+  test('it uses the default value when a prperty is assigned an undefined value', async () => {
+    const defaultInitDb = config.initdb;
+    await config.load({ initdb: undefined });
+    expect(config.initdb).toEqual(defaultInitDb);
+  });
 });


### PR DESCRIPTION
This adds assertion logic to the `Config` class to validate that any properties specified are of the expected type and, for certain properties, that the value is valid. This may prevent crashes or other unexpected behavior in xud due to invalid configuration, and will also log more instructive errors when a specified property is invalid.

Closes #1222.