### PR TITLE
feat(swapclient): add Locked status

### DIFF
--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -18,6 +18,8 @@ enum ClientStatus {
   OutOfSync,
   /** The server is reachable but needs to be unlocked before it accepts calls. */
   WaitingUnlock,
+  /** The server has been unlocked, but its status has not been verified yet. */
+  Unlocked,
   /** The client could not be initialized due to faulty configuration. */
   Misconfigured,
 }
@@ -192,7 +194,11 @@ abstract class SwapClient extends EventEmitter {
   }
 
   private reconnectionTimerCallback = async () => {
-    if (this.status === ClientStatus.Disconnected || this.status === ClientStatus.OutOfSync || this.status === ClientStatus.WaitingUnlock) {
+    if (this.status === ClientStatus.Disconnected
+        || this.status === ClientStatus.OutOfSync
+        || this.status === ClientStatus.WaitingUnlock
+        || this.status === ClientStatus.Unlocked
+      ) {
       try {
         await this.verifyConnection();
       } catch (err) {


### PR DESCRIPTION
This adds a status to the swap clients for after a client has been unlocked but before we have verified its connectivity. There can be additional initialization steps after a client has been unlocked and a possibility that it will encounter an error and shutdown, so we can not assume that the client will be available and set the status to `ConnectionVerified`. However, leaving the status as `WaitingUnlock` can be misleading or lead to additional unlock attempt that will fail. The new `Unlocked` status prevents further unlock attempts.

Closes #1411.