### PR TITLE
fix(cli): accept lower case currencies

### DIFF
--- a/lib/cli/commands/walletdeposit.ts
+++ b/lib/cli/commands/walletdeposit.ts
@@ -15,6 +15,6 @@ export const builder = (argv: Argv) => argv
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new DepositRequest();
-  request.setCurrency(argv.currency);
+  request.setCurrency(argv.currency.toUpperCase());
   (await loadXudClient(argv)).walletDeposit(request, callback(argv));
 };

--- a/lib/cli/commands/walletwithdraw.ts
+++ b/lib/cli/commands/walletwithdraw.ts
@@ -34,7 +34,7 @@ export const builder = (argv: Argv) => argv
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new WithdrawRequest();
-  request.setCurrency(argv.currency);
+  request.setCurrency(argv.currency.toUpperCase());
   if (argv.all) {
     request.setAll(argv.all);
   } else {


### PR DESCRIPTION
This allows xucli to accept lower or mixed case currency tickers (such as `btc` or `Btc`) as well as upper case for the `walletdeposit` and `walletwithdraw` commands.

Closes #1626.