### PR TITLE
fix(swapclient): don't initialize if misconfigured

### DIFF
--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -160,11 +160,14 @@ abstract class SwapClient extends EventEmitter {
     // client specific initialization
     await this.initSpecific();
 
-    // final steps to complete initialization
-    this.setStatus(ClientStatus.Initialized);
-    this.setTimers();
-    this.emit('initialized');
-    await this.verifyConnectionWithTimeout();
+    // check to make sure that the client wasn't disabled in the initSpecific routine
+    if (this.isNotInitialized()) {
+      // final steps to complete initialization
+      this.setStatus(ClientStatus.Initialized);
+      this.setTimers();
+      this.emit('initialized');
+      await this.verifyConnectionWithTimeout();
+    }
   }
 
   protected abstract async initSpecific(): Promise<void>;


### PR DESCRIPTION
This ensures that we don't attempt to use an lnd client that was marked as `Misconfigured` because we were unable to load the tls.cert file for making rpc calls.

I also added logic to try and detect and prevent similar unintentional status transitions from happening in the future by defining allowed status transitions and preventing disallowed ones.