### PR TITLE
chore: print xud logs only for simulation tests

### DIFF
--- a/test/simulation/logs.sh
+++ b/test/simulation/logs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cat $PWD/temp/logs/*.log
+find $PWD/temp/logs -type f -name xud*.log -printf "\n%f\n\n" -exec cat {} \;


### PR DESCRIPTION
This outputs only the xud logs for the `test:sim:logs` script, ignoring the lnd logs since they are too verbose and can result in too much text in the travis log output when the script is used. This also prints the filename at the top of each log file so they can be differentiated.