### PR TITLE
feat(rpc): add owner parameter for listorders

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -79,6 +79,7 @@
     - [UnlockNodeResponse](#xudrpc.UnlockNodeResponse)
   
     - [Currency.SwapClient](#xudrpc.Currency.SwapClient)
+    - [ListOrdersRequest.Owner](#xudrpc.ListOrdersRequest.Owner)
     - [OrderSide](#xudrpc.OrderSide)
     - [SwapSuccess.Role](#xudrpc.SwapSuccess.Role)
   
@@ -498,7 +499,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | pair_id | [string](#string) |  | The trading pair for which to retrieve orders. |
-| include_own_orders | [bool](#bool) |  | Whether own orders should be included in result or not. |
+| owner | [ListOrdersRequest.Owner](#xudrpc.ListOrdersRequest.Owner) |  | Whether only own, only peer or both orders should be included in result. |
 | limit | [uint32](#uint32) |  | The maximum number of orders to return from each side of the order book. |
 
 
@@ -1249,6 +1250,19 @@
 | ---- | ------ | ----------- |
 | LND | 0 |  |
 | RAIDEN | 1 |  |
+
+
+
+<a name="xudrpc.ListOrdersRequest.Owner"></a>
+
+### ListOrdersRequest.Owner
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| BOTH | 0 |  |
+| OWN | 1 |  |
+| PEER | 2 |  |
 
 
 

--- a/lib/cli/commands/listorders.ts
+++ b/lib/cli/commands/listorders.ts
@@ -4,6 +4,7 @@ import { ListOrdersRequest, ListOrdersResponse, Order } from '../../proto/xudrpc
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
 import { satsToCoinsStr } from '../utils';
+import { Owner } from '../../constants/enums';
 
 type FormattedTradingPairOrders = {
   pairId: string,
@@ -78,7 +79,7 @@ const displayTables = (orders: ListOrdersResponse.AsObject) => {
   formatOrders(orders).forEach(displayOrdersTable);
 };
 
-export const command = 'listorders [pair_id] [include_own_orders] [limit]';
+export const command = 'listorders [pair_id] [owner] [limit]';
 
 export const describe = 'list orders from the order book';
 
@@ -87,10 +88,11 @@ export const builder = {
     describe: 'trading pair for which to retrieve orders',
     type: 'string',
   },
-  include_own_orders: {
-    describe: 'whether to include own orders',
-    type: 'boolean',
-    default: true,
+  owner: {
+    describe: 'whether to include own, peer or both orders',
+    type: 'string',
+    choices: ['Both', 'Own', 'Peer'],
+    default: 'Both',
   },
   limit: {
     describe: 'max number of orders to return',
@@ -103,7 +105,7 @@ export const handler = (argv: Arguments<any>) => {
   const request = new ListOrdersRequest();
   const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
   request.setPairId(pairId);
-  request.setIncludeOwnOrders(argv.include_own_orders);
+  request.setOwner(Number(Owner[argv.owner]));
   request.setLimit(argv.limit);
   loadXudClient(argv).listOrders(request, callback(argv, displayTables));
 };

--- a/lib/cli/commands/orderbook.ts
+++ b/lib/cli/commands/orderbook.ts
@@ -4,6 +4,7 @@ import { ListOrdersRequest, ListOrdersResponse, Order } from '../../proto/xudrpc
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
 import { satsToCoinsStr } from '../utils';
+import { Owner } from '../../constants/enums';
 
 type FormattedOrderbook = {
   pairId: string,
@@ -181,6 +182,6 @@ export const handler = (argv: Arguments<any>) => {
   const request = new ListOrdersRequest();
   const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
   request.setPairId(pairId);
-  request.setIncludeOwnOrders(true);
+  request.setOwner(Number(Owner.Both));
   loadXudClient(argv).listOrders(request, callback(argv, displayTables, displayJson));
 };

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -14,6 +14,12 @@ export enum OrderSide {
   Sell,
 }
 
+export enum Owner {
+  Both,
+  Own,
+  Peer,
+}
+
 export enum XuNetwork {
   // real coins.
   MainNet = 'mainnet',

--- a/lib/proto/xudrpc.swagger.json
+++ b/lib/proto/xudrpc.swagger.json
@@ -328,12 +328,17 @@
             "type": "string"
           },
           {
-            "name": "include_own_orders",
-            "description": "Whether own orders should be included in result or not.",
+            "name": "owner",
+            "description": "Whether only own, only peer or both orders should be included in result.",
             "in": "query",
             "required": false,
-            "type": "boolean",
-            "format": "boolean"
+            "type": "string",
+            "enum": [
+              "BOTH",
+              "OWN",
+              "PEER"
+            ],
+            "default": "BOTH"
           },
           {
             "name": "limit",

--- a/lib/proto/xudrpc_pb.d.ts
+++ b/lib/proto/xudrpc_pb.d.ts
@@ -632,8 +632,8 @@ export class ListOrdersRequest extends jspb.Message {
     getPairId(): string;
     setPairId(value: string): void;
 
-    getIncludeOwnOrders(): boolean;
-    setIncludeOwnOrders(value: boolean): void;
+    getOwner(): ListOrdersRequest.Owner;
+    setOwner(value: ListOrdersRequest.Owner): void;
 
     getLimit(): number;
     setLimit(value: number): void;
@@ -652,9 +652,16 @@ export class ListOrdersRequest extends jspb.Message {
 export namespace ListOrdersRequest {
     export type AsObject = {
         pairId: string,
-        includeOwnOrders: boolean,
+        owner: ListOrdersRequest.Owner,
         limit: number,
     }
+
+    export enum Owner {
+    BOTH = 0,
+    OWN = 1,
+    PEER = 2,
+    }
+
 }
 
 export class ListOrdersResponse extends jspb.Message { 

--- a/lib/proto/xudrpc_pb.js
+++ b/lib/proto/xudrpc_pb.js
@@ -39,6 +39,7 @@ goog.exportSymbol('proto.xudrpc.GetNodeInfoResponse', null, global);
 goog.exportSymbol('proto.xudrpc.ListCurrenciesRequest', null, global);
 goog.exportSymbol('proto.xudrpc.ListCurrenciesResponse', null, global);
 goog.exportSymbol('proto.xudrpc.ListOrdersRequest', null, global);
+goog.exportSymbol('proto.xudrpc.ListOrdersRequest.Owner', null, global);
 goog.exportSymbol('proto.xudrpc.ListOrdersResponse', null, global);
 goog.exportSymbol('proto.xudrpc.ListPairsRequest', null, global);
 goog.exportSymbol('proto.xudrpc.ListPairsResponse', null, global);
@@ -4312,7 +4313,7 @@ proto.xudrpc.ListOrdersRequest.prototype.toObject = function(opt_includeInstance
 proto.xudrpc.ListOrdersRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     pairId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    includeOwnOrders: jspb.Message.getFieldWithDefault(msg, 2, false),
+    owner: jspb.Message.getFieldWithDefault(msg, 2, 0),
     limit: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
@@ -4355,8 +4356,8 @@ proto.xudrpc.ListOrdersRequest.deserializeBinaryFromReader = function(msg, reade
       msg.setPairId(value);
       break;
     case 2:
-      var value = /** @type {boolean} */ (reader.readBool());
-      msg.setIncludeOwnOrders(value);
+      var value = /** @type {!proto.xudrpc.ListOrdersRequest.Owner} */ (reader.readEnum());
+      msg.setOwner(value);
       break;
     case 3:
       var value = /** @type {number} */ (reader.readUint32());
@@ -4398,9 +4399,9 @@ proto.xudrpc.ListOrdersRequest.serializeBinaryToWriter = function(message, write
       f
     );
   }
-  f = message.getIncludeOwnOrders();
-  if (f) {
-    writer.writeBool(
+  f = message.getOwner();
+  if (f !== 0.0) {
+    writer.writeEnum(
       2,
       f
     );
@@ -4414,6 +4415,15 @@ proto.xudrpc.ListOrdersRequest.serializeBinaryToWriter = function(message, write
   }
 };
 
+
+/**
+ * @enum {number}
+ */
+proto.xudrpc.ListOrdersRequest.Owner = {
+  BOTH: 0,
+  OWN: 1,
+  PEER: 2
+};
 
 /**
  * optional string pair_id = 1;
@@ -4431,19 +4441,17 @@ proto.xudrpc.ListOrdersRequest.prototype.setPairId = function(value) {
 
 
 /**
- * optional bool include_own_orders = 2;
- * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
- * You should avoid comparisons like {@code val === true/false} in those cases.
- * @return {boolean}
+ * optional Owner owner = 2;
+ * @return {!proto.xudrpc.ListOrdersRequest.Owner}
  */
-proto.xudrpc.ListOrdersRequest.prototype.getIncludeOwnOrders = function() {
-  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 2, false));
+proto.xudrpc.ListOrdersRequest.prototype.getOwner = function() {
+  return /** @type {!proto.xudrpc.ListOrdersRequest.Owner} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
 
-/** @param {boolean} value */
-proto.xudrpc.ListOrdersRequest.prototype.setIncludeOwnOrders = function(value) {
-  jspb.Message.setProto3BooleanField(this, 2, value);
+/** @param {!proto.xudrpc.ListOrdersRequest.Owner} value */
+proto.xudrpc.ListOrdersRequest.prototype.setOwner = function(value) {
+  jspb.Message.setProto3EnumField(this, 2, value);
 };
 
 

--- a/proto/xudrpc.proto
+++ b/proto/xudrpc.proto
@@ -456,8 +456,13 @@ message ListCurrenciesResponse {
 message ListOrdersRequest {
   // The trading pair for which to retrieve orders.
   string pair_id = 1 [json_name = "pair_id"];
-  // Whether own orders should be included in result or not.
-  bool include_own_orders = 2 [json_name = "include_own_orders"];
+  enum Owner {
+    BOTH = 0;
+    OWN = 1;
+    PEER = 2;
+  }
+  // Whether only own, only peer or both orders should be included in result.
+  Owner owner = 2 [json_name = "owner"];
   // The maximum number of orders to return from each side of the order book.
   uint32 limit = 3 [json_name = "limit"];
 }

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import Xud from '../../lib/Xud';
 import chaiAsPromised from 'chai-as-promised';
 import Service from '../../lib/service/Service';
-import { SwapClientType, OrderSide } from '../../lib/constants/enums';
+import { SwapClientType, OrderSide, Owner } from '../../lib/constants/enums';
 import { getTempDir } from '../utils';
 
 chai.use(chaiAsPromised);
@@ -88,7 +88,7 @@ describe('API Service', () => {
   it('should get orders', async () => {
     const args = {
       pairId,
-      includeOwnOrders: true,
+      owner: Owner.Both,
       limit: 0,
     };
     const orders = service.listOrders(args);

--- a/test/jest/Service.spec.ts
+++ b/test/jest/Service.spec.ts
@@ -5,6 +5,7 @@ import SwapClientManager from '../../lib/swaps/SwapClientManager';
 import Pool from '../../lib/p2p/Pool';
 import Peer from '../../lib/p2p/Peer';
 import SwapClient from '../../lib/swaps/SwapClient';
+import { Owner } from '../../lib/constants/enums';
 
 jest.mock('../../lib/orderbook/OrderBook');
 const mockedOrderbook = <jest.Mock<Orderbook>><any>Orderbook;
@@ -239,5 +240,96 @@ describe('Service', () => {
       setup();
       await expect(service.tradingLimits({ currency: 'BBB' })).rejects.toMatchSnapshot();
     });
+  });
+
+  describe('listOrders', () => {
+    const pairIds = ['BTC/LTC', 'WETH/BTC'];
+
+    const setup = (peersOrders: any, ownOrders: any) => {
+      Object.defineProperty(components.orderBook, 'pairIds', { value: pairIds });
+      components.orderBook.getPeersOrders = jest.fn().mockImplementation(() => peersOrders);
+      components.orderBook.getOwnOrders = jest.fn().mockImplementation(() => ownOrders);
+      service = new Service(components);
+    };
+
+    const createOrder = (price: number, createdAt: number) => {
+      return {
+        price,
+        createdAt,
+      };
+    };
+
+    test('returns no orders if nothing is listed in the orderbook', () => {
+      const peersOrders = { buyArray: [], sellArray: [] };
+      const ownOrders = { buyArray: [], sellArray: [] };
+      setup(peersOrders, ownOrders);
+
+      const result = service.listOrders({ pairId: '', owner: Owner.Both, limit: 0 });
+      expect(result.size).toEqual(pairIds.length);
+      expect(result.get(pairIds[0])!.buyArray.length).toEqual(0);
+      expect(result.get(pairIds[0])!.sellArray.length).toEqual(0);
+      expect(result.get(pairIds[1])!.buyArray.length).toEqual(0);
+      expect(result.get(pairIds[1])!.sellArray.length).toEqual(0);
+    });
+
+    test('returns both own and peer orders for all trading pairs', () => {
+      const peersOrders = { buyArray: [createOrder(1, 123)], sellArray: [createOrder(3, 222), createOrder(1, 999)] };
+      const ownOrders = { buyArray: [createOrder(1, 999)], sellArray: [createOrder(2, 123)] };
+      setup(peersOrders, ownOrders);
+
+      const result = service.listOrders({ pairId: '', owner: Owner.Both, limit: 0 });
+      expect(result.size).toEqual(pairIds.length);
+      expect(result.get(pairIds[0])!.buyArray.length).toEqual(2);
+      expect(result.get(pairIds[0])!.sellArray.length).toEqual(3);
+      expect(result.get(pairIds[1])!.buyArray.length).toEqual(2);
+      expect(result.get(pairIds[1])!.sellArray.length).toEqual(3);
+    });
+
+    test('returns both own and peer orders for the specified trading pair', () => {
+      const peersOrders = { buyArray: [createOrder(1, 123)], sellArray: [createOrder(3, 222), createOrder(1, 999)] };
+      const ownOrders = { buyArray: [createOrder(1, 999)], sellArray: [createOrder(2, 123)] };
+      setup(peersOrders, ownOrders);
+
+      const result = service.listOrders({ pairId: pairIds[0], owner: Owner.Both, limit: 0 });
+      expect(result.size).toEqual(1);
+      expect(result.get(pairIds[0])!.buyArray.length).toEqual(2);
+      expect(result.get(pairIds[0])!.sellArray.length).toEqual(3);
+    });
+
+    test('returns only peer orders', () => {
+      const peersOrders = { buyArray: [createOrder(1, 123)], sellArray: [createOrder(3, 222), createOrder(1, 999)] };
+      const ownOrders = { buyArray: [createOrder(1, 999), createOrder(1, 123)], sellArray: [createOrder(2, 123)] };
+      setup(peersOrders, ownOrders);
+
+      const result = service.listOrders({ pairId: pairIds[0], owner: Owner.Peer, limit: 0 });
+      expect(result.size).toEqual(1);
+      expect(result.get(pairIds[0])!.buyArray.length).toEqual(1);
+      expect(result.get(pairIds[0])!.sellArray.length).toEqual(2);
+    });
+
+    test('returns only own orders', () => {
+      const peersOrders = { buyArray: [createOrder(1, 123)], sellArray: [createOrder(3, 222), createOrder(1, 999)] };
+      const ownOrders = { buyArray: [createOrder(1, 999), createOrder(1, 123)], sellArray: [createOrder(2, 123)] };
+      setup(peersOrders, ownOrders);
+
+      const result = service.listOrders({ pairId: pairIds[0], owner: Owner.Own, limit: 0 });
+      expect(result.size).toEqual(1);
+      expect(result.get(pairIds[0])!.buyArray.length).toEqual(2);
+      expect(result.get(pairIds[0])!.sellArray.length).toEqual(1);
+    });
+
+    test('returns limited amount of orders', () => {
+      const peersOrders = { buyArray: [createOrder(1, 111)], sellArray: [createOrder(4, 222), createOrder(5, 999)] };
+      const ownOrders = { buyArray: [createOrder(3, 999), createOrder(2, 123)], sellArray: [createOrder(6, 123)] };
+      setup(peersOrders, ownOrders);
+
+      const result = service.listOrders({ pairId: pairIds[0], owner: Owner.Both, limit: 2 });
+      expect(result.size).toEqual(1);
+      expect(result.get(pairIds[0])!.buyArray.length).toEqual(2);
+      expect(result.get(pairIds[0])!.buyArray.some(val => val.price === 1)).toBeTruthy();
+      expect(result.get(pairIds[0])!.sellArray.length).toEqual(2);
+      expect(result.get(pairIds[0])!.sellArray.some(val => val.price === 6)).toBeTruthy();
+    });
+
   });
 });


### PR DESCRIPTION
This commit adds an optional `owner` parameter for the `listorders` command while removing `include_own_orders_parmeter` and replacing its functionality.
The default value for the new parameter is `Both`, other options are `Own` and `Peer`.

The commit also fixes a bug that caused a situation where sell orders were displayed instead of buy orders when the limit was set.

Closes #1323