### PR TITLE
test(sim): export lnd instances logs

### DIFF
--- a/test/simulation/logs.sh
+++ b/test/simulation/logs.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cat $PWD/temp/logs/*.log > "$PWD/temp/xud.log"
-cat $PWD/temp/xud.log
+cat $PWD/temp/logs/*.log


### PR DESCRIPTION
Export test run bitcoin/litecoin lnd instances logs under `test/simulation/temp/logs` (available for print via `npm run test:sim:logs`).

---

Part of https://github.com/ExchangeUnion/xud/issues/1356