### PR TITLE
feat(cli): use ticker format for addpair

### DIFF
--- a/lib/cli/commands/addpair.ts
+++ b/lib/cli/commands/addpair.ts
@@ -1,25 +1,34 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudClient } from '../command';
+import { Arguments, Argv } from 'yargs';
 import { AddPairRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
-export const command = 'addpair <base_currency> <quote_currency>';
+export const command = 'addpair <pair_id|base_currency> [quote_currency]';
 
 export const describe = 'add a trading pair';
 
-export const builder = {
-  base_currency: {
-    description: 'the currency bought and sold for this trading pair',
+export const builder = (argv: Argv) => argv
+  .positional('pair_id', {
+    description: 'the pair ticker id or base currency',
     type: 'string',
-  },
-  quote_currency: {
+  })
+  .positional('quote_currency', {
     description: 'the currency used to quote a price',
     type: 'string',
-  },
-};
+  })
+  .example('$0 addpair LTC/BTC', 'add the LTC/BTC trading pair by ticker id')
+  .example('$0 addpair LTC BTC', 'add the LTC/BTC trading pair by currencies');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new AddPairRequest();
-  request.setBaseCurrency(argv.base_currency.toUpperCase());
-  request.setQuoteCurrency(argv.quote_currency.toUpperCase());
+  let baseCurrency: string;
+  let quoteCurrency: string;
+  if (argv.base_currency && argv.quote_currency) {
+    baseCurrency = argv.base_currency;
+    quoteCurrency = argv.quote_currency;
+  } else {
+    [baseCurrency, quoteCurrency] = argv.pair_id.split('/');
+  }
+  request.setBaseCurrency(baseCurrency.toUpperCase());
+  request.setQuoteCurrency(quoteCurrency.toUpperCase());
   (await loadXudClient(argv)).addPair(request, callback(argv));
 };

--- a/lib/cli/commands/openchannel.ts
+++ b/lib/cli/commands/openchannel.ts
@@ -1,4 +1,4 @@
-import { Arguments } from 'yargs';
+import { Arguments, CommandBuilder } from 'yargs';
 import { callback, loadXudClient } from '../command';
 import { OpenChannelRequest } from '../../proto/xudrpc_pb';
 import { coinsToSats } from '../utils';
@@ -7,7 +7,7 @@ export const command = 'openchannel <currency> <amount> [node_identifier] [push_
 
 export const describe = 'open a payment channel with a peer';
 
-export const builder = {
+export const builder: CommandBuilder = {
   node_identifier: {
     description: 'the node key or alias of the connected peer to open the channel with',
     type: 'string',


### PR DESCRIPTION
This modifies the `addpair` command to use the trading pair ticker format such as LTC/BTC used in different commands, while keeping the ability to specify currencies separately.

Related issue #1521.