### PR TITLE
fix(backup): use async fs calls

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -661,7 +661,7 @@ class Swaps extends EventEmitter {
     }
 
     // persist the swap deal to the database after we've added an invoice for it
-    await this.setDealPhase(deal, SwapPhase.SwapAccepted);
+    const newPhasePromise = this.setDealPhase(deal, SwapPhase.SwapAccepted);
 
     const responseBody: packets.SwapAcceptedPacketBody = {
       makerCltvDelta: deal.makerCltvDelta || 1,
@@ -670,7 +670,8 @@ class Swaps extends EventEmitter {
     };
 
     this.logger.debug(`sending swap accepted packet: ${JSON.stringify(responseBody)} to peer: ${peer.nodePubKey}`);
-    await peer.sendPacket(new packets.SwapAcceptedPacket(responseBody, requestPacket.header.id));
+    const sendSwapAcceptedPromise = peer.sendPacket(new packets.SwapAcceptedPacket(responseBody, requestPacket.header.id));
+    await Promise.all([newPhasePromise, sendSwapAcceptedPromise]);
     return true;
   }
 


### PR DESCRIPTION
This PR attempts to address issues and timeouts related to the Backup module writing new backups to disk synchronously. This can block the thread and prevent xud from proceeding with and responding to other matters requiring its attention. It appears to cause the swap acceptance logic to occasionally exceed the 10 second limit because accepting a swap involves several db writes which trigger the backup writes.

It also refactors the final steps of the routine to accept a swap deal to make it so that we update the deal phase (and in turn, update the db) in parallel with sending the swap accepted packet to our peer. This can reduce the total time needed to accept a deal request and begin the swap.

Likely related issue #1625.