### PR TITLE
fix(lnd): relax unhandled openchannel timeout

### DIFF
--- a/test/jest/LndClient.spec.ts
+++ b/test/jest/LndClient.spec.ts
@@ -126,30 +126,6 @@ describe('LndClient', () => {
         .toHaveBeenCalledWith(peerPubKey, units);
     });
 
-    test('it throws when timeout reached', async () => {
-      expect.assertions(3);
-      jest.useFakeTimers();
-      lnd['openChannelSync'] = jest.fn().mockReturnValue(Promise.resolve());
-      const timeOut = () => {
-        jest.runAllTimers();
-        return new Promise(() => {});
-      };
-      lnd['connectPeer'] = jest.fn()
-        .mockImplementation(timeOut);
-      try {
-        await lnd.openChannel({
-          units,
-          peerIdentifier: peerPubKey,
-          lndUris: lndListeningUris,
-        });
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
-      expect(lnd['connectPeer']).toHaveBeenCalledTimes(2);
-      expect(lnd['openChannelSync']).not.toHaveBeenCalled();
-      jest.clearAllTimers();
-    });
-
     test('it stops trying to connect to lnd uris when first once succeeds', async () => {
       expect.assertions(3);
       lnd['openChannelSync'] = jest.fn().mockReturnValue(Promise.resolve());

--- a/test/jest/__snapshots__/LndClient.spec.ts.snap
+++ b/test/jest/__snapshots__/LndClient.spec.ts.snap
@@ -1,10 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LndClient openChannel it throws when connectPeer fails 1`] = `[Error: connectPeerAddreses failed]`;
+exports[`LndClient openChannel it throws when connectPeer fails 1`] = `[Error: could not connect to lnd uris for 02f8895eb03c37b2665415be4d83b20228acc0abc55ebf6728565141c66cfc164a]`;
 
 exports[`LndClient openChannel it throws when openchannel fails 1`] = `[Error: openChannelSync error]`;
-
-exports[`LndClient openChannel it throws when timeout reached 1`] = `[Error: connectPeerAddreses failed]`;
 
 exports[`LndClient sendPayment it rejects upon sendPaymentSync error 1`] = `
 Object {


### PR DESCRIPTION
This removes the hard timeout placed on each attempt to connect to a peer's lnd node when attempting to open a channel with that peer. This timeout was causing xud to crash because it threw an error that was not being handled in the encapsulating catch block, which did not catch the error because it was thrown from a callback.

Rather than attempt to correct the asynchronous exception handling, this lifts the timeout limit set within xud and instead will wait on each connect attempt until it succeeds, times out, or fails according to the logic within lnd.

Fixes #1405.