### PR TITLE
feat(cli): add price max precision checks for orders

### DIFF
--- a/lib/cli/placeorder.ts
+++ b/lib/cli/placeorder.ts
@@ -2,11 +2,13 @@ import { Arguments, Argv } from 'yargs';
 import { Order, OrderSide, PlaceOrderEvent, PlaceOrderRequest, PlaceOrderResponse, SwapFailure, SwapSuccess } from '../proto/xudrpc_pb';
 import { callback, loadXudClient } from './command';
 import { coinsToSats, satsToCoinsStr } from './utils';
+import { checkDecimalPlaces } from '../utils/utils';
 
 export const placeOrderBuilder = (argv: Argv, side: OrderSide) => {
   const command = side === OrderSide.BUY ? 'buy' : 'sell';
   argv.option('quantity', {
     type: 'number',
+    describe: 'the quantity to trade',
   })
   .option('pair_id', {
     type: 'string',
@@ -59,6 +61,12 @@ export const placeOrderHandler = (argv: Arguments<any>, side: OrderSide) => {
     }
   } else if (priceStr !== ('mkt') && priceStr !== ('market')) {
     console.log('price must be numeric for limit orders or "mkt"/"market" for market orders');
+    return;
+  }
+
+  if (checkDecimalPlaces(numericPrice)) {
+    process.exitCode = 1;
+    console.error('price cannot have more than 12 decimal places');
     return;
   }
 

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -9,6 +9,8 @@ import { promisify } from 'util';
 import { Order, Pair } from '../orderbook/types';
 import p2pErrors from '../p2p/errors';
 
+const MAX_DECIMAL_PLACES = 12;
+
 /**
  * Gets the external IP of the node.
  */
@@ -103,6 +105,12 @@ export const groupBy = (arr: object[], keyGetter: (item: any) => string | number
     }
   });
   return ret;
+};
+
+/** Returns true if number has more than MAX_DECIMAL_PLACES, false otherwise. */
+export const checkDecimalPlaces = (digits: number) => {
+  const fixed = Number(digits.toFixed(MAX_DECIMAL_PLACES));
+  return fixed < digits;
 };
 
 /**


### PR DESCRIPTION
https://github.com/ExchangeUnion/xud/issues/1343. We decided to go with 10 ** 12 max precision. The number is easily configurable any time. Actually was quite a challenge to setup xud with lnd, btcd, ltcd and still shows some swapClient when executing order, but precision checks work fine.
<img width="716" alt="Screenshot 2020-02-04 at 15 12 24" src="https://user-images.githubusercontent.com/36715003/73745391-fa022380-4763-11ea-854b-ba6d70a9fb32.png">
