### PR TITLE
chore: ignore xud docker sim test directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ seedutil/seedutil
 
 # temp simulation test directory
 test/simulation/temp
-test/docker-xud/xud
+test/simulation/docker-xud/xud
 
 # Version file generated in build process
 lib/Version.ts


### PR DESCRIPTION
Running dockerized simulation tests was creating a directory that was not being ignored by git. This change prevents that from being picked up by git.