### PR TITLE
fix(cli): use localhost when rpc config 0.0.0.0 

### DIFF
--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -13,13 +13,19 @@ import { XudClient, XudInitClient } from '../proto/xudrpc_grpc_pb';
  */
 const loadXudConfig = async (argv: Arguments<any>) => {
   const config = new Config();
-  await config.load({
-    xudir: argv.xudir,
-    rpc: {
-      port: argv.rpcport,
-      host: argv.rpchost,
-    },
-  });
+  try {
+    await config.load({
+      xudir: argv.xudir,
+      rpc: {
+        port: argv.rpcport,
+        host: argv.rpchost,
+      },
+    });
+  } catch (err) {
+    // if we can't load the config file, we should alert the user but continue
+    // on to attempt the call with the commands args or default config values
+    console.error(err);
+  }
 
   // for any args that were not set, we update them to the values we
   // determined by loading the config

--- a/lib/cli/command.ts
+++ b/lib/cli/command.ts
@@ -6,10 +6,12 @@ import Config from '../Config';
 import { XudClient, XudInitClient } from '../proto/xudrpc_grpc_pb';
 
 /**
- * A generic function to instantiate an XU client.
+ * Attempts to load the xud configuration file to dynamically determine the
+ * port and interface that xud is listening for rpc calls on as well as the
+ * tls cert path, if arguments specifying these parameters were not provided.
  * @param argv the command line arguments
  */
-export const loadXudClient = async (argv: Arguments<any>) => {
+const loadXudConfig = async (argv: Arguments<any>) => {
   const config = new Config();
   await config.load({
     xudir: argv.xudir,
@@ -19,36 +21,37 @@ export const loadXudClient = async (argv: Arguments<any>) => {
     },
   });
 
-  const certPath = argv.tlscertpath || path.join(config.xudir, 'tls.cert');
+  // for any args that were not set, we update them to the values we
+  // determined by loading the config
+  argv.xudir = argv.xudir ?? config.xudir;
+  argv.rpcport = argv.rpcport ?? config.rpc.port;
+  if (argv.rpchost === undefined) {
+    argv.rpchost = (config.rpc.host === '0.0.0.0' || config.rpc.host === '::') ?
+      'localhost' : // if xud is listening on any address, try reaching it with localhost
+      config.rpc.host;
+  }
+};
+
+/**
+ * A generic function to instantiate an XU client.
+ * @param argv the command line arguments
+ */
+export const loadXudClient = async (argv: Arguments<any>) => {
+  await loadXudConfig(argv);
+
+  const certPath = argv.tlscertpath || path.join(argv.xudir, 'tls.cert');
   const cert = fs.readFileSync(certPath);
   const credentials = grpc.credentials.createSsl(cert);
-
-  // in case port and host args were not set, we update them to the values we
-  // determined by loading the config
-  argv.rpcport = config.rpc.port;
-  argv.rpchost = config.rpc.host;
 
   return new XudClient(`${argv.rpchost}:${argv.rpcport}`, credentials);
 };
 
 export const loadXudInitClient = async (argv: Arguments<any>) => {
-  const config = new Config();
-  await config.load({
-    xudir: argv.xudir,
-    rpc: {
-      port: argv.rpcport,
-      host: argv.rpchost,
-    },
-  });
+  await loadXudConfig(argv);
 
-  const certPath = argv.tlscertpath || path.join(config.xudir, 'tls.cert');
+  const certPath = argv.tlscertpath || path.join(argv.xudir, 'tls.cert');
   const cert = fs.readFileSync(certPath);
   const credentials = grpc.credentials.createSsl(cert);
-
-  // in case port and host args were not set, we update them to the values we
-  // determined by loading the config
-  argv.rpcport = config.rpc.port;
-  argv.rpchost = config.rpc.host;
 
   return new XudInitClient(`${argv.rpchost}:${argv.rpcport}`, credentials);
 };


### PR DESCRIPTION
This fixes an issue where xucli could read an rpc host of `0.0.0.0` from the config file, indicating that xud is listening on all interfaces, and then attempt to connect to it using that ip address which fails. Instead, if the xucli tool detects that xud is configured to listen on all interfaces, it should default to attempting to connect on localhost.

This above behavior would fix the issue on xud1-simnet, which listens to 0.0.0.0 for rpc commands, so that we don't need to explicitly pass `localhost` as the rpc host to xucli commands.

This also adds some error handling to proceed in case loading the xud config fails, so that we go on to attempt the command anyhow.