### PR TITLE
fix: broadcast invalidation after internal match

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -454,6 +454,7 @@ class OrderBook extends EventEmitter {
         this.logger.info(`internal match executed on taker ${taker.id} and maker ${maker.id} for ${maker.quantity}`);
         portion.localId = maker.localId;
         internalMatches.push(maker);
+        this.pool.broadcastOrderInvalidation(portion);
         this.emit('ownOrder.filled', portion);
         await this.persistTrade(portion.quantity, maker, taker);
         onUpdate && onUpdate({ type: PlaceOrderEventType.InternalMatch, payload: maker });

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -43,6 +43,10 @@ type nodeConfig struct {
 	RaidenHost    string
 	RaidenPort    int
 
+	ConnextDisable bool
+	ConnextHost    string
+	ConnextPort    int
+
 	P2PPort  int
 	RPCPort  int
 	HTTPPort int
@@ -88,6 +92,13 @@ func (cfg nodeConfig) genArgs() []string {
 		args = append(args, fmt.Sprintf("--raiden.port=%v", cfg.RaidenPort))
 	} else {
 		args = append(args, "--raiden.disable")
+	}
+
+	if !cfg.ConnextDisable {
+		args = append(args, fmt.Sprintf("--connext.host=%v", cfg.ConnextHost))
+		args = append(args, fmt.Sprintf("--connext.port=%v", cfg.ConnextPort))
+	} else {
+		args = append(args, "--connext.disable")
 	}
 
 	return args
@@ -140,6 +151,7 @@ func newNode(name string, xudPath string, noBalanceChecks bool) (*HarnessNode, e
 		XUDPath:         xudPath,
 		NoBalanceChecks: noBalanceChecks,
 		RaidenDisable:   true,
+		ConnextDisable:  true,
 	}
 	epoch := time.Now().Unix()
 	cfg.LogPath = fmt.Sprintf("./temp/logs/xud-%s-%d.log", name, epoch)


### PR DESCRIPTION
Fixes #1547.

This informs peers when an order is matched or filled internally that the order is no longer valid or available for swapping. It includes a simulation test case that fails with the current code and passes with the included fix.



