### PR TITLE
chore: remove extra newlines in create command to fit tty

### DIFF
--- a/lib/cli/commands/create.ts
+++ b/lib/cli/commands/create.ts
@@ -39,12 +39,12 @@ const formatOutput = (response: CreateNodeResponse.AsObject) => {
     console.log(walletInitializedMessage);
 
     console.log(`
-Please write down your 24 word mnemonic. It will allow you to recover your xud
-node key and on-chain funds for the initialized wallets listed above should you
-forget your password or lose your device. Off-chain funds in channels can NOT
-be recovered with it and must be backed up and recovered separately. Keep it
+Please write down your 24 word mnemonic. It will allow you to recover your xud \
+node key and on-chain funds for the initialized wallets listed above should you \
+forget your password or lose your device. Off-chain funds in channels can NOT \
+be recovered with it and must be backed up and recovered separately. Keep it \
 somewhere safe, it is your ONLY backup in case of data loss.
-    `);
+`);
   } else {
     console.log('xud was initialized without a seed because no wallets could be initialized.');
   }
@@ -56,10 +56,10 @@ export const handler = (argv: Arguments<any>) => {
     terminal: true,
   });
 
-  console.log(`
-You are creating an xud node key and underlying wallets. All will be secured by
+  console.log(`\
+You are creating an xud node key and underlying wallets. All will be secured by \
 a single password provided below.
-  `);
+`);
   process.stdout.write('Enter a password: ');
   rl.question('', (password1) => {
     process.stdout.write('\nRe-enter password: ');


### PR DESCRIPTION
This PR let `xucli create` command output fit the tty width. So it could be better integrated into other cli commands like in xud-docker.

```
You are creating an xud node key and underlying wallets. All will be secured by
a single password provided below.

Enter a password:
Re-enter password:

----------------------BEGIN XUD SEED---------------------
 1. abandon     2. busy        3. canvas      4. join
 5. mom         6. erode       7. always      8. lumber
 9. sort       10. deer       11. coach      12. story
13. enhance    14. believe    15. fatal      16. oppose
17. home       18. chief      19. balcony    20. cave
21. bitter     22. maximum    23. frequent   24. want
-----------------------END XUD SEED----------------------

The following wallets were initialized: BTC, LTC, ERC20(ETH)

Please write down your 24 word mnemonic. It will allow you to recover your xud
node key and on-chain funds for the initialized wallets listed above should you
forget your password or lose your device. Off-chain funds in channels can NOT
be recovered with it and must be backed up and recovered separately. Keep it
somewhere safe, it is your ONLY backup in case of data loss.

YOU WILL NOT BE ABLE TO DISPLAY YOUR XUD SEED AGAIN. Press ENTER to continue...

Please enter a path to a destination where to store a backup of your environment. It includes everything, but NOT your wallet balance which is secured by your XUD SEED. The path should be an external drive, like a USB or network drive, which is permanently available on your device since backups are written constantly.
```