### PR TITLE
feat: log preimage when revealed from sent payment

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -335,6 +335,7 @@ class ConnextClient extends SwapClient {
           executeTransfer,
           waitForPreimageByHash(this, deal.rHash),
         ]);
+        this.logger.debug(`received preimage ${preimage} for payment with hash ${deal.rHash}`);
         secret = preimage;
       } else {
         // we are the taker paying the maker

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -651,7 +651,10 @@ class LndClient extends SwapClient {
         throw swapErrors.FINAL_PAYMENT_ERROR(paymentError);
       }
     }
-    return base64ToHex(sendPaymentResponse.getPaymentPreimage_asB64());
+    const preimage = base64ToHex(sendPaymentResponse.getPaymentPreimage_asB64());
+
+    this.logger.debug(`sent payment with hash ${request.getPaymentHashString()}, preimage is ${preimage}`);
+    return preimage;
   }
 
   /**


### PR DESCRIPTION
This adds some more logging statements when a swapclient obtains the preimage for a hash from a payment that was sent successfully.