### PR TITLE
fix: add `::` to selfaddress detection

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -458,9 +458,9 @@ class Pool extends EventEmitter {
     if (address.port === this.listenPort) {
       switch (address.host) {
         case '::':
+        case '0.0.0.0':
         case '::1':
         case '127.0.0.1':
-        case '0.0.0.0':
         case 'localhost':
           return true;
       }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -457,9 +457,10 @@ class Pool extends EventEmitter {
   private addressIsSelf = (address: Address): boolean => {
     if (address.port === this.listenPort) {
       switch (address.host) {
+        case '::':
         case '::1':
-        case '0.0.0.0':
         case '127.0.0.1':
+        case '0.0.0.0':
         case 'localhost':
           return true;
       }

--- a/test/jest/Pool.spec.ts
+++ b/test/jest/Pool.spec.ts
@@ -128,8 +128,8 @@ describe('P2P Pool', () => {
   test('should reject connecting to its own addresses', async () => {
     const selfAddresses = [
       '::',
-      '::1',
       '0.0.0.0',
+      '::1',
       '127.0.0.1',
       'localhost',
     ];

--- a/test/jest/Pool.spec.ts
+++ b/test/jest/Pool.spec.ts
@@ -127,6 +127,7 @@ describe('P2P Pool', () => {
 
   test('should reject connecting to its own addresses', async () => {
     const selfAddresses = [
+      '::',
       '::1',
       '0.0.0.0',
       '127.0.0.1',


### PR DESCRIPTION
This adds the ipv6 version `::` of `0.0.0.0` to the self address detection of xud/xucli. Stumbled upon in https://github.com/ExchangeUnion/xud-docker/issues/419#issuecomment-616498254.