### PR TITLE
test(sim): fix security tests

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -669,6 +669,14 @@ class Pool extends EventEmitter {
     return peer;
   }
 
+  public tryGetPeer = (peerPubKey: string) => {
+    try {
+      return this.getPeer(peerPubKey);
+    } catch (err) {
+      return;
+    }
+  }
+
   public broadcastOrder = (order: OutgoingOrder) => {
     const orderPacket = new packets.OrderPacket(order);
     this.peers.forEach(async (peer) => {

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1013,8 +1013,9 @@ class Swaps extends EventEmitter {
 
   private handleSwapTimeout = async (rHash: string, reason: SwapFailureReason) => {
     const deal = this.getDeal(rHash)!;
-    const peer = this.pool.getPeer(deal.peerPubKey);
+    const peer = this.pool.tryGetPeer(deal.peerPubKey);
     this.timeouts.delete(rHash);
+
     await this.failDeal({
       deal,
       peer,

--- a/test/simulation/actions.go
+++ b/test/simulation/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/roasbeef/btcutil"
 	"time"
 
 	"github.com/ExchangeUnion/xud-simulation/lntest"
@@ -414,8 +415,8 @@ func getInfo(ctx context.Context, n *xudtest.HarnessNode) (*xudrpc.GetInfoRespon
 	return info, nil
 }
 
-func openBtcChannel(ctx context.Context, ln *lntest.NetworkHarness, srcNode, destNode *lntest.HarnessNode) (*lnrpc.ChannelPoint, error) {
-	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, 15000000, 7500000, false)
+func openBtcChannel(ctx context.Context, ln *lntest.NetworkHarness, srcNode, destNode *lntest.HarnessNode, amt int64, pushAmt int64) (*lnrpc.ChannelPoint, error) {
+	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, btcutil.Amount(amt), btcutil.Amount(pushAmt), false)
 	if err != nil {
 		return nil, err
 	}
@@ -444,8 +445,8 @@ func closeBtcChannel(ctx context.Context, ln *lntest.NetworkHarness, node *lntes
 	return nil
 }
 
-func openLtcChannel(ctx context.Context, ln *lntest.NetworkHarness, srcNode, destNode *lntest.HarnessNode) (*lnrpc.ChannelPoint, error) {
-	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, 15000000, 7500000, false)
+func openLtcChannel(ctx context.Context, ln *lntest.NetworkHarness, srcNode, destNode *lntest.HarnessNode, amt int64, pushAmt int64) (*lnrpc.ChannelPoint, error) {
+	openChanStream, err := ln.OpenChannel(ctx, srcNode, destNode, btcutil.Amount(amt), btcutil.Amount(pushAmt), false)
 	if err != nil {
 		return nil, err
 	}

--- a/test/simulation/xud_test.go
+++ b/test/simulation/xud_test.go
@@ -55,19 +55,22 @@ func TestIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	aliceBobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+	amt := int64(15000000)
+	pushAmt := int64(7500000)
+
+	aliceBobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode, amt, pushAmt)
 	assert.NoError(err)
-	aliceBobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+	aliceBobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode, amt, pushAmt)
 	assert.NoError(err)
 
-	bobCarolBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Carol.LndBtcNode)
+	bobCarolBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Carol.LndBtcNode, amt, pushAmt)
 	assert.NoError(err)
-	bobCarolLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Carol.LndLtcNode)
+	bobCarolLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Carol.LndLtcNode, amt, pushAmt)
 	assert.NoError(err)
 
-	carolDavidBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, xudNetwork.Dave.LndBtcNode)
+	carolDavidBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Carol.LndBtcNode, xudNetwork.Dave.LndBtcNode, amt, pushAmt)
 	assert.NoError(err)
-	carolDavidLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, xudNetwork.Dave.LndLtcNode)
+	carolDavidLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Carol.LndLtcNode, xudNetwork.Dave.LndLtcNode, amt, pushAmt)
 	assert.NoError(err)
 
 	initialStates := make(map[int]*xudrpc.GetInfoResponse)
@@ -146,9 +149,13 @@ func TestInstability(t *testing.T) {
 	// Open channels from both directions on each chain.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	aliceBobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+
+	amt := int64(15000000)
+	pushAmt := int64(7500000)
+
+	aliceBobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode, amt, pushAmt)
 	assert.NoError(err)
-	aliceBobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+	aliceBobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode, amt, pushAmt)
 	assert.NoError(err)
 
 	for _, testCase := range instabilityTestCases {
@@ -188,13 +195,17 @@ func TestSecurity(t *testing.T) {
 		// Open channels from both directions on each chain.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		aliceBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode)
+
+		amt := int64(15000000)
+		pushAmt := int64(7500000)
+
+		aliceBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Alice.LndBtcNode, xudNetwork.Bob.LndBtcNode, amt, pushAmt)
 		assert.NoError(err)
-		aliceLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode)
+		aliceLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Alice.LndLtcNode, xudNetwork.Bob.LndLtcNode, amt, pushAmt)
 		assert.NoError(err)
-		bobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Alice.LndBtcNode)
+		bobBtcChanPoint, err := openBtcChannel(ctx, xudNetwork.LndBtcNetwork, xudNetwork.Bob.LndBtcNode, xudNetwork.Alice.LndBtcNode, amt, pushAmt)
 		assert.NoError(err)
-		bobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Alice.LndLtcNode)
+		bobLtcChanPoint, err := openLtcChannel(ctx, xudNetwork.LndLtcNetwork, xudNetwork.Bob.LndLtcNode, xudNetwork.Alice.LndLtcNode, amt, pushAmt)
 		assert.NoError(err)
 
 		// Save the initial balance.


### PR DESCRIPTION
Fixing 2 different issues which caused the security test to fail:

1. **production code**: `swaps.handleSwapTimeout` to support a possibility that the swap peer isn’t connected. Previously it caused `xud` to panic and crash, hence was an attack vector.

2. **test code**: when asserting wallet/channels balance, take into consideration the amount that was pushed when the channels were opened.


Edit by karl:
Fixes https://github.com/ExchangeUnion/xud/issues/1455
