### PR TITLE
chore: add GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        node-version: [12.x]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Lint
+        run: npm run lintNoFix
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/seedutil.yml
+++ b/.github/workflows/seedutil.yml
@@ -1,0 +1,36 @@
+name: Seedutil
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        node-version: [12.x]
+        go-version: [1.13.x]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile:seedutil
+
+      - name: Test
+        run: npm run test:seedutil

--- a/.github/workflows/simtest.yml
+++ b/.github/workflows/simtest.yml
@@ -1,0 +1,36 @@
+name: Simulation tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        node-version: [12.x]
+        go-version: [1.13.x]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build simulation tests
+        run: npm run test:sim:build
+
+      - name: Run simulation tests
+        run: npm run test:sim:run

--- a/parseGitCommit.js
+++ b/parseGitCommit.js
@@ -13,7 +13,13 @@ const getCommitHash = () => {
   if (tag && tag.length > 0) {
     return '';
   } else {
-    return result.match(/[a-z0-9]+\s\(HEAD/g)[0].slice(0, -6);
+    const match = result.match(/[a-z0-9]+\s\(HEAD/g);
+
+    if (match) {
+      return match[0].slice(0, -6);
+    } else {
+      return '';
+    }
   }
 };
 


### PR DESCRIPTION
This PR adds build configurations GitHub actions. I split the GitHub action builds in three pieces:

- CI: compiling, linting and testing XUD
- Seedutil: compiling and testing the seedutil
- Simulation tests: building and running the simulation tests

The minor change in `parseGitCommit.js` was required because of the way GitHub actions clone the repository but it shouldn't affect any other builds at all.