### PR TITLE
test(sim): travis to run security/instability tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - docker
       script:
         - npm run test:sim:build
-        - npm run test:sim:run:integration
+        - npm run test:sim:run
       after_failure:
         - npm run test:sim:logs
     - name: test:seedutil

--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -44,7 +44,7 @@ index 672d6159..05c5043b 100644
      this.swapClientManager.on('htlcAccepted', async (swapClient, rHash, amount, currency) => {
        try {
 -        const rPreimage = await this.resolveHash(rHash, amount, currency);
--        await swapClient.settleInvoice(rHash, rPreimage);
+-        await swapClient.settleInvoice(rHash, rPreimage, currency);
 +        const rPreimage = await this.resolveHash(rHash, amount, currency)
 +        if (rPreimage === '') {
 +          this.logger.info('NOT SETTLING INVOICE');
@@ -66,7 +66,7 @@ index 672d6159..05c5043b 100644
 +        }
 +
 +        this.logger.info('SETTLING INVOICE');
-+        await swapClient.settleInvoice(rHash, rPreimage);
++        await swapClient.settleInvoice(rHash, rPreimage, currency);
 +
          if (deal) {
            await this.setDealPhase(deal, SwapPhase.PaymentReceived);

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -149,8 +149,8 @@ func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht 
 
 func testMakerLndCrashedBeforeSettlement(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, "instability", []string{
-		"BREAKSWAP=MAKER_LND_CRASHED_BEFORE_SETTLE",
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{
+		"CUSTOM_SCENARIO=INSTABILITY::MAKER_LND_CRASHED_BEFORE_SETTLE",
 		fmt.Sprintf("LNDLTC_PID=%d", net.Alice.LndLtcNode.Cmd.Process.Pid),
 	})
 	ht.assert.NoError(err)


### PR DESCRIPTION
## Changes
* Travis to run all the simulation test suites
* Fix merge conflicts in patch file
* Fix merge conflicts in test code

### Warnings

#### 1) long execution times

As since https://github.com/ExchangeUnion/xud/pull/1507, `test:sim:run` npm script will be running all the test suites, and not just the Integration test suite. 
This change is expected to extend the time length of the execution from ~1min to ~15min (not including the build, which takes ~7min).

#### 2) patch apply errors

Both `test:sim:build` and `test:sim:build:xud` npm scripts will be attempting to build `custom-xud` using the [patch file](https://github.com/ExchangeUnion/xud/blob/master/test/simulation/custom-xud.patch), hence changes to `/swaps/Swaps.ts` (like this [line](https://github.com/ExchangeUnion/xud/pull/1512/files#diff-207d104426c9b9c110cdd1c78f1fc6ecR208)) are expected to trigger an error in applying the patch (see here: https://travis-ci.org/github/ExchangeUnion/xud/jobs/684303146#L336).
If so, one must fix the patch file in order to proceed. 
