### PR TITLE
perf(rpc/orderbook): listorders array concatenation

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -376,8 +376,8 @@ class Service {
       if (includeOwnOrders) {
         const ownOrders = this.orderBook.getOwnOrders(pairId);
 
-        orders.buyArray = [...orders.buyArray, ...ownOrders.buyArray];
-        orders.sellArray = [...orders.sellArray, ...ownOrders.sellArray];
+        orders.buyArray = orders.buyArray.concat(ownOrders.buyArray);
+        orders.sellArray = orders.sellArray.concat(ownOrders.sellArray);
       }
 
       // sort all orders


### PR DESCRIPTION
This is a minor performance improvement to the way the `ListOrders` rpc call concatenates own orders to the list of orders. This uses option 5 from the following benchmark, which is roughly twice as fast in the test than the existing approach which is option 1: http://jsben.ch/SeFSP