### PR TITLE
test(sim): adjust ctx deadline

### DIFF
--- a/test/simulation/harnessTest.go
+++ b/test/simulation/harnessTest.go
@@ -37,18 +37,20 @@ type harnessTest struct {
 	act *actions
 
 	// ctx is the context for the test scenario.
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // newHarnessTest creates a new instance of a harnessTest from a regular
 // testing.T instance.
-func newHarnessTest(ctx context.Context, t *testing.T) *harnessTest {
+func newHarnessTest(ctx context.Context, cancel context.CancelFunc, t *testing.T) *harnessTest {
 	assert := require.New(t)
 	return &harnessTest{
 		t:        t,
 		testCase: nil,
 		assert:   assert,
 		ctx:      ctx,
+		cancel:   cancel,
 
 		// actions instance to contain assert and ctx,
 		// to avoid passing them on every method call.
@@ -93,4 +95,16 @@ func (h *harnessTest) RunTestCase(testCase *testCase, net *xudtest.NetworkHarnes
 	testCase.test(net, h)
 
 	return
+}
+
+func (h *harnessTest) SetCtx(ctx context.Context, cancel context.CancelFunc) {
+	h.cancel()
+
+	h.ctx = ctx
+	h.cancel = cancel
+	h.act = &actions{assert: h.assert, ctx: ctx}
+}
+
+func (h *harnessTest) teardown() {
+	h.cancel()
 }

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -29,7 +29,7 @@ var instabilityTestCases = []*testCase{
 
 func testMakerCrashedAfterSend(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "instability", []string{"BREAKSWAP=MAKER_CRASH_AFTER_SEND"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "instability", []string{"BREAKSWAP=MAKER_CRASH_AFTER_SEND"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -81,10 +81,10 @@ func testMakerCrashedAfterSend(net *xudtest.NetworkHarness, ht *harnessTest) {
 
 func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "instability", []string{"BREAKSWAP=MAKER_CRASH_AFTER_SEND"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "instability", []string{"BREAKSWAP=MAKER_CRASH_AFTER_SEND"})
 	ht.assert.NoError(err)
 
-	net.Bob, err = net.SetCustomXud(net.Bob, "instability", []string{"BREAKSWAP=TAKER_DELAY_BEFORE_SETTLE"})
+	net.Bob, err = net.SetCustomXud(ht.ctx, ht, net.Bob, "instability", []string{"BREAKSWAP=TAKER_DELAY_BEFORE_SETTLE"})
 	ht.assert.NoError(err)
 
 	ht.act.init(net.Alice)

--- a/test/simulation/tests-security.go
+++ b/test/simulation/tests-security.go
@@ -55,7 +55,7 @@ var unsettledChannelsSecurityTests = []*testCase{
 
 func testTakerStallingOnSwapAccepted(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_SWAPACCEPTED_STALL"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_SWAPACCEPTED_STALL"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -118,7 +118,7 @@ func testTakerStallingOnSwapAccepted(net *xudtest.NetworkHarness, ht *harnessTes
 
 func testMakerStallingAfter1stHTLC(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=MAKER_1ST_HTLC_STALL"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=MAKER_1ST_HTLC_STALL"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -185,7 +185,7 @@ func testMakerStallingAfter1stHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 func testMakerShutdownAfter1stHTLC(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=MAKER_1ST_HTLC_SHUTDOWN"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=MAKER_1ST_HTLC_SHUTDOWN"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -313,7 +313,7 @@ func testMakerShutdownAfter1stHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_2ND_HTLC_STALL"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_2ND_HTLC_STALL"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -376,7 +376,7 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_2ND_HTLC_SHUTDOWN"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_2ND_HTLC_SHUTDOWN"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -500,7 +500,7 @@ func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 func testTakerStallingAfterSwapSucceeded(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_SWAPSUCCEEDED_STALL"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "adversarial/breakswap", []string{"BREAKSWAP=TAKER_SWAPSUCCEEDED_STALL"})
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 

--- a/test/simulation/xud_test.go
+++ b/test/simulation/xud_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"os"
 	"strings"
@@ -46,31 +47,36 @@ func TestIntegration(t *testing.T) {
 		teardown()
 	}()
 
-	ht := newHarnessTest(context.Background(), t)
+	assert := require.New(t)
+
 	log.Printf("Running %v integration tests", len(integrationTestCases))
 
 	// Open channels from both directions on each chain.
-	aliceBobBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
-	ht.assert.NoError(err)
-	aliceBobLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
-	ht.assert.NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	bobCarolBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Carol.LndBtcNode)
-	ht.assert.NoError(err)
-	bobCarolLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Carol.LndLtcNode)
-	ht.assert.NoError(err)
+	aliceBobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+	assert.NoError(err)
+	aliceBobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+	assert.NoError(err)
 
-	carolDavidBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, xudNetwork.Dave.LndBtcNode)
-	ht.assert.NoError(err)
-	carolDavidLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, xudNetwork.Dave.LndLtcNode)
-	ht.assert.NoError(err)
+	bobCarolBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Carol.LndBtcNode)
+	assert.NoError(err)
+	bobCarolLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Carol.LndLtcNode)
+	assert.NoError(err)
+
+	carolDavidBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, xudNetwork.Dave.LndBtcNode)
+	assert.NoError(err)
+	carolDavidLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, xudNetwork.Dave.LndLtcNode)
+	assert.NoError(err)
 
 	initialStates := make(map[int]*xudrpc.GetInfoResponse)
 	for i, testCase := range integrationTestCases {
 		success := t.Run(testCase.name, func(t1 *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Timeout))
-			defer cancel()
-			ht := newHarnessTest(ctx, t1)
+			ht := newHarnessTest(ctx, cancel, t1)
+			defer ht.teardown()
+
 			ht.RunTestCase(testCase, xudNetwork)
 		})
 
@@ -80,27 +86,30 @@ func TestIntegration(t *testing.T) {
 			break
 		}
 
+		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
 		// Save the nodes initial state after the initialization test.
 		// On all consecutive tests, verify that it hasn't changed,
 		// so that tests won't be affected by preceding ones.
 		if i == 0 {
 			for num, node := range xudNetwork.ActiveNodes {
-				res, err := node.Client.GetInfo(ht.ctx, &xudrpc.GetInfoRequest{})
-				ht.assert.NoError(err)
+				res, err := node.Client.GetInfo(ctx, &xudrpc.GetInfoRequest{})
+				assert.NoError(err)
 				initialStates[num] = res
 			}
 		} else {
 			for num, node := range xudNetwork.ActiveNodes {
-				res, err := node.Client.GetInfo(ht.ctx, &xudrpc.GetInfoRequest{})
-				ht.assert.NoError(err)
+				res, err := node.Client.GetInfo(ctx, &xudrpc.GetInfoRequest{})
+				assert.NoError(err)
 				initialState, ok := initialStates[num]
-				ht.assert.True(ok)
+				assert.True(ok)
 
 				msg := fmt.Sprintf("test should not leave a node (%v) in altered state", node.Name)
-				ht.assert.Equal(initialState.Version, res.Version, msg)
-				ht.assert.Equal(initialState.NodePubKey, res.NodePubKey, msg)
+				assert.Equal(initialState.Version, res.Version, msg)
+				assert.Equal(initialState.NodePubKey, res.NodePubKey, msg)
 				//		ht.assert.Equal(initialState.NumPeers, res.NumPeers, msg)
-				ht.assert.Equal(initialState.NumPairs, res.NumPairs, msg)
+				assert.Equal(initialState.NumPairs, res.NumPairs, msg)
 
 				// TODO: check why the following assertion fails after 'order_matching_and_swap' test.
 				// ht.assert.Equal(initialState.Orders, res.Orders, msg)
@@ -109,37 +118,45 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// Close all channels, mostly in order to verify there are no pending HTLCs (which would require force-close).
-	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBobBtcChanPoint, false)
-	ht.assert.NoError(err)
-	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceBobLtcChanPoint, false)
-	ht.assert.NoError(err)
-	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, bobCarolBtcChanPoint, false)
-	ht.assert.NoError(err)
-	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, bobCarolLtcChanPoint, false)
-	ht.assert.NoError(err)
-	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, carolDavidBtcChanPoint, false)
-	ht.assert.NoError(err)
-	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, carolDavidLtcChanPoint, false)
-	ht.assert.NoError(err)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = closeBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBobBtcChanPoint, false)
+	assert.NoError(err)
+	err = closeLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceBobLtcChanPoint, false)
+	assert.NoError(err)
+	err = closeBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, bobCarolBtcChanPoint, false)
+	assert.NoError(err)
+	err = closeLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, bobCarolLtcChanPoint, false)
+	assert.NoError(err)
+	err = closeBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, carolDavidBtcChanPoint, false)
+	assert.NoError(err)
+	err = closeLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, carolDavidLtcChanPoint, false)
+	assert.NoError(err)
 }
 
 func TestInstability(t *testing.T) {
 	xudNetwork, teardown := launchNetwork(true)
 	defer teardown()
-	ht := newHarnessTest(context.Background(), t)
+
+	assert := require.New(t)
+
 	log.Printf("Running %v instability tests", len(instabilityTestCases))
 
 	// Open channels from both directions on each chain.
-	aliceBobBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
-	ht.assert.NoError(err)
-	aliceBobLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
-	ht.assert.NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	aliceBobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+	assert.NoError(err)
+	aliceBobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+	assert.NoError(err)
 
 	for _, testCase := range instabilityTestCases {
 		success := t.Run(testCase.name, func(t1 *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-			ht := newHarnessTest(ctx, t1)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ht := newHarnessTest(ctx, cancel, t1)
+			defer ht.teardown()
+
 			ht.RunTestCase(testCase, xudNetwork)
 		})
 
@@ -149,42 +166,48 @@ func TestInstability(t *testing.T) {
 	}
 
 	// Close all channels before next iteration.
-	err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBobBtcChanPoint, false)
-	ht.assert.NoError(err)
-	err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceBobLtcChanPoint, false)
-	ht.assert.NoError(err)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = closeBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBobBtcChanPoint, false)
+	assert.NoError(err)
+	err = closeLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceBobLtcChanPoint, false)
+	assert.NoError(err)
 }
 
 func TestSecurity(t *testing.T) {
 	xudNetwork, teardown := launchNetwork(true)
 	defer teardown()
 
-	ht := newHarnessTest(context.Background(), t)
+	assert := require.New(t)
+
 	log.Printf("Running %v security tests", len(securityTestCases))
 
 	// For each test: open channels, save the balance, execute the test,
 	// compare the balance and close the channels cooperatively.
 	for _, testCase := range securityTestCases {
 		// Open channels from both directions on each chain.
-		aliceBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
-		ht.assert.NoError(err)
-		aliceLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
-		ht.assert.NoError(err)
-		bobBtcChanPoint, err := openBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Alice.LndBtcNode)
-		ht.assert.NoError(err)
-		bobLtcChanPoint, err := openLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Alice.LndLtcNode)
-		ht.assert.NoError(err)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		aliceBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+		assert.NoError(err)
+		aliceLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+		assert.NoError(err)
+		bobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Alice.LndBtcNode)
+		assert.NoError(err)
+		bobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Alice.LndLtcNode)
+		assert.NoError(err)
 
 		// Save the initial balance.
-		alicePrevBalance, err := getBalance(ht.ctx, xudNetwork.Alice)
-		ht.assert.NoError(err)
-		bobPrevBalance, err := getBalance(ht.ctx, xudNetwork.Bob)
-		ht.assert.NoError(err)
+		alicePrevBalance, err := getBalance(ctx, xudNetwork.Alice)
+		assert.NoError(err)
+		bobPrevBalance, err := getBalance(ctx, xudNetwork.Bob)
+		assert.NoError(err)
 
 		success := t.Run(testCase.name, func(t1 *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-			defer cancel()
-			ht := newHarnessTest(ctx, t1)
+			ht := newHarnessTest(ctx, cancel, t1)
+			defer ht.teardown()
+
 			ht.RunTestCase(testCase, xudNetwork)
 		})
 
@@ -192,26 +215,29 @@ func TestSecurity(t *testing.T) {
 			break
 		}
 
+		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
 		if !testCase.balanceMayChange {
 			// Verify that balance remain unchanged.
-			aliceBalance, err := getBalance(ht.ctx, xudNetwork.Alice)
-			ht.assert.NoError(err)
-			ht.assert.Equal(alicePrevBalance, aliceBalance, "alice balance mismatch")
+			aliceBalance, err := getBalance(ctx, xudNetwork.Alice)
+			assert.NoError(err)
+			assert.Equal(alicePrevBalance, aliceBalance, "alice balance mismatch")
 
-			bobBalance, err := getBalance(ht.ctx, xudNetwork.Bob)
-			ht.assert.NoError(err)
-			ht.assert.Equal(bobPrevBalance, bobBalance, "bob balance mismatch")
+			bobBalance, err := getBalance(ctx, xudNetwork.Bob)
+			assert.NoError(err)
+			assert.Equal(bobPrevBalance, bobBalance, "bob balance mismatch")
 		}
 
 		// Close all channels before next iteration.
-		err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBtcChanPoint, false)
-		ht.assert.NoError(err)
-		err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceLtcChanPoint, false)
-		ht.assert.NoError(err)
-		err = closeBtcChannel(ht.ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, bobBtcChanPoint, false)
-		ht.assert.NoError(err)
-		err = closeLtcChannel(ht.ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, bobLtcChanPoint, false)
-		ht.assert.NoError(err)
+		err = closeBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, aliceBtcChanPoint, false)
+		assert.NoError(err)
+		err = closeLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, aliceLtcChanPoint, false)
+		assert.NoError(err)
+		err = closeBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, bobBtcChanPoint, false)
+		assert.NoError(err)
+		err = closeLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, bobLtcChanPoint, false)
+		assert.NoError(err)
 	}
 }
 
@@ -224,8 +250,9 @@ func TestSecurityUnsettledChannels(t *testing.T) {
 	for _, testCase := range unsettledChannelsSecurityTests {
 		success := t.Run(testCase.name, func(t1 *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(20*time.Minute))
-			defer cancel()
-			ht := newHarnessTest(ctx, t1)
+			ht := newHarnessTest(ctx, cancel, t1)
+			ht.teardown()
+
 			ht.RunTestCase(testCase, xudNetwork)
 		})
 

--- a/test/simulation/xud_test.go
+++ b/test/simulation/xud_test.go
@@ -251,7 +251,7 @@ func TestSecurityUnsettledChannels(t *testing.T) {
 		success := t.Run(testCase.name, func(t1 *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(20*time.Minute))
 			ht := newHarnessTest(ctx, cancel, t1)
-			ht.teardown()
+			defer ht.teardown()
 
 			ht.RunTestCase(testCase, xudNetwork)
 		})


### PR DESCRIPTION
Off-shoot from https://github.com/ExchangeUnion/xud/pull/1403#discussion_r383079446

Whenever a custom xud client is being downloaded/installed, adjust the ctx deadline so that time spent won't consume the test timeout duration.

Also added timeouts to channel openings (lesson from https://github.com/ExchangeUnion/xud/commit/b0ab4eb06bd0bf328675c20894167d3fcd47dbe5).

--- 

Part of #1356

