### PR TITLE
chore: move to new xud1-simnet instance

### DIFF
--- a/lib/db/seeds/simnet.ts
+++ b/lib/db/seeds/simnet.ts
@@ -3,8 +3,11 @@ import { SwapClientType } from '../../constants/enums';
 
 const nodes = [
   {
-    nodePubKey: '02b66438730d1fcdf4a4ae5d3d73e847a272f160fee2938e132b52cab0a0d9cfc6',
-    addresses: [{ host: 'xud1.simnet.exchangeunion.com', port: 28885 }],
+    nodePubKey: '03193508d52dc8235c1bf6e902dae30c6dc1823f1e3cdc3c1a97652af9142cd4fe',
+    addresses: [
+      { host: 'xud1.simnet.exchangeunion.com', port: 28885 },
+      { host: 'lqcaoc3ga4ateijlmo3mk7jb4r2fy22ko36asp44spjt6htmozosqbad.onion', port: 18885 },
+    ],
   },
 ] as db.NodeAttributes[];
 

--- a/lib/db/seeds/simnet.ts
+++ b/lib/db/seeds/simnet.ts
@@ -6,7 +6,7 @@ const nodes = [
     nodePubKey: '03193508d52dc8235c1bf6e902dae30c6dc1823f1e3cdc3c1a97652af9142cd4fe',
     addresses: [
       { host: 'xud1.simnet.exchangeunion.com', port: 28885 },
-      { host: 'lqcaoc3ga4ateijlmo3mk7jb4r2fy22ko36asp44spjt6htmozosqbad.onion', port: 18885 },
+      { host: 'lqcaoc3ga4ateijlmo3mk7jb4r2fy22ko36asp44spjt6htmozosqbad.onion', port: 28885 },
     ],
   },
 ] as db.NodeAttributes[];


### PR DESCRIPTION
I already pointed the dns record for xud1.simnet.exchangeunion.com to the new ip