### PR TITLE
feat(swaps): log full SwapFailureReason name

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -250,7 +250,7 @@ class Swaps extends EventEmitter {
       failureReason,
       errorMessage,
     };
-    this.logger.debug(`Sending swap error to peer: ${JSON.stringify(errorBody)}`);
+    this.logger.debug(`Sending ${SwapFailureReason[errorBody.failureReason]} error to peer: ${JSON.stringify(errorBody)}`);
     await peer.sendPacket(new packets.SwapFailedPacket(errorBody, reqId));
   }
 


### PR DESCRIPTION
This writes out the full name of the `SwapFailureReason` to the logs when sending a `SwapFailurePacket` to a peer, like below:

`Sending NoRouteFound error to peer: {...`

Previously only the numerical enum value was written to the log.

Closes #1499.