### PR TITLE
fix(orderbook): match own orders before peers'

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -63,7 +63,13 @@ class TradingPair {
 
     return (a: Order, b: Order) => {
       if (a.price === b.price) {
-        return a.createdAt < b.createdAt;
+        if (isOwnOrder(a) && !isOwnOrder(b)) {
+          return true;
+        } else if (!isOwnOrder(a) && isOwnOrder(b)) {
+          return false;
+        } else {
+          return a.createdAt < b.createdAt;
+        }
       } else {
         return directionComparator(a.price, b.price);
       }

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
+import { OrderingDirection } from '../../lib/constants/enums';
 import Logger, { Level } from '../../lib/Logger';
 import TradingPair from '../../lib/orderbook/TradingPair';
-import { OrderingDirection } from '../../lib/constants/enums';
 import { ms } from '../../lib/utils/utils';
 import { createOwnOrder, createPeerOrder } from '../utils';
 
@@ -138,6 +138,17 @@ describe('TradingPair.match', () => {
     tp.addPeerOrder(createPeerOrder(5, 5, false));
     const { remainingOrder } = tp.match(createOwnOrder(5, 10, true));
     expect(remainingOrder).to.be.undefined;
+  });
+
+  it('should match with own order if equivalent peer order exists', () => {
+    const peerOrder = createPeerOrder(5, 5, false);
+    const ownOrder = createOwnOrder(5, 5, false);
+    tp.addPeerOrder(peerOrder);
+    tp.addOwnOrder(ownOrder);
+    const { matches, remainingOrder } = tp.match(createOwnOrder(5, 5, true));
+    expect(remainingOrder).to.be.undefined;
+    expect(matches[0].maker).to.not.equal(peerOrder);
+    expect(matches[0].maker).to.equal(ownOrder);
   });
 
   it('should split taker order when makers are insufficient', () => {


### PR DESCRIPTION
This fixes the matching engine order book priority to prefer own orders over peer orders when two orders have the same price. Previously, the engine would take whichever order was seen first. This is now only considered if two given orders at the same price point are either both own orders or both peer orders.

Fixes #1206.