### PR TITLE
[WIP]: fix(orderbook): fully remove matched own orders 

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -26,8 +26,6 @@ interface OrderBook {
   on(event: 'peerOrder.invalidation', listener: (order: OrderPortion) => void): this;
   /** Adds a listener to be called when all or part of a remote order was filled by an own order and removed */
   on(event: 'peerOrder.filled', listener: (order: OrderPortion) => void): this;
-  /** Adds a listener to be called when all or part of a local order was swapped and removed, after it was filled and executed remotely */
-  on(event: 'ownOrder.swapped', listener: (order: OrderPortion) => void): this;
   /** Adds a listener to be called when all or part of a local order was filled by an own order and removed */
   on(event: 'ownOrder.filled', listener: (order: OrderPortion) => void): this;
   /** Adds a listener to be called when a local order was added */
@@ -41,8 +39,6 @@ interface OrderBook {
   emit(event: 'peerOrder.invalidation', order: OrderPortion): boolean;
   /** Notifies listeners that all or part of a remote order was filled by an own order and removed */
   emit(event: 'peerOrder.filled', order: OrderPortion): boolean;
-  /** Notifies listeners that all or part of a local order was swapped and removed, after it was filled and executed remotely */
-  emit(event: 'ownOrder.swapped', order: OrderPortion): boolean;
   /** Notifies listeners that all or part of a local order was filled by an own order and removed */
   emit(event: 'ownOrder.filled', order: OrderPortion): boolean;
   /** Notifies listeners that a local order was added */
@@ -170,7 +166,6 @@ class OrderBook extends EventEmitter {
         this.removeOrderHold(orderId, pairId, quantity);
 
         const ownOrder = this.removeOwnOrder(orderId, pairId, quantity, peerPubKey);
-        this.emit('ownOrder.swapped', { pairId, quantity, id: orderId });
         await this.persistTrade(swapSuccess.quantity, ownOrder, undefined, swapSuccess.rHash);
       }
     });

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -697,7 +697,6 @@ class Service {
     const orderRemoved$ = merge(
       fromEvent<OrderPortion>(this.orderBook, 'peerOrder.invalidation'),
       fromEvent<OrderPortion>(this.orderBook, 'peerOrder.filled'),
-      fromEvent<OrderPortion>(this.orderBook, 'ownOrder.filled'),
       fromEvent<OrderPortion>(this.orderBook, 'ownOrder.removed'),
     ).pipe(takeUntil(cancelled$)); // cleanup listeners when cancelled$ emits a value
 


### PR DESCRIPTION
This ensures that orders that are internally matched get fully removed from the order book. Previously, internally matched orders would be removed from the trading pair queues but not from the global order book mapping between local order ids and global order ids.

The `TradingPair` class now acts as an event emitter to notify its parent `OrderBook` when orders are matched and whether they were matched fully, with no remaining quantity or hold. Previously the `OrderBook` received a list of matches when calling the `match` method but wasn't aware when orders were fully matched.

Fixes #1556.

Some follow-ups that came to mind while investigating/working on this include:

- Change the `hold` vs `quantity` convention so that `quantity` only refers to the quantity available at that exact moment, excluding holds. In other words adding to `hold` would involve subtracting from `quantity`. There are a few parts where this would make the code and matching routine simpler, and it seems more intuitive to me after thinking through it some.

- Further investigate a potential bug where if the best available order is completely on hold, matching will immediately stop and not go to the next best orders. This is due to encountering no "matching quantity" with this best order, and is partly related to the bullet point above. 