### PR TITLE
refactor: organize/clarify canRouteToPeer logic

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -818,6 +818,14 @@ class LndClient extends SwapClient {
     return route;
   }
 
+  public canRouteToNode = async (_destination: string) => {
+    // lnd doesn't currently have a way to see if any route exists, regardless of balance
+    // for example, if we have a direct channel to peer but no balance in the channel and
+    // no other routes, QueryRoutes will return nothing as of lnd v0.8.1.
+    // For now we err on the side of leniency and assume a route may exist.
+    return true;
+  }
+
   /**
    * Lists all routes to destination.
    */

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -825,8 +825,10 @@ class OrderBook extends EventEmitter {
       }
     });
 
-    currenciesToVerify.forEach((_, currency) => {
-      if (!this.swaps.swapClientManager.hasRouteToPeer(currency, peer)) {
+    currenciesToVerify.forEach(async (_, currency) => {
+      const canRoute = await this.swaps.swapClientManager.canRouteToPeer(peer, currency);
+      if (!canRoute) {
+        // don't attempt to verify if we can use a currency if a route to peer is impossible
         currenciesToVerify.set(currency, false);
       }
     });

--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -331,6 +331,11 @@ class RaidenClient extends SwapClient {
     }
   }
 
+  public canRouteToNode = async (destination: string, currency: string) => {
+    const route = await this.getRoute(1, destination, currency);
+    return route !== undefined;
+  }
+
   public getHeight = async () => {
     return 1; // raiden's API does not tell us the height
   }

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -210,6 +210,13 @@ abstract class SwapClient extends EventEmitter {
   public abstract async getRoute(units: number, destination: string, currency: string, finalCltvDelta?: number): Promise<Route | undefined>;
 
   /**
+   * Checks whether it is possible to route a payment to a node. This does not test or guarantee
+   * that a payment can be routed successfully, only whether it is possible to do so currently
+   * given the state of the network and graph - without creating new channels or edges.
+   */
+  public abstract async canRouteToNode(destination: string, currency?: string): Promise<boolean>;
+
+  /**
    * @param units the amount of the invoice denominated in the smallest units supported by its currency
    */
   public abstract async addInvoice(rHash: string, units: number, expiry?: number): Promise<void>;

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -83,8 +83,7 @@ jest.mock('../../lib/swaps/Swaps');
 jest.mock('../../lib/swaps/SwapClientManager', () => {
   return jest.fn().mockImplementation(() => {
     return {
-      // temporary mock while raiden direct channel checks are required
-      hasRouteToPeer: jest.fn().mockReturnValue(true),
+      canRouteToPeer: jest.fn().mockReturnValue(true),
       isConnected: jest.fn().mockReturnValue(true),
     };
   });


### PR DESCRIPTION
This commit attempts to better organize and clarify the `hasRouteToPeer` logic used to determine whether any possible route exists to pay a peer for a given currency before enabling trading pairs involving that currency for that peer.

Previously, lnd and raiden specific logic was located inside the SwapClientManager class. This has been refactored into the respective LndClient and RaidenClient classes.

The naming of the method is also changed from "hasRoute" to "canRoute" to indicate that it only tests whether such a route is possible, not whether one necessarily exists or is functional. Methods have been commented to better indicate what they do.