### PR TITLE
test(sim): wait until xud finish initializing

### DIFF
--- a/test/simulation/xud_test.go
+++ b/test/simulation/xud_test.go
@@ -377,9 +377,6 @@ func launchNetwork(noBalanceChecks bool) (*xudtest.NetworkHarness, func()) {
 		log.Fatalf("cannot start xud network: %v", err)
 	}
 
-	// Wait a bit to avoid calls to xud nodes while still initializing.
-	time.Sleep(3 * time.Second)
-
 	teardown := func() {
 		if err := lndBtcNetworkHarness.TearDownAll(); err != nil {
 			log.Fatalf("lnd-btc: cannot tear down network harness: %v", err)


### PR DESCRIPTION
Off-shoot from https://github.com/ExchangeUnion/xud/pull/1403#discussion_r383079401

Before allowing any RPC calls, verify that xud has finished initializing (not returning "xud is starting" error).

---

Part of https://github.com/ExchangeUnion/xud/issues/1356