### PR TITLE
chore: build sim test images on version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:seedutil": "jest --rootDir seedutil",
     "test:jest:watch": "jest --watch",
     "typedoc": "typedoc --out typedoc --module commonjs --target es6 lib --readme none",
-    "preversion": "npm run lintNoFix && npm test && npm run test:sim",
+    "preversion": "npm run lintNoFix && npm test && npm run test:sim:build && npm run test:sim",
     "postversion": "npm run compile",
     "version": "npm run config && npm run changelog && git add sample-xud.conf CHANGELOG.md && npm run typedoc && npm run slate"
   },


### PR DESCRIPTION
This ensures we are testing with the latest xud code when running simulation tests before tagging a new version.