### PR TITLE
refactor(cli): async load client deposit/withdraw

### DIFF
--- a/lib/cli/commands/deposit.ts
+++ b/lib/cli/commands/deposit.ts
@@ -13,8 +13,8 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new DepositRequest();
   request.setCurrency(argv.currency);
-  loadXudClient(argv).deposit(request, callback(argv));
+  (await loadXudClient(argv)).deposit(request, callback(argv));
 };

--- a/lib/cli/commands/withdraw.ts
+++ b/lib/cli/commands/withdraw.ts
@@ -29,7 +29,7 @@ export const builder = {
   },
 };
 
-export const handler = (argv: Arguments<any>) => {
+export const handler = async (argv: Arguments<any>) => {
   const request = new WithdrawRequest();
   request.setCurrency(argv.currency);
   if (argv.all) {
@@ -40,5 +40,5 @@ export const handler = (argv: Arguments<any>) => {
   request.setDestination(argv.destination);
   request.setFee(argv.fee);
 
-  loadXudClient(argv).withdraw(request, callback(argv));
+  (await loadXudClient(argv)).withdraw(request, callback(argv));
 };


### PR DESCRIPTION
This resolves a merge issue between #1462 and #1481 where the `loadXudClient` method was made async in the latter but still used like a synchronous call in the former.