### PR TITLE
refactor(swapclient): status and initialization

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -102,10 +102,9 @@ class Xud extends EventEmitter {
 
       const nodeKeyPath = NodeKey.getPath(this.config.xudir, this.config.instanceid);
       const nodeKeyExists = await fs.access(nodeKeyPath).then(() => true).catch(() => false);
-      const awaitingCreate = !nodeKeyExists && !this.config.noencrypt;
 
       this.swapClientManager = new SwapClientManager(this.config, loggers, this.unitConverter);
-      await this.swapClientManager.init(this.db.models, awaitingCreate);
+      await this.swapClientManager.init(this.db.models);
 
       let nodeKey: NodeKey | undefined;
       if (this.config.noencrypt) {
@@ -184,7 +183,7 @@ class Xud extends EventEmitter {
         shutdown: this.beginShutdown,
       });
 
-      if (this.swapClientManager.raidenClient.isOperational()) {
+      if (this.swapClientManager.raidenClient?.isOperational()) {
         this.httpServer = new HttpServer(loggers.http, this.service);
         await this.httpServer.listen(
           this.config.http.port,
@@ -217,7 +216,7 @@ class Xud extends EventEmitter {
     const closePromises: Promise<void>[] = [];
 
     if (this.swapClientManager) {
-      closePromises.push(this.swapClientManager.close());
+      this.swapClientManager.close();
     }
     if (this.httpServer) {
       closePromises.push(this.httpServer.close());

--- a/lib/backup/Backup.ts
+++ b/lib/backup/Backup.ts
@@ -61,7 +61,7 @@ class Backup extends EventEmitter {
     this.logger.info('Started backup daemon');
   }
 
-  public stop = async () => {
+  public stop = () => {
     if (this.checkLndTimer) {
       clearInterval(this.checkLndTimer);
     }
@@ -70,7 +70,7 @@ class Backup extends EventEmitter {
     });
 
     for (const lndClient of this.lndClients) {
-      await lndClient.close();
+      lndClient.close();
     }
   }
 

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -43,6 +43,7 @@ class LndClient extends SwapClient {
   private lightning?: LightningClient;
   private walletUnlocker?: WalletUnlockerClient;
   private invoices?: InvoicesClient;
+  /** The path to the lnd admin macaroon, will be undefined if `nomacaroons` is enabled */
   private macaroonpath?: string;
   private meta = new grpc.Metadata();
   private uri!: string;
@@ -75,7 +76,7 @@ class LndClient extends SwapClient {
     { config, logger, currency }:
     { config: LndClientConfig, logger: Logger, currency: string },
   ) {
-    super(logger);
+    super(logger, config.disable);
     this.config = config;
     this.currency = currency;
     this.finalLock = config.cltvdelta;
@@ -105,24 +106,14 @@ class LndClient extends SwapClient {
    * Initializes the client for calls to lnd and verifies that we can connect to it.
    * @param awaitingCreate whether xud is waiting for its node key to be created
    */
-  public init = async (awaitingCreate = false) => {
-    if (!this.isNotInitialized() && !this.isMisconfigured) {
-      // we only initialize from NotInitialized or Misconfigured status
-      this.logger.warn(`can not init in ${this.status} status`);
-      return;
-    }
-
-    const { disable, certpath, macaroonpath, nomacaroons, host, port } = this.config;
-    if (disable) {
-      await this.setStatus(ClientStatus.Disabled);
-      return;
-    }
+  public initSpecific = async () => {
+    const { certpath, macaroonpath, nomacaroons, host, port } = this.config;
 
     let lndCert: Buffer | undefined;
     try {
       lndCert = await fs.readFile(certpath);
     } catch (err) {
-      if (awaitingCreate && err.code === 'ENOENT') {
+      if (err.code === 'ENOENT') {
         // if we have not created the lnd wallet yet and the tls.cert file can
         // not be found, we will briefly wait for the cert to be created in
         // case lnd has not been run before and is being started in parallel
@@ -155,8 +146,8 @@ class LndClient extends SwapClient {
       this.credentials = grpc.credentials.createSsl(lndCert);
     } else {
       this.logger.error(`could not load tls cert from ${certpath}, is lnd installed?`);
-      await this.setStatus(ClientStatus.Misconfigured);
-      this.initRetryTimeout = global.setTimeout(this.init, 5000, awaitingCreate);
+      this.setStatus(ClientStatus.Misconfigured);
+      this.initRetryTimeout = setTimeout(this.init, LndClient.RECONNECT_INTERVAL);
       return;
     }
 
@@ -165,27 +156,17 @@ class LndClient extends SwapClient {
       try {
         await this.loadMacaroon();
       } catch (err) {
-        if (!awaitingCreate || err.code !== 'ENOENT') {
-          // unless we are waiting for the xud nodekey and lnd wallet to be created
-          // we expect the macaroon to exist and disable this client otherwise
-          this.logger.error(`could not load admin macaroon from ${macaroonpath}`);
-          await this.setStatus(ClientStatus.Misconfigured);
-          this.initRetryTimeout = global.setTimeout(this.init, 5000, awaitingCreate);
-          return;
-        }
+        this.logger.warn(`could not load macaroon at ${macaroonpath}`);
       }
     } else {
       this.logger.info('macaroons are disabled');
     }
 
     this.uri = `${host}:${port}`;
-    await this.setStatus(ClientStatus.Initialized);
-    this.emit('initialized');
     if (this.initRetryTimeout) {
       clearTimeout(this.initRetryTimeout);
       this.initRetryTimeout = undefined;
     }
-    await this.verifyConnectionWithTimeout();
   }
 
   public get pubKey() {
@@ -213,7 +194,7 @@ class LndClient extends SwapClient {
   }
 
   /** Lnd specific procedure to mark the client as locked. */
-  private lock = async () => {
+  private lock = () => {
     if (!this.walletUnlocker) {
       this.walletUnlocker = new WalletUnlockerClient(this.uri, this.credentials);
     }
@@ -223,7 +204,7 @@ class LndClient extends SwapClient {
     }
 
     if (!this.isWaitingUnlock()) {
-      await this.setStatus(ClientStatus.WaitingUnlock);
+      this.setStatus(ClientStatus.WaitingUnlock);
     }
 
     this.emit('locked');
@@ -248,9 +229,9 @@ class LndClient extends SwapClient {
       (this.lightning[methodName] as Function)(params, this.meta, (err: grpc.ServiceError, response: U) => {
         if (err) {
           if (err.code === grpc.status.UNAVAILABLE) {
-            this.disconnect().catch(this.logger.error);
+            this.disconnect();
           } else if (err.code === grpc.status.UNIMPLEMENTED) {
-            this.lock().catch(this.logger.error);
+            this.lock();
           }
           this.logger.trace(`error on ${methodName}: ${err.message}`);
           reject(err);
@@ -282,9 +263,9 @@ class LndClient extends SwapClient {
       (this.invoices[methodName] as Function)(params, this.meta, (err: grpc.ServiceError, response: U) => {
         if (err) {
           if (err.code === grpc.status.UNAVAILABLE) {
-            this.disconnect().catch(this.logger.error);
+            this.disconnect();
           } else if (err.code === grpc.status.UNIMPLEMENTED) {
-            this.lock().catch(this.logger.error);
+            this.lock();
           }
           this.logger.trace(`error on ${methodName}: ${err.message}`);
           reject(err);
@@ -307,6 +288,9 @@ class LndClient extends SwapClient {
       }
       (this.walletUnlocker[methodName] as Function)(params, this.meta, (err: grpc.ServiceError, response: U) => {
         if (err) {
+          if (err.code === grpc.status.UNAVAILABLE) {
+            this.disconnect();
+          }
           if (err.code === grpc.status.UNIMPLEMENTED) {
             this.logger.debug(`lnd already unlocked before ${methodName} call`);
             resolve();
@@ -416,7 +400,7 @@ class LndClient extends SwapClient {
           this.verifyConnection().catch(this.logger.error);
         } catch (err) {
           this.logger.error(`could not load macaroon from ${this.macaroonpath}`);
-          await this.setStatus(ClientStatus.Disabled);
+          this.setStatus(ClientStatus.Disabled);
         }
       }
     }
@@ -426,83 +410,70 @@ class LndClient extends SwapClient {
     if (!this.isOperational()) {
       throw(errors.DISABLED);
     }
-
     if (this.macaroonpath && this.meta.get('macaroon').length === 0) {
       // we have not loaded the macaroon yet - it is not created until the lnd wallet is initialized
       if (!this.isWaitingUnlock()) { // check that we are not already waiting for wallet init & unlock
         this.walletUnlocker = new WalletUnlockerClient(this.uri, this.credentials);
         await LndClient.waitForClientReady(this.walletUnlocker);
-        await this.setStatus(ClientStatus.WaitingUnlock);
-        this.emit('locked');
-
-        if (this.reconnectionTimer) {
-          // we don't need scheduled attempts to retry the connection while waiting on the wallet
-          clearTimeout(this.reconnectionTimer);
-          this.reconnectionTimer = undefined;
-        }
+        this.lock();
 
         this.awaitWalletInit().catch(this.logger.error);
       }
       return;
     }
 
-    if (!this.isConnected()) {
-      this.logger.info(`trying to verify connection to lnd at ${this.uri}`);
-      this.lightning = new LightningClient(this.uri, this.credentials);
+    this.logger.info(`trying to verify connection to lnd at ${this.uri}`);
+    this.lightning = new LightningClient(this.uri, this.credentials);
 
-      try {
-        await LndClient.waitForClientReady(this.lightning);
+    try {
+      await LndClient.waitForClientReady(this.lightning);
 
-        const getInfoResponse = await this.getInfo();
-        if (getInfoResponse.getSyncedToChain()) {
-          // mark connection as active
-          await this.setStatus(ClientStatus.ConnectionVerified);
-
-          /** The new lnd pub key value if different from the one we had previously. */
-          let newPubKey: string | undefined;
-          let newUris: string[] = [];
-          if (this.identityPubKey !== getInfoResponse.getIdentityPubkey()) {
-            newPubKey = getInfoResponse.getIdentityPubkey();
-            this.logger.debug(`pubkey is ${newPubKey}`);
-            this.identityPubKey = newPubKey;
-            newUris = getInfoResponse.getUrisList();
-            if (newUris.length) {
-              this.logger.debug(`uris are ${newUris}`);
-            } else {
-              this.logger.debug('no uris advertised');
-            }
-            this.urisList = newUris;
+      const getInfoResponse = await this.getInfo();
+      if (getInfoResponse.getSyncedToChain()) {
+        // check if the lnd pub key value is different from the one we had previously.
+        let newPubKey: string | undefined;
+        let newUris: string[] = [];
+        if (this.identityPubKey !== getInfoResponse.getIdentityPubkey()) {
+          newPubKey = getInfoResponse.getIdentityPubkey();
+          this.logger.debug(`pubkey is ${newPubKey}`);
+          this.identityPubKey = newPubKey;
+          newUris = getInfoResponse.getUrisList();
+          if (newUris.length) {
+            this.logger.debug(`uris are ${newUris}`);
+          } else {
+            this.logger.debug('no uris advertised');
           }
-          const chain = getInfoResponse.getChainsList()[0];
-          const chainIdentifier = `${chain.getChain()}-${chain.getNetwork()}`;
-          if (!this.chainIdentifier) {
-            this.chainIdentifier = chainIdentifier;
-            this.logger.debug(`chain is ${chainIdentifier}`);
-          } else if (this.chainIdentifier !== chainIdentifier) {
-            // we switched chains for this lnd client while xud was running which is not supported
-            this.logger.error(`chain switched from ${this.chainIdentifier} to ${chainIdentifier}`);
-            await this.setStatus(ClientStatus.Disabled);
-          }
-          this.emit('connectionVerified', {
-            newUris,
-            newIdentifier: newPubKey,
-          });
-
-          this.invoices = new InvoicesClient(this.uri, this.credentials);
-
-          if (this.walletUnlocker) {
-            // WalletUnlocker service is disabled when the main Lightning service is available
-            this.walletUnlocker.close();
-            this.walletUnlocker = undefined;
-          }
-        } else {
-          await this.setStatus(ClientStatus.OutOfSync);
-          this.logger.warn(`lnd is out of sync with chain, retrying in ${LndClient.RECONNECT_TIME_LIMIT} ms`);
+          this.urisList = newUris;
         }
-      } catch (err) {
-        const errStr = typeof(err) === 'string' ? err : JSON.stringify(err);
-        this.logger.error(`could not verify connection at ${this.uri}, error: ${errStr}, retrying in ${LndClient.RECONNECT_TIME_LIMIT} ms`);
+
+        // check if the chain this lnd instance uses has changed
+        const chain = getInfoResponse.getChainsList()[0];
+        const chainIdentifier = `${chain.getChain()}-${chain.getNetwork()}`;
+        if (!this.chainIdentifier) {
+          this.chainIdentifier = chainIdentifier;
+          this.logger.debug(`chain is ${chainIdentifier}`);
+        } else if (this.chainIdentifier !== chainIdentifier) {
+          // we switched chains for this lnd client while xud was running which is not supported
+          this.logger.error(`chain switched from ${this.chainIdentifier} to ${chainIdentifier}`);
+          this.setStatus(ClientStatus.Misconfigured);
+        }
+
+        this.invoices = new InvoicesClient(this.uri, this.credentials);
+
+        if (this.walletUnlocker) {
+          // WalletUnlocker service is disabled when the main Lightning service is available
+          this.walletUnlocker.close();
+          this.walletUnlocker = undefined;
+        }
+
+        await this.setConnected(newPubKey, newUris);
+      } else {
+        this.setStatus(ClientStatus.OutOfSync);
+        this.logger.warn(`lnd is out of sync with chain, retrying in ${LndClient.RECONNECT_INTERVAL} ms`);
       }
+    } catch (err) {
+      const errStr = typeof(err) === 'string' ? err : JSON.stringify(err);
+      this.logger.error(`could not verify connection at ${this.uri}, error: ${errStr}, retrying in ${LndClient.RECONNECT_INTERVAL} ms`);
     }
   }
 
@@ -1029,9 +1000,9 @@ class LndClient extends SwapClient {
   }
 
   /** Lnd specific procedure to disconnect from the server. */
-  protected disconnect = async () => {
+  protected disconnect = () => {
     if (this.isOperational()) {
-      await this.setStatus(ClientStatus.Disconnected);
+      this.setStatus(ClientStatus.Disconnected);
     }
 
     if (this.channelBackupSubscription) {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -334,8 +334,10 @@ class Service {
     }
 
     const lnd = await this.swapClientManager.getLndClientsInfo();
-    const raiden = await this.swapClientManager.raidenClient.getRaidenInfo();
-    raiden.chain = `${raiden.chain ? raiden.chain : ''} ${this.pool.getNetwork()}`;
+    const raiden = await this.swapClientManager.raidenClient?.getRaidenInfo();
+    if (raiden) {
+      raiden.chain = `${raiden.chain ? raiden.chain : ''} ${this.pool.getNetwork()}`;
+    }
 
     return {
       lnd,

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -80,7 +80,7 @@ abstract class SwapClient extends EventEmitter {
   public abstract readonly finalLock: number;
   public abstract readonly type: SwapClientType;
   /** Time in milliseconds between attempts to recheck connectivity to the client. */
-  public static readonly RECONNECT_TIME_LIMIT = 5000;
+  public static readonly RECONNECT_INTERVAL = 5000;
   protected status: ClientStatus = ClientStatus.NotInitialized;
   protected reconnectionTimer?: NodeJS.Timer;
 
@@ -90,7 +90,7 @@ abstract class SwapClient extends EventEmitter {
   /** Time in milliseconds between updating the maximum outbound capacity. */
   private static CAPACITY_REFRESH_INTERVAL = 3000;
 
-  constructor(public logger: Logger) {
+  constructor(public logger: Logger, protected disable: boolean) {
     super();
   }
 
@@ -129,10 +129,10 @@ abstract class SwapClient extends EventEmitter {
     // don't wait longer than the allotted time for the connection to
     // be verified to prevent initialization from hanging
     return new Promise<void>((resolve, reject) => {
-      const verifyTimeout = setTimeout(async () => {
+      const verifyTimeout = setTimeout(() => {
         // we could not verify the connection within the allotted time
         this.logger.info(`could not verify connection within initialization time limit of ${SwapClient.INITIALIZATION_TIME_LIMIT}`);
-        await this.setStatus(ClientStatus.Disconnected);
+        this.setStatus(ClientStatus.Disconnected);
         resolve();
       }, SwapClient.INITIALIZATION_TIME_LIMIT);
       this.verifyConnection().then(() => {
@@ -142,43 +142,74 @@ abstract class SwapClient extends EventEmitter {
     });
   }
 
-  protected setStatus = async (status: ClientStatus): Promise<void> => {
+  public init = async () => {
+    // up front checks before initializing client
+    if (this.disable) {
+      this.setStatus(ClientStatus.Disabled);
+      return;
+    }
+
+    if (!this.isNotInitialized() && !this.isMisconfigured()) {
+      // we only initialize from NotInitialized or Misconfigured status
+      this.logger.warn(`can not init in ${this.status} status`);
+      return;
+    }
+    // client specific initialization
+    await this.initSpecific();
+
+    // final steps to complete initialization
+    this.setStatus(ClientStatus.Initialized);
+    this.setTimers();
+    this.emit('initialized');
+    await this.verifyConnectionWithTimeout();
+  }
+
+  protected abstract async initSpecific(): Promise<void>;
+
+  protected setConnected = async (newIdentifier?: string, newUris?: string[]) => {
+    await this.updateCapacity();
+    this.setStatus(ClientStatus.ConnectionVerified);
+    this.emit('connectionVerified', {
+      newIdentifier,
+      newUris,
+    });
+
+  }
+
+  protected setStatus = (status: ClientStatus): void => {
     if (this.status === status) {
       return;
     }
 
     this.logger.info(`${this.constructor.name} status: ${ClientStatus[status]}`);
     this.status = status;
-    await this.setTimers();
   }
 
-  private setTimers = async () => {
-    if (this.status === ClientStatus.ConnectionVerified) {
-      if (!this.updateCapacityTimer) {
-        await this.updateCapacity();
-        this.updateCapacityTimer = setInterval(this.updateCapacity, SwapClient.CAPACITY_REFRESH_INTERVAL);
-      }
+  private updateCapacityTimerCallback = async () => {
+    if (this.isConnected()) {
+      await this.updateCapacity();
+    }
+  }
 
-      if (this.reconnectionTimer) {
-        clearTimeout(this.reconnectionTimer);
-        this.reconnectionTimer = undefined;
+  private reconnectionTimerCallback = async () => {
+    if (this.status === ClientStatus.Disconnected || this.status === ClientStatus.OutOfSync || this.status === ClientStatus.WaitingUnlock) {
+      try {
+        await this.verifyConnection();
+      } catch (err) {
+        this.logger.debug(`reconnectionTimer errored with ${err}`);
       }
-    } else {
-      if (this.updateCapacityTimer) {
-        clearInterval(this.updateCapacityTimer);
-        this.updateCapacityTimer = undefined;
-      }
-      if (this.status === ClientStatus.Disconnected || this.status === ClientStatus.OutOfSync || this.status === ClientStatus.WaitingUnlock) {
-        if (!this.reconnectionTimer) {
-          this.reconnectionTimer = setTimeout(async () => {
-            await this.verifyConnection();
-            if (!this.isConnected() && this.reconnectionTimer) {
-              // if we were still not able to verify the connection, schedule another attempt
-              this.reconnectionTimer.refresh();
-            }
-          }, SwapClient.RECONNECT_TIME_LIMIT);
-        }
-      }
+    }
+    if (this.reconnectionTimer) {
+      this.reconnectionTimer.refresh();
+    }
+  }
+
+  private setTimers = () => {
+    if (!this.updateCapacityTimer) {
+      this.updateCapacityTimer = setInterval(this.updateCapacityTimerCallback, SwapClient.CAPACITY_REFRESH_INTERVAL);
+    }
+    if (!this.reconnectionTimer) {
+      this.reconnectionTimer = setTimeout(this.reconnectionTimerCallback, SwapClient.RECONNECT_INTERVAL);
     }
   }
 
@@ -272,17 +303,19 @@ abstract class SwapClient extends EventEmitter {
   }
 
   /** Ends all connections, subscriptions, and timers for for this client. */
-  public async close() {
-    await this.disconnect();
+  public close() {
+    this.disconnect();
     if (this.reconnectionTimer) {
       clearTimeout(this.reconnectionTimer);
+      this.reconnectionTimer = undefined;
     }
     if (this.updateCapacityTimer) {
       clearInterval(this.updateCapacityTimer);
+      this.updateCapacityTimer = undefined;
     }
     this.removeAllListeners();
   }
-  protected abstract async disconnect(): Promise<void>;
+  protected abstract disconnect(): void;
 }
 
 export default SwapClient;

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -42,7 +42,7 @@ interface SwapClientManager {
 class SwapClientManager extends EventEmitter {
   /** A map between currencies and all enabled swap clients */
   public swapClients = new Map<string, SwapClient>();
-  public raidenClient: RaidenClient;
+  public raidenClient?: RaidenClient;
   public misconfiguredClients = new Set<SwapClient>();
   private walletPassword?: string;
 
@@ -52,13 +52,6 @@ class SwapClientManager extends EventEmitter {
     private unitConverter: UnitConverter,
   ) {
     super();
-
-    this.raidenClient = new RaidenClient({
-      unitConverter,
-      config: config.raiden,
-      logger: loggers.raiden,
-      directChannelChecks: config.debug.raidenDirectChannelChecks,
-    });
   }
 
   /**
@@ -66,7 +59,7 @@ class SwapClientManager extends EventEmitter {
    * and waits for the swap clients to initialize.
    * @returns A promise that resolves upon successful initialization, rejects otherwise.
    */
-  public init = async (models: Models, awaitingCreate = false): Promise<void> => {
+  public init = async (models: Models): Promise<void> => {
     const initPromises = [];
     // setup configured LND clients and initialize them
     for (const currency in this.config.lnd) {
@@ -78,12 +71,22 @@ class SwapClientManager extends EventEmitter {
           logger: this.loggers.lnd.createSubLogger(currency),
         });
         this.swapClients.set(currency, lndClient);
-        initPromises.push(lndClient.init(awaitingCreate));
+        initPromises.push(lndClient.init());
       }
     }
-    // setup Raiden
-    const currencyInstances = await models.Currency.findAll();
-    initPromises.push(this.raidenClient.init(currencyInstances));
+
+    if (!this.config.raiden.disable) {
+      // setup Raiden
+      const currencyInstances = await models.Currency.findAll();
+      this.raidenClient = new RaidenClient({
+        currencyInstances,
+        unitConverter: this.unitConverter,
+        config: this.config.raiden,
+        logger: this.loggers.raiden,
+        directChannelChecks: this.config.debug.raidenDirectChannelChecks,
+      });
+      initPromises.push(this.raidenClient.init());
+    }
 
     // bind event listeners before all swap clients have initialized
     this.bind();
@@ -101,16 +104,15 @@ class SwapClientManager extends EventEmitter {
       }
     });
 
-    if (this.raidenClient.isMisconfigured()) {
-      this.misconfiguredClients.add(this.raidenClient);
-    } else if (!this.raidenClient.isDisabled()) {
-      // associate swap clients with currencies managed by raiden client
-      const currencyInstances = await models.Currency.findAll();
-      currencyInstances.forEach((currency) => {
-        if (currency.tokenAddress) {
-          this.swapClients.set(currency.id, this.raidenClient);
+    if (this.raidenClient) {
+      if (this.raidenClient.isMisconfigured()) {
+        this.misconfiguredClients.add(this.raidenClient);
+      } else if (!this.raidenClient.isDisabled()) {
+        // associate swap clients with currencies managed by raiden client
+        for (const currency of this.raidenClient.tokenAddresses.keys()) {
+          this.swapClients.set(currency, this.raidenClient);
         }
-      });
+      }
     }
   }
 
@@ -137,7 +139,7 @@ class SwapClientManager extends EventEmitter {
             lndClient.removeListener('connectionVerified', onAvailable);
             lndClient.removeListener('locked', onAvailable);
             reject(lndClient.currency);
-          }, SwapClient.RECONNECT_TIME_LIMIT);
+          }, SwapClient.RECONNECT_INTERVAL);
         } else {
           resolve();
         }
@@ -189,7 +191,7 @@ class SwapClientManager extends EventEmitter {
       }
     }
 
-    if (!this.raidenClient.isDisabled()) {
+    if (this.raidenClient) {
       const { keystorepath } = this.config.raiden;
       // TODO: we are setting the raiden keystore as an empty string until raiden
       // allows for decrypting the keystore without needing to save the password
@@ -202,10 +204,10 @@ class SwapClientManager extends EventEmitter {
       }
 
       const keystorePromise = keystore(seedMnemonic, '', keystorepath).then(() => {
-        this.raidenClient.logger.info(`created raiden keystore with master seed and empty password in ${keystorepath}`);
+        this.raidenClient!.logger.info(`created raiden keystore with master seed and empty password in ${keystorepath}`);
         initializedRaiden = true;
       }).catch((err) => {
-        this.raidenClient.logger.error('could not create keystore');
+        this.raidenClient!.logger.error('could not create keystore');
         throw errors.SWAP_CLIENT_WALLET_NOT_CREATED(`could not create keystore: ${err}`);
       });
       initWalletPromises.push(keystorePromise);
@@ -279,7 +281,7 @@ class SwapClientManager extends EventEmitter {
    * @returns Nothing upon success, throws otherwise.
    */
   public add = (currency: Currency): void => {
-    if (currency.swapClient === SwapClientType.Raiden && currency.tokenAddress) {
+    if (currency.swapClient === SwapClientType.Raiden && currency.tokenAddress && this.raidenClient) {
       this.swapClients.set(currency.id, this.raidenClient);
       this.raidenClient.tokenAddresses.set(currency.id, currency.tokenAddress);
       this.emit('raidenUpdate', this.raidenClient.tokenAddresses, this.raidenClient.address);
@@ -309,7 +311,7 @@ class SwapClientManager extends EventEmitter {
     const swapClient = this.get(currency);
     this.swapClients.delete(currency);
     if (swapClient && isRaidenClient(swapClient)) {
-      this.raidenClient.tokenAddresses.delete(currency);
+      this.raidenClient?.tokenAddresses.delete(currency);
     }
   }
 
@@ -354,27 +356,25 @@ class SwapClientManager extends EventEmitter {
    * Closes all swap client instances gracefully.
    * @returns Nothing upon success, throws otherwise.
    */
-  public close = async (): Promise<void> => {
-    const closePromises: Promise<void>[] = [];
+  public close = (): void => {
     let raidenClosed = false;
     for (const swapClient of this.swapClients.values()) {
-      closePromises.push(swapClient.close());
+      swapClient.close();
       if (isRaidenClient(swapClient)) {
         raidenClosed = true;
       }
     }
     for (const swapClient of this.misconfiguredClients) {
-      closePromises.push(swapClient.close());
+      swapClient.close();
       if (isRaidenClient(swapClient)) {
         raidenClosed = true;
       }
     }
     // we make sure to close raiden client because it
     // might not be associated with any currency
-    if (!this.raidenClient.isDisabled() && !raidenClosed) {
-      closePromises.push(this.raidenClient.close());
+    if (this.raidenClient && !this.raidenClient.isDisabled() && !raidenClosed) {
+      this.raidenClient.close();
     }
-    await Promise.all(closePromises);
   }
 
   /**
@@ -460,11 +460,11 @@ class SwapClientManager extends EventEmitter {
     // we handle raiden separately because we don't want to attach
     // duplicate listeners in case raiden client is associated with
     // multiple currencies
-    if (this.raidenClient.isOperational()) {
+    if (this.raidenClient?.isOperational()) {
       this.raidenClient.on('connectionVerified', (swapClientInfo) => {
         const { newIdentifier } = swapClientInfo;
         if (newIdentifier) {
-          this.emit('raidenUpdate', this.raidenClient.tokenAddresses, newIdentifier);
+          this.emit('raidenUpdate', this.raidenClient!.tokenAddresses, newIdentifier);
         }
       });
     }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -156,7 +156,7 @@ class Swaps extends EventEmitter {
         });
       }
     });
-    if (this.swapClientManager.raidenClient.address) {
+    if (this.swapClientManager.raidenClient?.address) {
       this.pool.updateRaidenState(this.swapClientManager.raidenClient.tokenAddresses, this.swapClientManager.raidenClient.address);
     }
 
@@ -791,7 +791,7 @@ class Swaps extends EventEmitter {
       case SwapRole.Maker:
         expectedAmount = deal.makerUnits;
         expectedCurrency = deal.makerCurrency;
-        expectedTokenAddress = this.swapClientManager.raidenClient.tokenAddresses.get(deal.makerCurrency);
+        expectedTokenAddress = this.swapClientManager.raidenClient?.tokenAddresses.get(deal.makerCurrency);
         source = 'Taker';
         destination = 'Maker';
         const lockExpirationDelta = expiration - chain_height;
@@ -819,7 +819,7 @@ class Swaps extends EventEmitter {
       case SwapRole.Taker:
         expectedAmount = deal.takerUnits;
         expectedCurrency = deal.takerCurrency;
-        expectedTokenAddress = this.swapClientManager.raidenClient.tokenAddresses.get(deal.takerCurrency);
+        expectedTokenAddress = this.swapClientManager.raidenClient?.tokenAddresses.get(deal.takerCurrency);
         source = 'Maker';
         destination = 'Taker';
         break;


### PR DESCRIPTION
This commit makes several related changes to the `SwapClient` class, especially in regards to managing the status of a client, with the goal of making future changes and adding new `SwapClient` implementaions or statuses simpler. Key changes include:

- Removing the logic that would enable and disable timers such as the 
`reconnectionTimer` and `updateCapacityTimer` based on the status. Instead, the timers are always running, but only take action if the status matches a specified condition.

- Making all status change calls synchronous. When a particular status involves an asynchronous component, a method that wraps that status change with the asynchronous logic can be used instead (see next point).

- A new `setConnected` method that handles all steps related to marking a client as connected, including updating its capacity.

- An inherited `init` method that handles generic steps around initializing a swap client. It calls an abstract `initSpecific` method that is implemented by each class extending `SwapClient` to contain the client-specific logic for initialization.

- Making the raiden client optional within the swap client manager. When disabled, the raiden client will not be initialized at all.