### PR TITLE
fix: string message grpc error handling

### DIFF
--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -75,9 +75,9 @@ const getGrpcError = (err: any) => {
 
   // return a grpc error with the code if we've assigned one, otherwise pass along the caught error as UNKNOWN
   const grpcError: grpc.ServiceError = {
-    code: code || status.UNKNOWN,
-    message: err.message,
-    name: err.name,
+    code: code ?? status.UNKNOWN,
+    message: err.message ?? (typeof err === 'string' ? err : ''),
+    name: err.name ?? 'UnknownError',
   };
 
   return grpcError;


### PR DESCRIPTION
This fixes an internal bug where passing a string to the `getGrpcError` method - or possibly any object without `code`, `message`, or `name` properties - would result in a gRPC exception of `TypeError: Incorrectly typed arguments to startBatch` that is unhandled and crashes xud. This ensures that the gRPC errors returned by xud are well-formed.