### PR TITLE
fix(swaps): go to recovery for all failures

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -587,6 +587,7 @@ class ConnextClient extends SwapClient {
    * @param lockHash
    */
   private executeHashLockTransfer = async (payload: TokenPaymentRequest): Promise<string> => {
+    this.logger.debug(`sending payment of ${payload.amount} with hash ${payload.lockHash} to ${payload.recipient}`);
     const res = await this.sendRequest('/hashlock-transfer', 'POST', payload);
     const { appId } = await parseResponseBody<ConnextTransferResponse>(res);
     return appId;

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -595,7 +595,7 @@ class LndClient extends SwapClient {
    * Sends a payment through the Lightning Network.
    */
   private sendPaymentSync = (request: lndrpc.SendRequest): Promise<lndrpc.SendResponse> => {
-    this.logger.trace(`sending payment of ${request.getAmt()} for ${request.getPaymentHashString()}`);
+    this.logger.trace(`sending payment with request: ${JSON.stringify(request.toObject())}`);
     return this.unaryCall<lndrpc.SendRequest, lndrpc.SendResponse>('sendPaymentSync', request);
   }
 
@@ -631,8 +631,7 @@ class LndClient extends SwapClient {
     if (!this.isConnected()) {
       throw swapErrors.FINAL_PAYMENT_ERROR(errors.UNAVAILABLE(this.currency, this.status).message);
     }
-
-    this.logger.trace(`sending payment with ${JSON.stringify(request.toObject())}`);
+    this.logger.debug(`sending payment of ${request.getAmt()} with hash ${request.getPaymentHashString()} to ${request.getDestString()}`);
     let sendPaymentResponse: lndrpc.SendResponse;
     try {
       sendPaymentResponse = await this.sendPaymentSync(request);

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1187,6 +1187,7 @@ class Swaps extends EventEmitter {
       case SwapPhase.SwapAccepted:
         assert(deal.role === SwapRole.Maker, 'SwapAccepted can only be set by the maker');
         assert(deal.phase === SwapPhase.SwapCreated, 'SwapAccepted can be only be set after SwapCreated');
+        this.logger.debug(`Setting SwapAccepted phase for deal ${deal.rHash}`);
         break;
       case SwapPhase.SendingPayment:
         assert(deal.role === SwapRole.Taker && deal.phase === SwapPhase.SwapRequested ||


### PR DESCRIPTION
This fixes a bug where failed swaps in the `SendingPayment` phase as maker would only be tracked by the `SwapRecovery` module if they failed due to a timeout error.

Closes #1606.

This bug was due to an oversight in the changes from #1600.