### PR TITLE
feat(cli): automatically determine rpc host/port

### DIFF
--- a/bin/xucli
+++ b/bin/xucli
@@ -12,13 +12,11 @@ require('yargs')
     },
     rpcport: {
       alias: 'p',
-      default: 8886,
       describe: 'RPC service port',
       type: 'number',
     },
     rpchost: {
       alias: 'h',
-      default: 'localhost',
       describe: 'RPC service hostname',
       type: 'string',
     },
@@ -32,6 +30,11 @@ require('yargs')
       describe: 'Display output in json format',
       type: 'boolean',
       default: false,
+    },
+    xudir: {
+      alias: 'x',
+      describe: 'Data directory for xud',
+      type: 'string',
     },
   })
   .commandDir('../dist/cli/commands/', { recurse: true })

--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -1,25 +1,54 @@
 import fs from 'fs';
 import grpc, { status } from 'grpc';
+import path from 'path';
 import { Arguments } from 'yargs';
+import Config from '../Config';
 import { XudClient, XudInitClient } from '../proto/xudrpc_grpc_pb';
-import { getDefaultCertPath } from './utils';
 
 /**
  * A generic function to instantiate an XU client.
  * @param argv the command line arguments
  */
-export const loadXudClient = (argv: Arguments<any>) => {
-  const certPath = argv.tlscertpath || getDefaultCertPath();
+export const loadXudClient = async (argv: Arguments<any>) => {
+  const config = new Config();
+  await config.load({
+    xudir: argv.xudir,
+    rpc: {
+      port: argv.rpcport,
+      host: argv.rpchost,
+    },
+  });
+
+  const certPath = argv.tlscertpath || path.join(config.xudir, 'tls.cert');
   const cert = fs.readFileSync(certPath);
   const credentials = grpc.credentials.createSsl(cert);
+
+  // in case port and host args were not set, we update them to the values we
+  // determined by loading the config
+  argv.rpcport = config.rpc.port;
+  argv.rpchost = config.rpc.host;
 
   return new XudClient(`${argv.rpchost}:${argv.rpcport}`, credentials);
 };
 
-export const loadXudInitClient = (argv: Arguments<any>) => {
-  const certPath = argv.tlscertpath || getDefaultCertPath();
+export const loadXudInitClient = async (argv: Arguments<any>) => {
+  const config = new Config();
+  await config.load({
+    xudir: argv.xudir,
+    rpc: {
+      port: argv.rpcport,
+      host: argv.rpchost,
+    },
+  });
+
+  const certPath = argv.tlscertpath || path.join(config.xudir, 'tls.cert');
   const cert = fs.readFileSync(certPath);
   const credentials = grpc.credentials.createSsl(cert);
+
+  // in case port and host args were not set, we update them to the values we
+  // determined by loading the config
+  argv.rpcport = config.rpc.port;
+  argv.rpchost = config.rpc.host;
 
   return new XudInitClient(`${argv.rpchost}:${argv.rpcport}`, credentials);
 };

--- a/lib/cli/commands/addcurrency.ts
+++ b/lib/cli/commands/addcurrency.ts
@@ -28,11 +28,11 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new Currency();
   request.setCurrency(argv.currency.toUpperCase());
   request.setSwapClient(Number(SwapClientType[argv.swap_client]));
   request.setTokenAddress(argv.token_address);
   request.setDecimalPlaces(argv.decimal_places);
-  loadXudClient(argv).addCurrency(request, callback(argv));
+  (await loadXudClient(argv)).addCurrency(request, callback(argv));
 };

--- a/lib/cli/commands/addpair.ts
+++ b/lib/cli/commands/addpair.ts
@@ -17,9 +17,9 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new AddPairRequest();
   request.setBaseCurrency(argv.base_currency.toUpperCase());
   request.setQuoteCurrency(argv.quote_currency.toUpperCase());
-  loadXudClient(argv).addPair(request, callback(argv));
+  (await loadXudClient(argv)).addPair(request, callback(argv));
 };

--- a/lib/cli/commands/ban.ts
+++ b/lib/cli/commands/ban.ts
@@ -13,8 +13,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new BanRequest();
   request.setNodeIdentifier(argv.node_identifier);
-  loadXudClient(argv).ban(request, callback(argv));
+  (await loadXudClient(argv)).ban(request, callback(argv));
 };

--- a/lib/cli/commands/buy.ts
+++ b/lib/cli/commands/buy.ts
@@ -8,4 +8,4 @@ export const describe = 'place a buy order';
 
 export const builder = (argv: Argv) => placeOrderBuilder(argv, OrderSide.BUY);
 
-export const handler = (argv: Arguments) => placeOrderHandler(argv, OrderSide.BUY);
+export const handler = async (argv: Arguments) => placeOrderHandler(argv, OrderSide.BUY);

--- a/lib/cli/commands/connect.ts
+++ b/lib/cli/commands/connect.ts
@@ -13,8 +13,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new ConnectRequest();
   request.setNodeUri(argv.node_uri);
-  loadXudClient(argv).connect(request, callback(argv));
+  (await loadXudClient(argv)).connect(request, callback(argv));
 };

--- a/lib/cli/commands/create.ts
+++ b/lib/cli/commands/create.ts
@@ -79,7 +79,7 @@ a single password provided below.
           return;
         }
 
-        const client = loadXudInitClient(argv);
+        const client = await loadXudInitClient(argv);
         // wait up to 3 seconds for rpc server to listen before call in case xud was just started
         client.waitForReady(Date.now() + 3000, () => {
           client.createNode(request, callback(argv, formatOutput));

--- a/lib/cli/commands/discovernodes.ts
+++ b/lib/cli/commands/discovernodes.ts
@@ -13,8 +13,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new DiscoverNodesRequest();
   request.setNodeIdentifier(argv.node_identifier);
-  loadXudClient(argv).discoverNodes(request, callback(argv));
+  (await loadXudClient(argv)).discoverNodes(request, callback(argv));
 };

--- a/lib/cli/commands/executeswap.ts
+++ b/lib/cli/commands/executeswap.ts
@@ -33,12 +33,12 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new ExecuteSwapRequest();
   request.setOrderId(argv.order_id);
   request.setPairId(argv.pair_id);
   if (argv.quantity) {
     request.setQuantity(coinsToSats(argv.quantity));
   }
-  loadXudClient(argv).executeSwap(request, callback(argv, displaySwapSuccess));
+  (await loadXudClient(argv)).executeSwap(request, callback(argv, displaySwapSuccess));
 };

--- a/lib/cli/commands/getbalance.ts
+++ b/lib/cli/commands/getbalance.ts
@@ -70,10 +70,10 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new GetBalanceRequest();
   if (argv.currency) {
     request.setCurrency(argv.currency.toUpperCase());
   }
-  loadXudClient(argv).getBalance(request, callback(argv, displayBalances));
+  (await loadXudClient(argv)).getBalance(request, callback(argv, displayBalances));
 };

--- a/lib/cli/commands/getinfo.ts
+++ b/lib/cli/commands/getinfo.ts
@@ -108,6 +108,6 @@ export const command = 'getinfo';
 
 export const describe = 'get general info from the local xud node';
 
-export const handler = (argv: Arguments) => {
-  loadXudClient(argv).getInfo(new GetInfoRequest(), callback(argv, displayGetInfo));
+export const handler = async (argv: Arguments) => {
+  (await loadXudClient(argv)).getInfo(new GetInfoRequest(), callback(argv, displayGetInfo));
 };

--- a/lib/cli/commands/getnodeinfo.ts
+++ b/lib/cli/commands/getnodeinfo.ts
@@ -26,8 +26,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new GetNodeInfoRequest();
   request.setNodeIdentifier(argv.node_identifier);
-  loadXudClient(argv).getNodeInfo(request, callback(argv, displayNodeInfo));
+  (await loadXudClient(argv)).getNodeInfo(request, callback(argv, displayNodeInfo));
 };

--- a/lib/cli/commands/listcurrencies.ts
+++ b/lib/cli/commands/listcurrencies.ts
@@ -43,6 +43,6 @@ export const command = 'listcurrencies';
 
 export const describe = 'list available currencies';
 
-export const handler = (argv: Arguments) => {
-  loadXudClient(argv).listCurrencies(new ListCurrenciesRequest(), callback(argv, displayTable));
+export const handler = async (argv: Arguments) => {
+  (await loadXudClient(argv)).listCurrencies(new ListCurrenciesRequest(), callback(argv, displayTable));
 };

--- a/lib/cli/commands/listorders.ts
+++ b/lib/cli/commands/listorders.ts
@@ -101,11 +101,11 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new ListOrdersRequest();
   const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
   request.setPairId(pairId);
   request.setOwner(Number(Owner[argv.owner]));
   request.setLimit(argv.limit);
-  loadXudClient(argv).listOrders(request, callback(argv, displayTables));
+  (await loadXudClient(argv)).listOrders(request, callback(argv, displayTables));
 };

--- a/lib/cli/commands/listpairs.ts
+++ b/lib/cli/commands/listpairs.ts
@@ -28,6 +28,6 @@ export const command = 'listpairs';
 
 export const describe = 'get order book\'s available pairs';
 
-export const handler = (argv: Arguments) => {
-  loadXudClient(argv).listPairs(new ListPairsRequest(), callback(argv, displayPairs));
+export const handler = async (argv: Arguments) => {
+  (await loadXudClient(argv)).listPairs(new ListPairsRequest(), callback(argv, displayPairs));
 };

--- a/lib/cli/commands/listpeers.ts
+++ b/lib/cli/commands/listpeers.ts
@@ -80,6 +80,6 @@ export const command = 'listpeers';
 
 export const describe = 'list connected peers';
 
-export const handler = (argv: Arguments) => {
-  loadXudClient(argv).listPeers(new ListPeersRequest(), callback(argv, displayTables));
+export const handler = async (argv: Arguments) => {
+  (await loadXudClient(argv)).listPeers(new ListPeersRequest(), callback(argv, displayTables));
 };

--- a/lib/cli/commands/listtrades.ts
+++ b/lib/cli/commands/listtrades.ts
@@ -46,8 +46,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new ListTradesRequest();
   request.setLimit(argv.limit);
-  loadXudClient(argv).listTrades(request, callback(argv, displayTrades));
+  (await loadXudClient(argv)).listTrades(request, callback(argv, displayTrades));
 };

--- a/lib/cli/commands/openchannel.ts
+++ b/lib/cli/commands/openchannel.ts
@@ -26,11 +26,12 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new OpenChannelRequest();
   request.setNodeIdentifier(argv.node_identifier);
   request.setCurrency(argv.currency.toUpperCase());
   request.setAmount(coinsToSats(argv.amount));
   request.setPushAmount(coinsToSats(argv.amount));
-  loadXudClient(argv).openChannel(request, callback(argv));
+
+  (await loadXudClient(argv)).openChannel(request, callback(argv));
 };

--- a/lib/cli/commands/orderbook.ts
+++ b/lib/cli/commands/orderbook.ts
@@ -178,10 +178,10 @@ const displayJson = (orders: ListOrdersResponse.AsObject, argv: Arguments<any>) 
   console.log(JSON.stringify(jsonOrderbooks, undefined, 2));
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new ListOrdersRequest();
   const pairId = argv.pair_id ? argv.pair_id.toUpperCase() : undefined;
   request.setPairId(pairId);
   request.setOwner(Number(Owner.Both));
-  loadXudClient(argv).listOrders(request, callback(argv, displayTables, displayJson));
+  (await loadXudClient(argv)).listOrders(request, callback(argv, displayTables, displayJson));
 };

--- a/lib/cli/commands/removecurrency.ts
+++ b/lib/cli/commands/removecurrency.ts
@@ -13,8 +13,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new RemoveCurrencyRequest();
   request.setCurrency(argv.currency.toUpperCase());
-  loadXudClient(argv).removeCurrency(request, callback(argv));
+  (await loadXudClient(argv)).removeCurrency(request, callback(argv));
 };

--- a/lib/cli/commands/removeorder.ts
+++ b/lib/cli/commands/removeorder.ts
@@ -17,11 +17,11 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new RemoveOrderRequest();
   request.setOrderId(argv.order_id);
   if (argv.quantity) {
     request.setQuantity(coinsToSats(argv.quantity));
   }
-  loadXudClient(argv).removeOrder(request, callback(argv));
+  (await loadXudClient(argv)).removeOrder(request, callback(argv));
 };

--- a/lib/cli/commands/removepair.ts
+++ b/lib/cli/commands/removepair.ts
@@ -13,8 +13,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new RemovePairRequest();
   request.setPairId(argv.pair_id.toUpperCase());
-  loadXudClient(argv).removePair(request, callback(argv));
+  (await loadXudClient(argv)).removePair(request, callback(argv));
 };

--- a/lib/cli/commands/restore.ts
+++ b/lib/cli/commands/restore.ts
@@ -158,7 +158,7 @@ a single password provided below.
             return;
           }
 
-          const client = loadXudInitClient(argv);
+          const client = await loadXudInitClient(argv);
           // wait up to 3 seconds for rpc server to listen before call in case xud was just started
           client.waitForReady(Date.now() + 3000, () => {
             client.restoreNode(request, callback(argv, formatOutput));

--- a/lib/cli/commands/sell.ts
+++ b/lib/cli/commands/sell.ts
@@ -8,4 +8,4 @@ export const describe = 'place a sell order';
 
 export const builder = (argv: Argv) => placeOrderBuilder(argv, OrderSide.SELL);
 
-export const handler = (argv: Arguments) => placeOrderHandler(argv, OrderSide.SELL);
+export const handler = async (argv: Arguments) => placeOrderHandler(argv, OrderSide.SELL);

--- a/lib/cli/commands/shutdown.ts
+++ b/lib/cli/commands/shutdown.ts
@@ -6,6 +6,6 @@ export const command = 'shutdown';
 
 export const describe = 'gracefully shutdown local xud node';
 
-export const handler = (argv: Arguments) => {
-  loadXudClient(argv).shutdown(new ShutdownRequest(), callback(argv));
+export const handler = async (argv: Arguments) => {
+  (await loadXudClient(argv)).shutdown(new ShutdownRequest(), callback(argv));
 };

--- a/lib/cli/commands/tradinglimits.ts
+++ b/lib/cli/commands/tradinglimits.ts
@@ -51,11 +51,11 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new TradingLimitsRequest();
   if (argv.currency) {
     request.setCurrency(argv.currency.toUpperCase());
   }
 
-  loadXudClient(argv).tradingLimits(request, callback(argv, displayLimits));
+  (await loadXudClient(argv)).tradingLimits(request, callback(argv, displayLimits));
 };

--- a/lib/cli/commands/unban.ts
+++ b/lib/cli/commands/unban.ts
@@ -18,9 +18,9 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new UnbanRequest();
   request.setNodeIdentifier(argv.node_identifier);
   request.setReconnect(argv.reconnect);
-  loadXudClient(argv).unban(request, callback(argv));
+  (await loadXudClient(argv)).unban(request, callback(argv));
 };

--- a/lib/cli/commands/unlock.ts
+++ b/lib/cli/commands/unlock.ts
@@ -26,12 +26,12 @@ export const handler = (argv: Arguments) => {
   });
 
   process.stdout.write('Enter master xud password: ');
-  rl.question('', (password) => {
+  rl.question('', async (password) => {
     process.stdout.write('\n');
     rl.close();
     const request = new UnlockNodeRequest();
     request.setPassword(password);
-    const client = loadXudInitClient(argv);
+    const client = await loadXudInitClient(argv);
     // wait up to 3 seconds for rpc server to listen before call in case xud was just started
     client.waitForReady(Date.now() + 3000, () => {
       client.unlockNode(request, callback(argv, formatOutput));

--- a/lib/cli/placeorder.ts
+++ b/lib/cli/placeorder.ts
@@ -43,7 +43,7 @@ export const placeOrderBuilder = (argv: Argv, side: OrderSide) => {
   .example(`$0 ${command} 10 ZRX/GNT market`, `place a market order to ${command} 10 ZRX for GNT`);
 };
 
-export const placeOrderHandler = (argv: Arguments<any>, side: OrderSide) => {
+export const placeOrderHandler = async (argv: Arguments<any>, side: OrderSide) => {
   const request = new PlaceOrderRequest();
 
   const numericPrice = Number(argv.price);
@@ -74,8 +74,9 @@ export const placeOrderHandler = (argv: Arguments<any>, side: OrderSide) => {
     request.setReplaceOrderId(argv.replace_order_id);
   }
 
+  const client = await loadXudClient(argv);
   if (argv.stream) {
-    const subscription = loadXudClient(argv).placeOrder(request);
+    const subscription = client.placeOrder(request);
     let noMatches = true;
     subscription.on('data', (response: PlaceOrderEvent) => {
       if (argv.json) {
@@ -108,7 +109,7 @@ export const placeOrderHandler = (argv: Arguments<any>, side: OrderSide) => {
       console.error(err.message);
     });
   } else {
-    loadXudClient(argv).placeOrderSync(request, callback(argv, formatPlaceOrderOutput));
+    client.placeOrderSync(request, callback(argv, formatPlaceOrderOutput));
   }
 };
 


### PR DESCRIPTION
This enhances the cli to automatically attempt to find and read from the xud configuration file to determine the port and host for the xud gRPC service based on the configured network - which determines default port numbers - or configured port if specified. This prevents the user from having to specify the rpc port on `xucli` commands when using a non-mainnet xud instance or a non-default gRPC port via the config file.

Closes #1451.