### PR TITLE
test(sim): lock btcd version

### DIFF
--- a/test/simulation/docker-btcd/Dockerfile
+++ b/test/simulation/docker-btcd/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11
 
 WORKDIR /app
-COPY . .
 
-RUN GOPATH=$PWD/go go get -u github.com/btcsuite/btcd
-
+RUN git clone https://github.com/btcsuite/btcd.git
+RUN cd btcd && git checkout tags/v0.20.1-beta
+RUN cd btcd && GOPATH=/app/go go install


### PR DESCRIPTION
Locking `btcd` version to v0.20.1-beta.

This is required since tests were broken due to to recent breaking changes in `btcd` rpc. `lnd` rpcclient dependency version was locked, while the test build version wasn't. 

