### PR TITLE
fix(swaps): don't cancel invoice on swap timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ jobs:
       services:
         - docker
       script:
-        - npm run test:sim:build
-        - npm run test:sim:run
+        - npm run test:sim:build && npm run test:sim:run
       after_failure:
         - npm run test:sim:logs
     - name: test:seedutil

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -33,6 +33,7 @@ export enum Context {
   Swaps = 'SWAPS',
   Http = 'HTTP',
   Backup = 'BACKUP',
+  Service = 'SERVICE',
 }
 
 type Loggers = {
@@ -46,6 +47,7 @@ type Loggers = {
   connext: Logger,
   swaps: Logger,
   http: Logger,
+  service: Logger,
 };
 
 class Logger {
@@ -121,6 +123,7 @@ class Logger {
       connext: new Logger({ ...object, context: Context.Connext }),
       swaps: new Logger({ ...object, context: Context.Swaps }),
       http: new Logger({ ...object, context: Context.Http }),
+      service: new Logger({ ...object, context: Context.Service }),
     };
   }
 

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -203,6 +203,7 @@ class Xud extends EventEmitter {
         swapClientManager: this.swapClientManager,
         pool: this.pool,
         swaps: this.swaps,
+        logger: loggers.service,
         shutdown: this.beginShutdown,
       });
 

--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -350,9 +350,8 @@ class ConnextClient extends SwapClient {
         case errorCodes.TIMEOUT:
         case errorCodes.SERVER_ERROR:
         case errorCodes.INVALID_TOKEN_PAYMENT_RESPONSE:
-          throw swapErrors.UNKNOWN_PAYMENT_ERROR(err.message);
         default:
-          throw swapErrors.FINAL_PAYMENT_ERROR(err.message);
+          throw swapErrors.UNKNOWN_PAYMENT_ERROR(err.message);
       }
     }
   }

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -142,8 +142,10 @@ export enum SwapFailureReason {
   RemoteError = 13,
   /** The swap failed because of a system or xud crash while the swap was being executed. */
   Crash = 14,
-  /** A swap was attempted between an invalid matching of orders */
+  /** A swap was attempted between an invalid matching of orders. */
   InvalidOrders = 15,
+  /** Our payment to the peer was rejected, either deliberately or due to an error. */
+  PaymentRejected = 16,
 }
 
 export enum DisconnectionReason {

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -332,7 +332,12 @@ class OrderBook extends EventEmitter {
       };
     }
 
-    return this.placeOrder(stampedOrder, immediateOrCancel, onUpdate, Date.now() + OrderBook.MAX_PLACEORDER_ITERATIONS_TIME);
+    return this.placeOrder({
+      onUpdate,
+      order: stampedOrder,
+      discardRemaining: immediateOrCancel,
+      maxTime: Date.now() + OrderBook.MAX_PLACEORDER_ITERATIONS_TIME,
+    });
   }
 
   public placeMarketOrder = async (order: OwnMarketOrder, onUpdate?: (e: PlaceOrderEvent) => void): Promise<PlaceOrderResult> => {
@@ -341,7 +346,12 @@ class OrderBook extends EventEmitter {
     }
 
     const stampedOrder = this.stampOwnOrder({ ...order, price: order.isBuy ? Number.POSITIVE_INFINITY : 0 });
-    const addResult = await this.placeOrder(stampedOrder, true, onUpdate, Date.now() + OrderBook.MAX_PLACEORDER_ITERATIONS_TIME);
+    const addResult = await this.placeOrder({
+      onUpdate,
+      order: stampedOrder,
+      discardRemaining: true,
+      maxTime: Date.now() + OrderBook.MAX_PLACEORDER_ITERATIONS_TIME,
+    });
     delete addResult.remainingOrder;
     return addResult;
   }
@@ -357,12 +367,19 @@ class OrderBook extends EventEmitter {
    * routine including internal matches, successful swaps, failed swaps, and remaining orders
    * @param maxTime the deadline in epoch milliseconds for this method to end recursive calls
    */
-  private placeOrder = async (
-    order: OwnOrder,
+  private placeOrder = async ({
+    order,
     discardRemaining = false,
+    retry = false,
+    onUpdate,
+    maxTime,
+  }: {
+    order: OwnOrder,
+    discardRemaining?: boolean,
+    retry?: boolean,
     onUpdate?: (e: PlaceOrderEvent) => void,
     maxTime?: number,
-  ): Promise<PlaceOrderResult> => {
+  }): Promise<PlaceOrderResult> => {
     // Check if order complies to thresholds
     if (this.thresholds.minQuantity > 0) {
       if (!this.checkThresholdCompliance(order)) {
@@ -373,7 +390,7 @@ class OrderBook extends EventEmitter {
     // this method can be called recursively on swap failures retries.
     // if max time exceeded, don't try to match
     if (maxTime && Date.now() > maxTime) {
-      assert(discardRemaining, 'discardRemaining must be true on recursive calls where maxTime could exceed');
+      assert(retry, 'we may only timeout placeOrder on retries');
       this.logger.debug(`placeOrder max time exceeded. order (${JSON.stringify(order)}) won't be fully matched`);
 
       // returning the remaining order to be rolled back and handled by the initial call
@@ -381,7 +398,7 @@ class OrderBook extends EventEmitter {
         internalMatches: [],
         swapSuccesses: [],
         swapFailures: [],
-        remainingOrder: order,
+        remainingOrder: discardRemaining ? undefined : order,
       };
     }
 
@@ -430,7 +447,7 @@ class OrderBook extends EventEmitter {
       const orderToRetry: OwnOrder = { ...order, quantity: failedSwapQuantity };
 
       // invoke placeOrder recursively, append matches/swaps and any remaining order
-      const retryResult = await this.placeOrder(orderToRetry, true, onUpdate, maxTime);
+      const retryResult = await this.placeOrder({ discardRemaining, onUpdate, maxTime, order: orderToRetry, retry: true });
       internalMatches.push(...retryResult.internalMatches);
       swapSuccesses.push(...retryResult.swapSuccesses);
       if (retryResult.remainingOrder) {
@@ -518,7 +535,11 @@ class OrderBook extends EventEmitter {
     if (remainingOrder) {
       if (discardRemaining) {
         remainingOrder = undefined;
-      } else {
+      } else if (!retry) {
+        // on recursive retries of placeOrder, we don't add remaining orders to the orderbook
+        // instead we preserve the remainder and return it to the parent caller, which will sum
+        // up any remaining orders and add them to the order book as a single order once
+        // matching is complete
         this.addOwnOrder(remainingOrder);
         onUpdate && onUpdate({ type: PlaceOrderEventType.RemainingOrder, order: remainingOrder });
       }

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -78,7 +78,7 @@ class OrderBook extends EventEmitter {
   private swaps: Swaps;
 
   /** Max time for placeOrder iterations (due to swaps failures retries). */
-  private static readonly MAX_PLACEORDER_ITERATIONS_TIME = 10000; // 10 sec
+  private static readonly MAX_PLACEORDER_ITERATIONS_TIME = 60000; // 1 min
   /** Max time for sanity swaps to succeed. */
   private static readonly MAX_SANITY_SWAP_TIME = 15000;
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { EventEmitter } from 'events';
 import net, { Server, Socket } from 'net';
 import semver from 'semver';
-import { DisconnectionReason, ReputationEvent, XuNetwork } from '../constants/enums';
+import { DisconnectionReason, ReputationEvent, XuNetwork, SwapFailureReason } from '../constants/enums';
 import { Models } from '../db/DB';
 import { ReputationEventInstance } from '../db/types';
 import Logger from '../Logger';
@@ -825,7 +825,7 @@ class Pool extends EventEmitter {
       }
       case PacketType.SwapFailed: {
         const { body } = (packet as packets.SwapFailedPacket);
-        this.logger.debug(`received swapFailed due to ${body?.failureReason} from ${peer.label}: ${JSON.stringify(body)}`);
+        this.logger.debug(`received swapFailed due to ${SwapFailureReason[body!.failureReason]} from ${peer.label}: ${JSON.stringify(body)}`);
         this.emit('packet.swapFailed', packet);
         break;
       }

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1,6 +1,7 @@
 import { ProvidePreimageEvent, TransferReceivedEvent } from '../connextclient/types';
 import { OrderSide, Owner, SwapClientType, SwapRole } from '../constants/enums';
 import { OrderAttributes, TradeInstance } from '../db/types';
+import Logger from '../Logger';
 import OrderBook from '../orderbook/OrderBook';
 import { Currency, isOwnOrder, Order, OrderPortion, OwnLimitOrder, OwnMarketOrder, PlaceOrderEvent } from '../orderbook/types';
 import Pool from '../p2p/Pool';
@@ -57,6 +58,7 @@ class Service {
   private pool: Pool;
   private version: string;
   private swaps: Swaps;
+  private logger: Logger;
 
   /** Create an instance of available RPC methods and bind all exposed functions. */
   constructor(components: ServiceComponents) {
@@ -65,6 +67,7 @@ class Service {
     this.swapClientManager = components.swapClientManager;
     this.pool = components.pool;
     this.swaps = components.swaps;
+    this.logger = components.logger;
 
     this.version = components.version;
   }
@@ -678,6 +681,7 @@ class Service {
    */
   public subscribeSwapFailures = async (args: { includeTaker: boolean }, callback: (swapFailure: SwapFailure) => void) => {
     this.swaps.on('swap.failed', (deal) => {
+      this.logger.trace(`notifying SwapFailure subscription for ${deal.rHash} with role ${SwapRole[deal.role]}`);
       // always alert client for maker matches, taker matches only when specified
       if (deal.role === SwapRole.Maker || args.includeTaker) {
         callback(deal as SwapFailure);

--- a/lib/service/types.ts
+++ b/lib/service/types.ts
@@ -7,6 +7,7 @@ import Pool from '../p2p/Pool';
 import { RaidenInfo } from '../raidenclient/types';
 import SwapClientManager from '../swaps/SwapClientManager';
 import Swaps from '../swaps/Swaps';
+import Logger from 'lib/Logger';
 
 /**
  * The components required by the API service layer.
@@ -15,10 +16,11 @@ export type ServiceComponents = {
   orderBook: OrderBook;
   swapClientManager: SwapClientManager;
   pool: Pool;
-    /** The version of the local xud instance. */
+  /** The version of the local xud instance. */
   version: string;
   swaps: Swaps;
-    /** The function to be called to shutdown the parent process */
+  logger: Logger;
+  /** The function to be called to shutdown the parent process */
   shutdown: () => void;
 };
 

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1209,12 +1209,13 @@ class Swaps extends EventEmitter {
           deal.role === SwapRole.Maker && deal.phase === SwapPhase.SwapAccepted,
             'SendingPayment can only be set after SwapRequested (taker) or SwapAccepted (maker)');
         deal.executeTime = Date.now();
+        this.logger.debug(`Setting SendingPayment phase for deal ${deal.rHash}`);
         break;
       case SwapPhase.PaymentReceived:
         assert(deal.phase === SwapPhase.SendingPayment, 'PaymentReceived can be only be set after SendingPayment');
         deal.completeTime = Date.now();
         deal.state = SwapState.Completed;
-        this.logger.debug(`Payment received for deal with hash ${deal.rHash} - preimage is ${deal.rPreimage}`);
+        this.logger.debug(`Setting PaymentReceived phase for deal ${deal.rHash} - preimage is ${deal.rPreimage}`);
         break;
       default:
         assert.fail('unknown deal phase');

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1095,6 +1095,8 @@ class Swaps extends EventEmitter {
     }) => {
     assert(deal.state !== SwapState.Completed, 'Can not fail a completed deal.');
 
+    this.logger.trace(`failing deal ${deal.rHash} in state ${SwapState[deal.state]} & phase ${SwapPhase[deal.phase]} due to ${SwapFailureReason[failureReason]}`);
+
     // If we are already in error state and got another error report we
     // aggregate all error reasons by concatenation
     if (deal.state === SwapState.Error) {
@@ -1168,6 +1170,7 @@ class Swaps extends EventEmitter {
       swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
     }
 
+    this.logger.trace(`emitting swap.failed event for ${deal.rHash}`);
     this.emit('swap.failed', deal);
 
     if (peer) {

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -105,6 +105,7 @@ const loggers = {
   connext: logger,
   swaps: logger,
   http: logger,
+  service: logger,
 };
 
 const localId = '97945230-8144-11e9-beb7-49ba94e5bd74';

--- a/test/jest/Service.spec.ts
+++ b/test/jest/Service.spec.ts
@@ -1,4 +1,5 @@
 import { Owner } from '../../lib/constants/enums';
+import Logger from '../../lib/Logger';
 import Orderbook from '../../lib/orderbook/OrderBook';
 import Peer from '../../lib/p2p/Peer';
 import Pool from '../../lib/p2p/Pool';
@@ -20,6 +21,8 @@ jest.mock('../../lib/p2p/Pool');
 const mockedPool = <jest.Mock<Pool>><any>Pool;
 jest.mock('../../lib/p2p/Peer');
 const mockedPeer = <jest.Mock<Peer>><any>Peer;
+jest.mock('../../lib/Logger');
+const mockedLogger = <jest.Mock<Logger>><any>Logger;
 
 const getArgs = () => {
   return {
@@ -41,6 +44,7 @@ describe('Service', () => {
       swaps: new mockedSwaps(),
       version: '1.0.0',
       shutdown: jest.fn(),
+      logger: new mockedLogger(),
     };
     peer = new mockedPeer();
     components.pool.getPeer = jest.fn().mockReturnValue(peer);

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -81,6 +81,7 @@ const loggers = {
   connext: logger,
   swaps: logger,
   http: logger,
+  service: logger,
 };
 jest.mock('../../lib/p2p/Peer');
 const mockedPeer = <jest.Mock<Peer>><any>Peer;

--- a/test/jest/SwapRecovery.spec.ts
+++ b/test/jest/SwapRecovery.spec.ts
@@ -88,7 +88,7 @@ describe('SwapRecovery', () => {
     expect(deal.state).toEqual(SwapState.Error);
     expect(deal.failureReason).toEqual(SwapFailureReason.Crash);
     expect(swapRecovery.pendingSwaps.delete).toHaveBeenCalledTimes(1);
-    expect(swapRecovery.pendingSwaps.delete).toHaveBeenCalledWith(deal);
+    expect(swapRecovery.pendingSwaps.delete).toHaveBeenCalledWith(deal.rHash);
     expect(save).toHaveBeenCalledTimes(1);
   });
 
@@ -165,7 +165,7 @@ describe('SwapRecovery', () => {
     await swapRecovery.recoverDeal(deal);
     expect(lndLtc.lookupPayment).toHaveBeenCalledTimes(1);
     expect(lndLtc.lookupPayment).toHaveBeenCalledWith(deal.rHash, deal.takerCurrency);
-    expect(swapRecovery.pendingSwaps).toContain(deal);
+    expect(swapRecovery.pendingSwaps.has(deal.rHash)).toBeTruthy();
   });
 
 });

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -76,6 +76,7 @@ describe('Swaps Integration', () => {
     logger = new mockedLogger();
     logger.debug = jest.fn();
     logger.error = jest.fn();
+    logger.trace = jest.fn();
     db = new mockedDB();
     pool = new mockedPool();
     swapClientManager = new mockedSwapClientManager();

--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -15,7 +15,7 @@ index b50acec47..bfd7a86d6 100644
        if (!this.config.rpc.disable) {
          // start rpc server first, it will respond with UNAVAILABLE error
 diff --git a/lib/swaps/SwapRecovery.ts b/lib/swaps/SwapRecovery.ts
-index f077b3ca4..7398a97b4 100644
+index 9a4bc5efb..78e4c53a4 100644
 --- a/lib/swaps/SwapRecovery.ts
 +++ b/lib/swaps/SwapRecovery.ts
 @@ -21,7 +21,15 @@ class SwapRecovery {
@@ -36,7 +36,7 @@ index f077b3ca4..7398a97b4 100644
    }
  
 diff --git a/lib/swaps/Swaps.ts b/lib/swaps/Swaps.ts
-index 5ee168fa9..f0a3b879d 100644
+index 3f9f73ede..1effe1637 100644
 --- a/lib/swaps/Swaps.ts
 +++ b/lib/swaps/Swaps.ts
 @@ -205,9 +205,28 @@ class Swaps extends EventEmitter {
@@ -112,12 +112,14 @@ index 5ee168fa9..f0a3b879d 100644
      } catch (err) {
        // first we must handle the edge case where the maker has paid us but failed to claim our payment
        // in this case, we've already marked the swap as having been paid and completed
-@@ -939,12 +978,29 @@ class Swaps extends EventEmitter {
+@@ -939,6 +978,18 @@ class Swaps extends EventEmitter {
  
        this.logger.debug('Executing maker code to resolve hash');
  
 +      if (process.env.CUSTOM_SCENARIO === 'SECURITY::MAKER_1ST_HTLC_STALL') {
 +        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
++        const makerSwapClient = this.swapClientManager.get(deal.makerCurrency)!;
++        await makerSwapClient.removeInvoice(deal.rHash).catch(this.logger.error);
 +        return '';
 +      }
 +
@@ -129,7 +131,8 @@ index 5ee168fa9..f0a3b879d 100644
        const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
  
        // we update the phase persist the deal to the database before we attempt to send payment
-       await this.setDealPhase(deal, SwapPhase.SendingPayment);
+@@ -949,6 +1000,13 @@ class Swaps extends EventEmitter {
+       assert(deal.state !== SwapState.Error, `cannot send payment for failed swap ${deal.rHash}`);
  
        try {
 +        if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND') {
@@ -142,7 +145,7 @@ index 5ee168fa9..f0a3b879d 100644
          deal.rPreimage = await swapClient.sendPayment(deal);
          return deal.rPreimage;
        } catch (err) {
-@@ -974,6 +1030,16 @@ class Swaps extends EventEmitter {
+@@ -995,6 +1053,16 @@ class Swaps extends EventEmitter {
        assert(htlcCurrency === undefined || htlcCurrency === deal.takerCurrency, 'incoming htlc does not match expected deal currency');
        this.logger.debug('Executing taker code to resolve hash');
  


### PR DESCRIPTION
This fixes a bug where we cancel the incoming invoice for swaps that time out as the maker. Although we would put the timed out swap into the SwapRecovery module, the swap cannot be recovered if the incoming invoice has been canceled, and if the taker later claims our payment it leaves us unable to claim the maker's payment.

The widely used `failDeal` method in Swaps was canceling incoming invoices which is what led to this unintended behavior. Now this logic is removed from `failDeal` - since it is only relevant when we attempt a payment as maker and it fails in a permanent fashion. Instead, we only cancel & remove the invoice for this specific case.

Fixes #1574.