### PR TITLE
feat(cli): clarify positional args & add examples

### DIFF
--- a/lib/cli/commands/addcurrency.ts
+++ b/lib/cli/commands/addcurrency.ts
@@ -1,32 +1,33 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudClient } from '../command';
-import { Currency } from '../../proto/xudrpc_pb';
+import { Arguments, Argv } from 'yargs';
 import { SwapClientType } from '../../constants/enums';
+import { Currency } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
 export const command = 'addcurrency <currency> <swap_client> [decimal_places] [token_address]';
 
 export const describe = 'add a currency';
 
-export const builder = {
-  currency: {
+export const builder = (argv: Argv) => argv
+  .positional('currency', {
     description: 'the ticker symbol for the currency',
     type: 'string',
-  },
-  swap_client: {
+  })
+  .positional('swap_client', {
     description: 'the payment channel network client for swaps',
     type: 'string',
     choices: ['Lnd', 'Raiden', 'Connext'],
-  },
-  decimal_places: {
+  })
+  .option('decimal_places', {
     description: 'the places to the right of the decimal point of the smallest subunit (e.g. satoshi)',
     default: 8,
     type: 'number',
-  },
-  token_address: {
+  })
+  .option('token_address', {
     description: 'the contract address for tokens such as ERC20',
     type: 'string',
-  },
-};
+  })
+  .example('$0 addcurrency BTC Lnd', 'add BTC')
+  .example('$0 addcurrency ETH Connext 18 0x0000000000000000000000000000000000000000', 'add ETH');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new Currency();

--- a/lib/cli/commands/ban.ts
+++ b/lib/cli/commands/ban.ts
@@ -1,17 +1,18 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { BanRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
 export const command = 'ban <node_identifier>';
 
 export const describe = 'ban a remote node';
 
-export const builder = {
-  node_identifier: {
+export const builder = (argv: Argv) => argv
+  .positional('node_identifier', {
     description: 'the node key or alias of the remote node to ban',
     type: 'string',
-  },
-};
+  })
+  .example('$0 ban 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b', 'ban by node key')
+  .example('$0 ban CheeseMonkey', 'ban by alias');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new BanRequest();

--- a/lib/cli/commands/closechannel.ts
+++ b/lib/cli/commands/closechannel.ts
@@ -1,4 +1,4 @@
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { CloseChannelRequest } from '../../proto/xudrpc_pb';
 import { callback, loadXudClient } from '../command';
 
@@ -6,20 +6,22 @@ export const command = 'closechannel <node_identifier> <currency> [--force]';
 
 export const describe = 'close any payment channels with a peer';
 
-export const builder = {
-  node_identifier: {
+export const builder = (argv: Argv) => argv
+  .positional('node_identifier', {
     description: 'the node key or alias of the connected peer to close the channel with',
     type: 'string',
-  },
-  currency: {
+  })
+  .positional('currency', {
     description: 'the ticker symbol for the currency',
     type: 'string',
-  },
-  force: {
+  })
+  .option('force', {
     type: 'boolean',
     description: 'whether to force close if the peer is offline',
-  },
-};
+  })
+  .example('$0 closechannel 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b BTC', 'close BTC channels by node key')
+  .example('$0 closechannel CheeseMonkey BTC', 'close BTC channels by alias')
+  .example('$0 closechannel CheeseMonkey BTC --force', 'force close BTC channels by alias');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new CloseChannelRequest();

--- a/lib/cli/commands/connect.ts
+++ b/lib/cli/commands/connect.ts
@@ -1,17 +1,17 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudClient } from '../command';
+import { Arguments, Argv } from 'yargs';
 import { ConnectRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
 export const command = 'connect <node_uri>';
 
 export const describe = 'connect to a remote node';
 
-export const builder = {
-  node_uri: {
+export const builder = (argv: Argv) => argv
+  .positional('node_uri', {
     description: 'uri of remote node as [node_key]@[host]:[port]',
     type: 'string',
-  },
-};
+  })
+  .example('$0 connect 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b@86.75.30.9:8885', 'connect by node uri');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new ConnectRequest();

--- a/lib/cli/commands/deposit.ts
+++ b/lib/cli/commands/deposit.ts
@@ -1,4 +1,4 @@
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { DepositRequest } from '../../proto/xudrpc_pb';
 import { callback, loadXudClient } from '../command';
 
@@ -6,12 +6,12 @@ export const command = 'deposit <currency>';
 
 export const describe = 'gets an address to deposit funds to xud';
 
-export const builder = {
-  currency: {
+export const builder = (argv: Argv) => argv
+  .positional('currency', {
     description: 'the ticker symbol of the currency to deposit.',
     type: 'string',
-  },
-};
+  })
+  .example('$0 deposit BTC', 'get a BTC deposit address');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new DepositRequest();

--- a/lib/cli/commands/discovernodes.ts
+++ b/lib/cli/commands/discovernodes.ts
@@ -1,17 +1,18 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { DiscoverNodesRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
 export const command = 'discovernodes <node_identifier>';
 
 export const describe = 'discover nodes from a specific peer';
 
-export const builder = {
-  node_identifier: {
+export const builder = (argv: Argv) => argv
+  .positional('node_identifier', {
     description: 'the node key or alias of the connected peer to discover nodes from',
     type: 'string',
-  },
-};
+  })
+  .example('$0 discovernodes 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b', 'discover nodes from a peer by node key')
+  .example('$0 discovernodes CheeseMonkey', 'discover nodes from a peer by alias');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new DiscoverNodesRequest();

--- a/lib/cli/commands/executeswap.ts
+++ b/lib/cli/commands/executeswap.ts
@@ -1,9 +1,9 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
-import { ExecuteSwapRequest, SwapSuccess } from '../../proto/xudrpc_pb';
-import { coinsToSats } from '../utils';
 import Table, { VerticalTable } from 'cli-table3';
 import colors from 'colors/safe';
+import { Arguments, Argv } from 'yargs';
+import { ExecuteSwapRequest, SwapSuccess } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
+import { coinsToSats } from '../utils';
 
 const displaySwapSuccess = (swap: SwapSuccess.AsObject) => {
   const table = new Table() as VerticalTable;
@@ -20,18 +20,17 @@ export const command = 'executeswap <pair_id> <order_id> [quantity]';
 // export const describe = 'execute a swap on a peer order (nomatching mode only)';
 export const describe = undefined;
 
-export const builder = {
-  order_id: {
+export const builder = (argv: Argv) => argv
+  .positional('order_id', {
     type: 'string',
-  },
-  pair_id: {
+  })
+  .positional('pair_id', {
     type: 'string',
-  },
-  quantity: {
+  })
+  .option('quantity', {
     type: 'number',
     description: 'the quantity to swap; the whole order will be swapped if unspecified',
-  },
-};
+  });
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new ExecuteSwapRequest();

--- a/lib/cli/commands/getbalance.ts
+++ b/lib/cli/commands/getbalance.ts
@@ -1,9 +1,9 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
-import { GetBalanceRequest, GetBalanceResponse } from '../../proto/xudrpc_pb';
-import { satsToCoinsStr } from '../utils';
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
+import { Arguments, Argv } from 'yargs';
+import { GetBalanceRequest, GetBalanceResponse } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
+import { satsToCoinsStr } from '../utils';
 
 const HEADERS = [
   colors.blue('Currency'),
@@ -63,12 +63,13 @@ export const command = 'getbalance [currency]';
 
 export const describe = 'get total balance for a given currency';
 
-export const builder = {
-  currency: {
+export const builder = (argv: Argv) => argv
+  .option('currency', {
     describe: 'the currency to query for',
     type: 'string',
-  },
-};
+  })
+  .example('$0 getbalance', 'get balance for all currencies')
+  .example('$0 getbalance BTC', 'get BTC balance');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new GetBalanceRequest();

--- a/lib/cli/commands/getnodeinfo.ts
+++ b/lib/cli/commands/getnodeinfo.ts
@@ -1,4 +1,4 @@
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { callback, loadXudClient } from '../command';
 import Table, { VerticalTable } from 'cli-table3';
 import colors from 'colors/safe';
@@ -17,14 +17,15 @@ const displayNodeInfo = (node: GetNodeInfoResponse.AsObject) => {
 
 export const command = 'getnodeinfo <node_identifier>';
 
-export const describe = 'get general information about a peer';
+export const describe = 'get general information about a known node';
 
-export const builder = {
-  node_identifier: {
+export const builder = (argv: Argv) => argv
+  .positional('node_identifier', {
     type: 'string',
-    description: 'the node key or alias of the connected peer to get general information from',
-  },
-};
+    description: 'the node key or alias of the node to get information for',
+  })
+  .example('$0 getnodeinfo 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b', 'get info about a node by node key')
+  .example('$0 getnodeinfo CheeseMonkey', 'get info about a node by alias');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new GetNodeInfoRequest();

--- a/lib/cli/commands/listtrades.ts
+++ b/lib/cli/commands/listtrades.ts
@@ -1,8 +1,8 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudClient } from '../command';
-import { ListTradesRequest, ListTradesResponse, Trade } from '../../proto/xudrpc_pb';
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
+import { Arguments, Argv } from 'yargs';
+import { ListTradesRequest, ListTradesResponse, Trade } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 import { satsToCoinsStr } from '../utils';
 
 const HEADERS = [
@@ -38,13 +38,14 @@ export const command = 'listtrades [limit]';
 
 export const describe = 'list completed trades';
 
-export const builder = {
-  limit: {
+export const builder = (argv: Argv) => argv
+  .option('limit', {
     description: 'the maximum number of trades to display',
     type: 'number',
     default: 15,
-  },
-};
+  })
+  .example('$0 listtrades', 'list most recent trades')
+  .example('$0 listtrades 50', 'list the 50 most recent trades');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new ListTradesRequest();

--- a/lib/cli/commands/openchannel.ts
+++ b/lib/cli/commands/openchannel.ts
@@ -1,31 +1,33 @@
-import { Arguments, CommandBuilder } from 'yargs';
-import { callback, loadXudClient } from '../command';
+import { Arguments, Argv } from 'yargs';
 import { OpenChannelRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 import { coinsToSats } from '../utils';
 
 export const command = 'openchannel <currency> <amount> [node_identifier] [push_amount]';
 
 export const describe = 'open a payment channel with a peer';
 
-export const builder: CommandBuilder = {
-  node_identifier: {
-    description: 'the node key or alias of the connected peer to open the channel with',
-    type: 'string',
-  },
-  currency: {
+export const builder = (argv: Argv) => argv
+  .positional('currency', {
     description: 'the ticker symbol for the currency',
     type: 'string',
-  },
-  amount: {
+  })
+  .positional('amount', {
     type: 'number',
     description: 'the amount to be deposited into the channel',
-  },
-  push_amount: {
+  })
+  .option('node_identifier', {
+    description: 'the node key or alias of the connected peer to open the channel with',
+    type: 'string',
+  })
+  .option('push_amount', {
     type: 'number',
     description: 'the amount to be pushed to the remote side of the channel',
     default: 0,
-  },
-};
+  })
+  .example('$0 openchannel BTC 0.1 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b', 'open an 0.1 BTC channel by node key')
+  .example('$0 openchannel BTC 0.1 CheeseMonkey', 'open an 0.1 BTC channel by alias')
+  .example('$0 openchannel BTC 0.1 CheeseMonkey 0.05', 'open an 0.1 BTC channel by alias and push 0.05 to remote side');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new OpenChannelRequest();

--- a/lib/cli/commands/orderbook.ts
+++ b/lib/cli/commands/orderbook.ts
@@ -1,6 +1,6 @@
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { Owner } from '../../constants/enums';
 import { ListOrdersRequest, ListOrdersResponse, Order } from '../../proto/xudrpc_pb';
 import { callback, loadXudClient } from '../command';
@@ -145,17 +145,20 @@ export const command = 'orderbook [pair_id] [precision]';
 
 export const describe = 'display the order book, with orders aggregated per price point';
 
-export const builder = {
-  pair_id: {
+export const builder = (argv: Argv) => argv
+  .option('pair_id', {
     describe: 'trading pair for which to retrieve the order book',
     type: 'string',
-  },
-  precision: {
+  })
+  .option('precision', {
     describe: 'the number of digits following the decimal point',
     type: 'number',
     default: 8,
-  },
-};
+  })
+  .example('$0 orderbook', 'display the order books for all trading pairs')
+  .example('$0 orderbook LTC/BTC', 'display the LTC/BTC order book')
+  .example('$0 orderbook LTC/BTC 2', 'display the LTC/BTC order book with 2 decimal precision')
+  .example('$0 orderbook --precision 2', 'display the order books for all trading pairs with 2 decimal precision');
 
 const displayJson = (orders: ListOrdersResponse.AsObject, argv: Arguments<any>) => {
   const jsonOrderbooks: OrderbookJson[] = [];

--- a/lib/cli/commands/removecurrency.ts
+++ b/lib/cli/commands/removecurrency.ts
@@ -1,17 +1,17 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudClient } from '../command';
+import { Arguments, Argv } from 'yargs';
 import { RemoveCurrencyRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
 export const command = 'removecurrency <currency>';
 
 export const describe = 'remove a currency';
 
-export const builder = {
-  currency: {
+export const builder = (argv: Argv) => argv
+  .positional('currency', {
     description: 'the ticker symbol for the currency',
     type: 'string',
-  },
-};
+  })
+  .example('$0 removecurrency BTC', 'remove BTC');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new RemoveCurrencyRequest();

--- a/lib/cli/commands/removeorder.ts
+++ b/lib/cli/commands/removeorder.ts
@@ -1,21 +1,22 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { RemoveOrderRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 import { coinsToSats } from '../utils';
 
 export const command = 'removeorder <order_id> [quantity]';
 
 export const describe = 'remove an order';
 
-export const builder = {
-  order_id: {
+export const builder = (argv: Argv) => argv
+  .positional('order_id', {
     type: 'string',
-  },
-  quantity: {
+  })
+  .option('quantity', {
     type: 'number',
-    describe: 'quantity to remove; if zero or unspecified the entire order is removed',
-  },
-};
+    describe: 'quantity to remove; if unspecified the entire order is removed',
+  })
+  .example('$0 removeorder 79d2cd30-8a26-11ea-90cf-439fb244cf44', 'remove an order by id')
+  .example('$0 removeorder 79d2cd30-8a26-11ea-90cf-439fb244cf44 0.1', 'remove 0.1 quantity from an order by id');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new RemoveOrderRequest();

--- a/lib/cli/commands/removepair.ts
+++ b/lib/cli/commands/removepair.ts
@@ -1,17 +1,17 @@
-import { Arguments } from 'yargs';
-import { callback, loadXudClient } from '../command';
+import { Arguments, Argv } from 'yargs';
 import { RemovePairRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
 export const command = 'removepair <pair_id>';
 
 export const describe = 'remove a trading pair';
 
-export const builder = {
-  pair_id: {
+export const builder = (argv: Argv) => argv
+  .positional('pair_id', {
     description: 'the trading pair ticker to remove',
     type: 'string',
-  },
-};
+  })
+  .example('$0 removepair LTC/BTC', 'remove the LTC/BTC trading pair');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new RemovePairRequest();

--- a/lib/cli/commands/sell.ts
+++ b/lib/cli/commands/sell.ts
@@ -2,7 +2,7 @@ import { Arguments, Argv } from 'yargs';
 import { OrderSide } from '../../proto/xudrpc_pb';
 import { placeOrderBuilder, placeOrderHandler } from '../placeorder';
 
-export const command = 'sell <quantity> <pair_id> <price> [order_id] [stream] [replace_order_id]';
+export const command = 'sell <quantity> <pair_id> <price> [order_id]';
 
 export const describe = 'place a sell order';
 

--- a/lib/cli/commands/streamorders.ts
+++ b/lib/cli/commands/streamorders.ts
@@ -1,19 +1,18 @@
-import { loadXudClient } from '../command';
-import { Arguments } from 'yargs';
-import * as xudrpc from '../../proto/xudrpc_pb';
+import { Arguments, Argv } from 'yargs';
 import { XudClient } from '../../proto/xudrpc_grpc_pb';
+import * as xudrpc from '../../proto/xudrpc_pb';
+import { loadXudClient } from '../command';
 
 export const command = 'streamorders [existing]';
 
 export const describe = 'stream order added, removed, and swapped events (DEMO)';
 
-export const builder = {
-  existing: {
+export const builder = (argv: Argv) => argv
+  .option('existing', {
     description: 'whether to return existing orders',
     type: 'boolean',
     default: true,
-  },
-};
+  });
 
 export const handler = async (argv: Arguments) => {
   await ensureConnection(argv, true);

--- a/lib/cli/commands/tradinglimits.ts
+++ b/lib/cli/commands/tradinglimits.ts
@@ -1,9 +1,9 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
-import { TradingLimitsRequest, TradingLimitsResponse } from '../../proto/xudrpc_pb';
-import { satsToCoinsStr } from '../utils';
 import Table, { HorizontalTable } from 'cli-table3';
 import colors from 'colors/safe';
+import { Arguments, Argv } from 'yargs';
+import { TradingLimitsRequest, TradingLimitsResponse } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
+import { satsToCoinsStr } from '../utils';
 
 const HEADERS = [
   colors.blue('Currency'),
@@ -44,12 +44,13 @@ export const command = 'tradinglimits [currency]';
 
 export const describe = 'trading limits for a given currency';
 
-export const builder = {
-  currency: {
+export const builder = (argv: Argv) => argv
+  .option('currency', {
     describe: 'the currency to query for',
     type: 'string',
-  },
-};
+  })
+  .example('$0 tradinglimits', 'get the trading limits for all currencies')
+  .example('$0 tradinglimits BTC', 'get the trading limits for BTC');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new TradingLimitsRequest();

--- a/lib/cli/commands/unban.ts
+++ b/lib/cli/commands/unban.ts
@@ -1,22 +1,23 @@
-import { callback, loadXudClient } from '../command';
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { UnbanRequest } from '../../proto/xudrpc_pb';
+import { callback, loadXudClient } from '../command';
 
-export const command = 'unban <node_identifier> [reconnect]';
+export const command = 'unban <node_identifier> [--reconnect]';
 
 export const describe = 'unban a previously banned remote node';
 
-export const builder = {
-  node_identifier: {
+export const builder = (argv: Argv) => argv
+  .positional('node_identifier', {
     description: 'the node key or alias of the remote node to unban',
     type: 'string',
-  },
-  reconnect: {
+  })
+  .option('reconnect', {
     description: 'whether to connect to the remote node after unbanning',
     type: 'boolean',
     default: true,
-  },
-};
+  })
+  .example('$0 unban 028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b', 'unban by node key')
+  .example('$0 unban CheeseMonkey', 'unban by alias');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new UnbanRequest();

--- a/lib/cli/commands/withdraw.ts
+++ b/lib/cli/commands/withdraw.ts
@@ -1,33 +1,35 @@
-import { Arguments } from 'yargs';
+import { Arguments, Argv } from 'yargs';
 import { WithdrawRequest } from '../../proto/xudrpc_pb';
 import { callback, loadXudClient } from '../command';
 
-export const command = 'withdraw <amount> <currency> <destination> [fee]';
+export const command = 'withdraw [amount] [currency] [destination] [fee]';
 
 export const describe = 'withdraws on-chain funds from xud';
 
-export const builder = {
-  amount: {
+export const builder = (argv: Argv) => argv
+  .option('amount', {
     description: 'the amount to withdraw',
     type: 'number',
-  },
-  currency: {
+  })
+  .option('currency', {
     description: 'the ticker symbol of the currency to withdraw.',
     type: 'string',
-  },
-  destination: {
+  })
+  .option('destination', {
     description: 'the address to send withdrawn funds to',
     type: 'string',
-  },
-  fee: {
+  })
+  .option('fee', {
     description: 'the fee in satoshis (or equivalent) per byte',
     type: 'number',
-  },
-  all: {
-    description: 'whether to withdraw all available funds for the specified currency',
+  })
+  .option('all', {
+    description: 'whether to withdraw all available funds',
     type: 'boolean',
-  },
-};
+  })
+  .example('$0 withdraw 0.1 BTC 1BitcoinEaterAddressDontSendf59kuE', 'withdraws 0.1 BTC')
+  .example('$0 withdraw 0.1 BTC 1BitcoinEaterAddressDontSendf59kuE 20', 'withdraws 0.1 BTC using 20 sats/byte')
+  .example('$0 withdraw --all --currency BTC --address 1BitcoinEaterAddressDontSendf59kuE', 'withdraws all BTC');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new WithdrawRequest();

--- a/lib/cli/placeorder.ts
+++ b/lib/cli/placeorder.ts
@@ -6,15 +6,15 @@ import { checkDecimalPlaces } from '../utils/utils';
 
 export const placeOrderBuilder = (argv: Argv, side: OrderSide) => {
   const command = side === OrderSide.BUY ? 'buy' : 'sell';
-  argv.option('quantity', {
+  argv.positional('quantity', {
     type: 'number',
     describe: 'the quantity to trade',
   })
-  .option('pair_id', {
+  .positional('pair_id', {
     type: 'string',
     describe: 'the trading pair ticker id for the order',
   })
-  .option('price', {
+  .positional('price', {
     type: 'string',
     describe: 'the price for limit orders, or "mkt"/"market" for market orders',
   })


### PR DESCRIPTION
This clarifies the usage and help output of each `xucli` command. Previously, all arguments were described as "Options" - even the positional arguments that were actually required. Specifying these required arguments as flags (for example `xucli ban --node_identifier CheeseMonkey`) would not work.

This commit attempts to properly use yargs' `positional` method wherever applicable for arguments with a fixed position in the command syntax. It also provides examples for the various ways commands can be used.