### PR TITLE
 fix: resolve alias for all known nodes 

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -1032,25 +1032,11 @@ class Pool extends EventEmitter {
    * pub key cannot be found for the provided alias.
    */
   public resolveAlias = (alias: string) => {
-    if (alias === '') {
+    const nodePubKey = this.nodes.getPubKeyForAlias(alias);
+    if (!nodePubKey) {
       throw errors.UNKNOWN_ALIAS(alias);
     }
-    let matchingNodePubKeys: string[] = [];
-    this.peers.forEach((peer) => {
-      if (peer.alias) {
-        if (peer.alias.toLowerCase() === alias.toLowerCase()) {
-          matchingNodePubKeys.push(peer.nodePubKey!);
-        }
-      }
-    });
-    matchingNodePubKeys = matchingNodePubKeys.concat(this.nodes.getBannedPubKeys(alias));
-    if (matchingNodePubKeys.length === 1) {
-      return matchingNodePubKeys[0];
-    } else if (matchingNodePubKeys.length === 0) {
-      throw errors.UNKNOWN_ALIAS(alias);
-    } else {
-      throw errors.ALIAS_CONFLICT(alias);
-    }
+    return nodePubKey;
   }
 }
 


### PR DESCRIPTION
This fixes the logic used to resolve a node alias - when it is provided via the rpc layer, to a node pub key. Previously, we only checked if the alias matched connected peers and banned nodes, but not nodes we know of but aren't actively connected to.

This also refactors the `resolveAlias` logic to use a map of known aliases to node pub keys, such that we don't dynamically calculate the list of known aliases each time we must resolve an alias. Instead, aliases for all known nodes are determined up front.

Finally it refactors the nodelist to combine the `Map` of banned nodes with that of unbanned nodes, as the distinction was unnecessary. Instead a single map contains all known nodes.