### PR TITLE
chore: generate slate on new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typedoc": "typedoc --out typedoc --module commonjs --target es6 lib --readme none",
     "preversion": "npm run lintNoFix && npm test && npm run test:sim",
     "postversion": "npm run compile",
-    "version": "npm run config && npm run changelog && git add sample-xud.conf CHANGELOG.md && npm run typedoc"
+    "version": "npm run config && npm run changelog && git add sample-xud.conf CHANGELOG.md && npm run typedoc && npm run slate"
   },
   "cross-os": {
     "clean": {


### PR DESCRIPTION
This automatically generates new slate API documentation when a new version is tagged.