### PR TITLE
test(sim): decouple nvm/xud installation from the test files image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ seedutil/seedutil
 
 # temp simulation test directory
 test/simulation/temp
+test/docker-xud/xud
 
 # Version file generated in build process
 lib/Version.ts

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:p2p": "mocha --timeout 10000 -r ts-node/register test/p2p/*",
     "test:p2p:watch": "mocha --timeout 10000 -r ts-node/register test/p2p/*  --watch --watch-extensions ts",
     "test:crypto": "mocha --timeout 10000 -r ts-node/register test/crypto/*",
-    "test:sim:build": "(npm run compile:dev && mkdir -p test/simulation/temp/xud && cp -a dist test/simulation/temp/xud && cp -a bin test/simulation/temp/xud && cp package.json test/simulation/temp/xud && cd test/simulation && ./docker-build.sh)",
+    "test:sim:build": "(npm run compile:dev && mkdir -p test/simulation/docker-xud/xud && cp -a dist test/simulation/docker-xud/xud && cp -a bin test/simulation/docker-xud/xud && cp package.json test/simulation/docker-xud/xud && cd test/simulation && ./docker-build.sh)",
     "test:sim:clean": "(cd test/simulation && ./docker-clean.sh)",
     "test:sim": "(cd test/simulation && ./docker-run.sh TestIntegration)",
     "test:sim:run:instability": "(cd test/simulation && ./docker-run.sh TestInstability)",

--- a/test/simulation/Dockerfile
+++ b/test/simulation/Dockerfile
@@ -1,30 +1,20 @@
 FROM golang:1.11
 
+# install rsync, needed for compilation of custom xud nodes
+RUN apt-get update && apt-get -y install rsync
+
 # btcd executable file is expected to be found in $PATH
 ENV PATH="/btcd-vol/go/bin:${PATH}"
 
 # use gomod dependencies download
 ENV GOPATH="/gomod-vol/go"
 
-# install node LTS version via nvm
-ENV NVM_DIR /usr/local/nvm
-WORKDIR $NVM_DIR
-RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install --lts \
-    && nvm alias default lts/* \
-    && nvm use default
-
-# install rsync, needed for compilation of custom xud nodes
-RUN apt-get update && apt-get -y install rsync
-
 ENV WD=/app
 WORKDIR $WD
 
+# copy the test code
 COPY . .
 
-# run npm install
-RUN cd temp/xud && . $NVM_DIR/nvm.sh && npm i
-
 # run the container cmd after doing source on nvm.sh (in order to get `node` executable on $PATH)
+ENV NVM_DIR /nvm-vol
 ENTRYPOINT ["/bin/bash", "-c", ". $NVM_DIR/nvm.sh && \"$@\"", "-s"]

--- a/test/simulation/docker-compose.yml
+++ b/test/simulation/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     build: ./docker-lnd
     volumes:
       - lnd-vol:/app
+  xud:
+    build: ./docker-xud
+    volumes:
+      - xud-vol:/app
+      - nvm-vol:/usr/local/nvm
   gomod:
     build:
       context: .
@@ -19,13 +24,18 @@ services:
     depends_on:
       - btcd
       - lnd
+      - xud
       - gomod
     volumes:
       - btcd-vol:/btcd-vol
       - lnd-vol:/lnd-vol
+      - xud-vol:/xud-vol
+      - nvm-vol:/nvm-vol
       - gomod-vol:/gomod-vol
 volumes:
   btcd-vol:
   lnd-vol:
+  xud-vol:
+  nvm-vol:
   gomod-vol:
 

--- a/test/simulation/docker-xud/Dockerfile
+++ b/test/simulation/docker-xud/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.11
+
+# install node LTS version via nvm
+ENV NVM_DIR /usr/local/nvm
+WORKDIR $NVM_DIR
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install --lts \
+    && nvm alias default lts/* \
+    && nvm use default
+
+ENV WD=/app
+WORKDIR $WD
+
+# copy xud and install dependencies
+COPY xud .
+RUN . $NVM_DIR/nvm.sh && npm i

--- a/test/simulation/xudtest/harness.go
+++ b/test/simulation/xudtest/harness.go
@@ -151,15 +151,8 @@ func (n *NetworkHarness) Start() error {
 
 // SetUp creates the xud nodes to be used for this harness.
 func (n *NetworkHarness) SetUp(noBalanceChecks bool) error {
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	xudPath := filepath.Join(wd, "./temp/xud")
-	if err != nil {
-		return err
-	}
+	xudPath := "/xud-vol"
+	var err error
 
 	n.Alice, err = n.newNode("Alice", xudPath, noBalanceChecks)
 	if err != nil {


### PR DESCRIPTION
Since working on the sim tests mostly involves refactoring test code, binding its deployment to docker with nvm/xud installation caused long docker build times. 

This PR decouples nvm/xud installation to a separate image, so that the test code container can consume it via volumes.

As previously, after changing test code one must run (from within the `test/simulation` dir):
```
$ docker-compose build test
```