### PR TITLE
refactor(swapclients): currency:client type check

### DIFF
--- a/lib/raidenclient/RaidenClient.ts
+++ b/lib/raidenclient/RaidenClient.ts
@@ -105,7 +105,7 @@ class RaidenClient extends SwapClient {
    */
   private setTokenAddresses = (currencyInstances: CurrencyInstance[]) => {
     currencyInstances.forEach((currency) => {
-      if (currency.tokenAddress) {
+      if (currency.swapClient === SwapClientType.Raiden && currency.tokenAddress) {
         this.tokenAddresses.set(currency.id, currency.tokenAddress);
       }
     });

--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -77,7 +77,11 @@ class SwapClientManager extends EventEmitter {
 
     if (!this.config.raiden.disable) {
       // setup Raiden
-      const currencyInstances = await models.Currency.findAll();
+      const currencyInstances = await models.Currency.findAll({
+        where: {
+          swapClient: SwapClientType.Raiden,
+        },
+      });
       this.raidenClient = new RaidenClient({
         currencyInstances,
         unitConverter: this.unitConverter,


### PR DESCRIPTION
EDIT: Closes https://github.com/ExchangeUnion/xud/issues/1433

This adds a check of the swap client type value for each currency before associating it with a given swap client. Currently this only applies to Raiden, which previously was being automatically associated with any currency having a token address.