### PR TITLE
chore: ignore simulation temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ docker/xud/xud.db
 seedutil/go
 seedutil/seedutil
 
+# temp simulation test directory
+test/simulation/temp
+
 # Version file generated in build process
 lib/Version.ts
 


### PR DESCRIPTION
The simulation temp directory is still used but not ignored after #1357. This makes the folder ignored once again to prevent unintentionally committed files.

Note that this is a quick fix, however when examining the issue I was also thinking that the temp folder might not be necessary and can be removed altogether by simply using the dist folder. I'll open a separate PR for that to discuss that approach.