### PR TITLE
test(sim): fix maker_crash_after_send instability test case

### DIFF
--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -18,11 +18,11 @@ var instabilityTestCases = []*testCase{
 		test: testNetworkInit,
 	},
 	{
-		name: "maker crashed after send payment",
+		name: "maker crashed after send payment", // replacing Alice
 		test: testMakerCrashedAfterSend,
 	},
 	{
-		name: "maker crashed after send payment with delayed settlement",
+		name: "maker crashed after send payment with delayed settlement", // replacing Alice + Bob
 		test: testMakerCrashedAfterSendDelayedSettlement,
 	},
 }
@@ -129,14 +129,14 @@ func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht 
 	aliceIntermediateBalance, err := getBalance(ht.ctx, net.Alice)
 	ht.assert.NoError(err)
 	aliceIntermediateLtcBalance := aliceIntermediateBalance.ltc.channel.GetBalance()
-	ht.assert.NotEqual(alicePrevLtcBalance+ltcQuantity, aliceIntermediateLtcBalance)
+	ht.assert.Less(aliceIntermediateLtcBalance, alicePrevLtcBalance)
 
 	// Delay to allow for payment to be claimed by bob then recovered by alice
-	time.Sleep(4 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// Verify that alice received her LTC
 	aliceBalance, err := getBalance(ht.ctx, net.Alice)
 	ht.assert.NoError(err)
 	aliceLtcBalance := aliceBalance.ltc.channel.GetBalance()
-	ht.assert.Equal(alicePrevLtcBalance+ltcQuantity, aliceLtcBalance, "alice did not receive LTC")
+	ht.assert.Equal(alicePrevLtcBalance+ltcQuantity, aliceLtcBalance, "alice did not recover LTC funds")
 }


### PR DESCRIPTION
Fixing the following test, from the instability test suite: `maker crashed after send payment with delayed settlement`.


This test relies on the taker delaying invoice settlement, while the maker crashes in the meanwhile. after it restarts, it is expected to not be able to recover the swap immediately, since the taker is still delaying the settlement.

But it looks like that the maker crash was triggered *after* `sendPayment` call returns - hence after the taker delay, and after he already settled the invoice. So when the maker xud restarts, it can immediately recover the swap, and the test fails due to an assertion which assume that the swap should not be able to be recovered immediately.

My only explanation to how this test previously passed is due to a race condition, where after the maker xud restarts, we query the balance before the swap is recovered, although it was immediately available (@sangaman let me know if I’m missing something here).

After changing the custom-xud branch so that the maker would shutdown and restart *while* the taker is delaying the invoice settlement (hence while `sendPayment` was still pending/blocking), the maker fail to recover the swap on launch (`recovered swap for XXX still has pending payments and will be monitored`), and funds are recovered only after the next recovery procedure cycle (usually in 5m, but changed to 5sec in the custom branch).

--- 

The important changes are in the custom-xud branch: https://github.com/ExchangeUnion/xud/commit/cfe0166c512248f8b4e125fc76a06036520d8e6a

The test code changes (this PR) are less significant: 
1. make the balance assertion more strict 
2. expand the delay to allow swap recovery
