### PR TITLE
feat: testing config option for develoment/tests

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -77,6 +77,11 @@ const { argv } = require('yargs')
       type: 'string',
       alias: 'x',
     },
+    'debug.testing': {
+      describe: 'Developer mode to facilitate testing swaps',
+      type: 'boolean',
+      default: undefined,
+    },
     'debug.raidenDirectChannelChecks': {
       describe: 'Whether to require direct channels for raiden payments',
       type: 'boolean',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -58,7 +58,10 @@ class Config {
   public connext: ConnextClientConfig;
   public orderthresholds: OrderBookThresholds;
   public webproxy: { port: number, disable: boolean };
-  public debug: { raidenDirectChannelChecks: boolean };
+  public debug: {
+    testing: boolean,
+    raidenDirectChannelChecks: boolean,
+  };
   public instanceid = 0;
   /** Whether to intialize a new database with default values. */
   public initdb = true;
@@ -140,6 +143,7 @@ class Config {
       port: 8080,
     };
     this.debug = {
+      testing: false,
       raidenDirectChannelChecks: true,
     };
     // TODO: add dynamic max/min price limits

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -164,6 +164,7 @@ class Xud extends EventEmitter {
         xuNetwork: this.config.network,
         logger: loggers.p2p,
         models: this.db.models,
+        testing: this.config.debug.testing,
       });
 
       const initPromises: Promise<any>[] = [];
@@ -181,6 +182,7 @@ class Xud extends EventEmitter {
         nosanityswaps: this.config.nosanityswaps,
         nobalancechecks: this.config.nobalancechecks,
         maxlimits: this.config.maxlimits,
+        testing: this.config.debug.testing,
       });
       initPromises.push(this.orderBook.init());
 

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -128,6 +128,7 @@ describe('Swaps.SwapClientManager', () => {
     };
     config.debug = {
       raidenDirectChannelChecks: true,
+      testing: false,
     };
     db = new DB(loggers.db, config.dbpath);
     unitConverter = new UnitConverter();


### PR DESCRIPTION
This adds a `debug.testing` config option to be used when testing swaps for development purposes. When enabled, this option does three things.

* It adds peer orders back to the order book should they fail the swap.
* It disables reputation events besides the manual ban and unban events to prevent us from unintentionally banning peers due to too many failed
swaps.
* It always activates trading pairs for peers.

Closes #1496.