### PR TITLE
fix(lnd): don't check for manual unlock

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -433,6 +433,10 @@ class LndClient extends SwapClient {
     if (!this.isOperational()) {
       throw(errors.DISABLED);
     }
+    if (this.isWaitingUnlock()) {
+      return; // temporary workaround to prevent unexplained lnd crashes after unlock
+    }
+
     if (this.macaroonpath && this.meta.get('macaroon').length === 0) {
       // we have not loaded the macaroon yet - it is not created until the lnd wallet is initialized
       if (!this.isWaitingUnlock()) { // check that we are not already waiting for wallet init & unlock


### PR DESCRIPTION
This is a workaround fix to prevent unexplained crashes in lnd after it is unlocked. It prevents lnd from checking if it is manually unlocked outside of xud. The downside is that if lnd is unlocked while xud is running, xud won't be aware.

This is related to #1415 and the issue with lnd crashing suddenly. I'm still not clear on why exactly this change seems to make the issue go away, but I no longer experience the issue with this. I suspect this is related to lnd using multiple services for unlock calls and for regular get info calls, they have plans to merge the two and I'll revisit this after that happens.