### PR TITLE
refactor: only verify peer currencies if connected

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -793,7 +793,7 @@ class OrderBook extends EventEmitter {
 
   /**
    * Verifies the advertised trading pairs of a peer. Checks that the peer has advertised
-   * lnd pub keys for both the base and quote currencies for each pair, and also attempts a
+   * lnd pub keys for both the base and quote currencies for each pair, and optionally attempts a
    * "sanity swap" for each currency which is a 1 satoshi for 1 satoshi swap of a given currency
    * that demonstrates that we can both accept and receive payments for this peer.
    * @param pairIds the list of trading pair ids to verify
@@ -805,7 +805,11 @@ class OrderBook extends EventEmitter {
         return false; // don't verify a pair that is already active
       }
       const [baseCurrency, quoteCurrency] = pairId.split('/');
-      return !peer.disabledCurrencies.has(baseCurrency) && !peer.disabledCurrencies.has(quoteCurrency);
+      const peerCurrenciesEnabled = !peer.disabledCurrencies.has(baseCurrency)
+        && !peer.disabledCurrencies.has(quoteCurrency);
+      const ownCurrenciesConnected = this.swaps.swapClientManager.isConnected(baseCurrency)
+        && this.swaps.swapClientManager.isConnected(quoteCurrency);
+      return peerCurrenciesEnabled && ownCurrenciesConnected;
     });
 
     // identify the unique currencies we need to verify for specified trading pairs

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -265,6 +265,15 @@ class SwapClientManager extends EventEmitter {
   }
 
   /**
+   * Returns whether the swap client for a specified currency is connected.
+   * @returns `true` if a swap client exists and is connected, otherwise `false`
+   */
+  public isConnected = (currency: string) => {
+    const swapClient = this.swapClients.get(currency);
+    return swapClient !== undefined && swapClient.isConnected();
+  }
+
+  /**
    * Adds a new swap client and currency association.
    * @param currency a currency that should be linked with a swap client.
    * @returns Nothing upon success, throws otherwise.

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -85,6 +85,7 @@ jest.mock('../../lib/swaps/SwapClientManager', () => {
     return {
       // temporary mock while raiden direct channel checks are required
       hasRouteToPeer: jest.fn().mockReturnValue(true),
+      isConnected: jest.fn().mockReturnValue(true),
     };
   });
 });


### PR DESCRIPTION
This modifies the logic around verifying whether peer currencies are tradable to skip over any currencies for which our local swap client is currently disconnected. This prevents foreseeable failures when we try to send or receive with a swap client that is offline.