### PR TITLE
 feat(swaps): new PreimageResolved swap phase 

### DIFF
--- a/.github/workflows/simtest.yml
+++ b/.github/workflows/simtest.yml
@@ -33,4 +33,24 @@ jobs:
         run: npm run test:sim:build
 
       - name: Run simulation tests
-        run: npm run test:sim:run
+        run: npm run test:sim:run:integration
+
+      - name: Print simulation test logs
+        if: ${{ failure() }}
+        run: npm run test:sim:logs && rm -rf test/simulation/temp/logs
+
+      - name: Run simulation security tests
+        if: ${{ always() }}
+        run: rm -rf test/simulation/temp/logs && npm run test:sim:run:security
+
+      - name: Print simulation security test logs
+        if: ${{ failure() }}
+        run: npm run test:sim:logs && rm -rf test/simulation/temp/logs
+
+      - name: Run simulation instability tests
+        if: ${{ always() }}
+        run: rm -rf test/simulation/temp/logs && npm run test:sim:run:instability
+
+      - name: Print simulation instability test logs
+        if: ${{ failure() }}
+        run: npm run test:sim:logs

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -4,6 +4,7 @@ import colors from 'colors/safe';
 import { getTsString } from './utils/utils';
 
 enum Level {
+  Alert = 'alert',
   Error = 'error',
   Warn = 'warn',
   Info = 'info',
@@ -13,12 +14,13 @@ enum Level {
 }
 
 const LevelPriorities = {
-  error: 0,
-  warn: 1,
-  info: 2,
-  verbose: 3,
-  debug: 4,
-  trace: 5,
+  alert: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  verbose: 4,
+  debug: 5,
+  trace: 6,
 };
 
 export enum Context {
@@ -154,6 +156,7 @@ class Logger {
   private getLevel = (level: string, colorize: boolean): string => {
     if (colorize) {
       switch (level) {
+        case 'alert': return colors.bgRed(level);
         case 'error': return colors.red(level);
         case 'warn': return colors.yellow(level);
         case 'info': return colors.green(level);
@@ -169,6 +172,10 @@ class Logger {
     if (this.logger) {
       this.logger.log(level, msg);
     }
+  }
+
+  public alert = (msg: string) => {
+    this.log(Level.Alert, msg);
   }
 
   public error = (msg: Error | string, err?: any) => {

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -110,10 +110,21 @@ export enum ReputationEvent {
   SwapSuccess = 5,
   /** When a swap is accepted and is attempted to be executed but fails. */
   SwapFailure = 6,
-  /** When a swap is accepted and then fails due to exceeding time limits. */
+  /** When a swap fails due to exceeding time limits. */
   SwapTimeout = 7,
   /** When a swap fails due to unexpected or possibly malicious behavior. */
   SwapMisbehavior = 8,
+  /**
+   * The peer has behaved dishonestly during a swap in a way that strongly
+   * suggests it is running modified malicious code.
+   */
+  SwapAbuse = 9,
+  /**
+   * The peer completed a swap that was delayed beyond the expected deadline
+   * to complete or fail the swap deal, but the delay was not so long as to
+   * preclude the possibility of latency or lag.
+   */
+  SwapDelay = 10,
 }
 
 export enum SwapFailureReason {

--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -64,21 +64,26 @@ export enum SwapRole {
 }
 
 export enum SwapPhase {
-  /** The swap deal has been created locally. */
+  /** 0/5 The swap deal has been created locally. */
   SwapCreated = 0,
-  /** We've made a request to a peer to accept this swap. */
+  /** 1/5 We've made a request to a peer to accept this swap. */
   SwapRequested = 1,
-  /** The terms of the swap have been agreed to, and we will attempt to execute it. */
+  /** 2/5 The terms of the swap have been agreed to, and we will attempt to execute it. */
   SwapAccepted = 2,
   /**
-   * We have made a request to the swap client to send payment according to the agreed terms.
+   * 3/5 We have made a request to the swap client to send payment according to the agreed terms.
    * The payment (and swap) could still fail due to no route with sufficient capacity, lack of
    * cooperation from the receiver or any intermediary node along the route, or an unexpected
    * error from the swap client.
    */
   SendingPayment = 3,
   /**
-   * We have received the agreed amount of the swap and released the preimage to the
+   * 4/5 We have completed our outgoing payment and retrieved the preimage which can be used to
+   * settle the incoming payment locked by the same hash.
+   */
+  PreimageResolved = 5,
+  /**
+   * 5/5 We have received the agreed amount of the swap and released the preimage to the
    * receiving swap client so it can accept payment.
    */
   PaymentReceived = 4,

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import uuidv1 from 'uuid/v1';
 import { SwapClientType, SwapFailureReason, SwapPhase, SwapRole } from '../constants/enums';
 import { Models } from '../db/DB';
-import { CurrencyFactory, CurrencyInstance, PairInstance } from '../db/types';
+import { CurrencyFactory, CurrencyInstance, OrderFactory, PairInstance } from '../db/types';
 import Logger from '../Logger';
 import { SwapFailedPacket, SwapRequestPacket } from '../p2p/packets';
 import Peer from '../p2p/Peer';
@@ -16,8 +16,10 @@ import { derivePairId, ms, setTimeoutPromise } from '../utils/utils';
 import errors from './errors';
 import OrderBookRepository from './OrderBookRepository';
 import TradingPair from './TradingPair';
-import { IncomingOrder, isOwnOrder, Order, OrderBookThresholds, OrderIdentifier, OrderPortion, OutgoingOrder, OwnLimitOrder, OwnMarketOrder,
-  OwnOrder, Pair, PeerOrder, PlaceOrderEvent, PlaceOrderEventType, PlaceOrderResult } from './types';
+import {
+  IncomingOrder, isOwnOrder, Order, OrderBookThresholds, OrderIdentifier, OrderPortion, OutgoingOrder, OwnLimitOrder, OwnMarketOrder,
+  OwnOrder, Pair, PeerOrder, PlaceOrderEvent, PlaceOrderEventType, PlaceOrderResult,
+} from './types';
 
 interface OrderBook {
   /** Adds a listener to be called when a remote order was added. */
@@ -162,6 +164,15 @@ class OrderBook extends EventEmitter {
   }
 
   private bindSwaps = () => {
+    this.swaps.on('swap.recovered', async (recoveredSwap) => {
+      // when a swap is recovered, we want to record it in the database
+      // as a trade since funds did eventually get swapped
+      await this.persistTrade({
+        quantity: recoveredSwap.quantity!,
+        makerOrderId: recoveredSwap.orderId,
+        rHash: recoveredSwap.rHash,
+      });
+    });
     this.swaps.on('swap.paid', async (swapSuccess) => {
       if (swapSuccess.role === SwapRole.Maker) {
         const { orderId, pairId, quantity, peerPubKey } = swapSuccess;
@@ -171,7 +182,11 @@ class OrderBook extends EventEmitter {
 
         const ownOrder = this.removeOwnOrder(orderId, pairId, quantity, peerPubKey);
         this.emit('ownOrder.swapped', { pairId, quantity, id: orderId });
-        await this.persistTrade(swapSuccess.quantity, ownOrder, undefined, swapSuccess.rHash);
+        await this.persistTrade({
+          quantity: swapSuccess.quantity,
+          makerOrder: ownOrder,
+          rHash: swapSuccess.rHash,
+        });
       }
     });
     this.swaps.on('swap.failed', (deal) => {
@@ -474,7 +489,11 @@ class OrderBook extends EventEmitter {
         internalMatches.push(maker);
         this.pool.broadcastOrderInvalidation(portion);
         this.emit('ownOrder.filled', portion);
-        await this.persistTrade(portion.quantity, maker, taker);
+        await this.persistTrade({
+          quantity: portion.quantity,
+          makerOrder: maker,
+          takerOrder: taker,
+        });
       } else {
         // this is a match with a peer order which cannot be considered executed until after a
         // successful swap, which is an asynchronous process that can fail for numerous reasons
@@ -576,7 +595,12 @@ class OrderBook extends EventEmitter {
     try {
       const swapResult = await this.swaps.executeSwap(maker, taker);
       this.emit('peerOrder.filled', maker);
-      await this.persistTrade(swapResult.quantity, maker, taker, swapResult.rHash);
+      await this.persistTrade({
+        quantity: swapResult.quantity,
+        makerOrder: maker,
+        takerOrder: taker,
+        rHash: swapResult.rHash,
+      });
       return swapResult;
     } catch (err) {
       const failureReason: number = err;
@@ -604,8 +628,19 @@ class OrderBook extends EventEmitter {
     return true;
   }
 
-  private persistTrade = async (quantity: number, makerOrder: Order, takerOrder?: OwnOrder, rHash?: string) => {
-    const addOrderPromises = [this.repository.addOrderIfNotExists(makerOrder)];
+  private persistTrade = async ({ quantity, makerOrder, takerOrder, makerOrderId, rHash }:
+  {
+    quantity: number,
+    makerOrder?: OrderFactory,
+    takerOrder?: OrderFactory,
+    makerOrderId?: string,
+    rHash?: string,
+  }) => {
+    assert(makerOrder || makerOrderId, 'either makerOrder or makerOrderId must be specified to persist a trade');
+    const addOrderPromises: Promise<any>[] = [];
+    if (makerOrder) {
+      addOrderPromises.push(this.repository.addOrderIfNotExists(makerOrder));
+    }
     if (takerOrder) {
       addOrderPromises.push(this.repository.addOrderIfNotExists(takerOrder));
     }
@@ -614,7 +649,7 @@ class OrderBook extends EventEmitter {
     await this.repository.addTrade({
       quantity,
       rHash,
-      makerOrderId: makerOrder.id,
+      makerOrderId: makerOrder ? makerOrder.id : makerOrderId!,
       takerOrderId: takerOrder ? takerOrder.id : undefined,
     });
   }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -292,7 +292,7 @@ class Pool extends EventEmitter {
 
   private bindNodeList = () => {
     this.nodes.on('node.ban', (nodePubKey: string, events: ReputationEventInstance[]) => {
-      this.logger.warn(`node ${nodePubKey} was banned`);
+      this.logger.info(`node ${nodePubKey} was banned`);
 
       const peer = this.peers.get(nodePubKey);
       if (peer) {

--- a/lib/swaps/SwapRecovery.ts
+++ b/lib/swaps/SwapRecovery.ts
@@ -80,6 +80,7 @@ class SwapRecovery {
       await deal.save();
     } catch (err) {
       this.logger.error(`could not settle ${deal.makerCurrency} invoice for payment ${deal.rHash}`, err);
+      this.logger.alert(`incoming ${deal.makerCurrency} payment with hash ${deal.rHash} could not be settled with preimage ${deal.rPreimage}, **funds may be lost and this must be investigated manually**`);
       // TODO: determine when we are permanently unable (due to htlc expiration or unknown invoice hash) to
       // settle an invoice and fail the deal, rather than endlessly retrying settle invoice calls
     }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -82,7 +82,7 @@ class Swaps extends EventEmitter {
   ) {
     super();
 
-    this.swapRecovery = new SwapRecovery(swapClientManager, logger);
+    this.swapRecovery = new SwapRecovery(swapClientManager, logger.createSubLogger('RECOVERY'));
     this.repository = new SwapRepository(this.models);
     this.bind();
   }

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -12,6 +12,7 @@ import Peer from '../p2p/Peer';
 import Pool from '../p2p/Pool';
 import { generatePreimageAndHash, setTimeoutPromise } from '../utils/utils';
 import errors, { errorCodes } from './errors';
+import SwapClient, { PaymentState } from './SwapClient';
 import SwapClientManager from './SwapClientManager';
 import SwapRecovery from './SwapRecovery';
 import SwapRepository from './SwapRepository';
@@ -53,6 +54,20 @@ class Swaps extends EventEmitter {
   private static readonly SWAP_ACCEPT_TIMEOUT = 10000;
   /** The maximum time in milliseconds we will wait for a swap to be completed before failing it. */
   private static readonly SWAP_COMPLETE_TIMEOUT = 35000;
+  /**
+   * Additional time that the maker will wait for a swap to be completed before considering it timed
+   * out. This exists because the maker starts timing sooner and ends timing later than the taker.
+   * The maker starts timing as soon as it sends its SwapAccepted packet, but taker starts upon
+   * receiving that packet some short time later. Furthermore, the taker stops the timer as soon as
+   * it reveals the preimage and settles its incoming payment, whereas the maker doesn't stop until
+   * it receives the preimage.
+   */
+  private static readonly SWAP_COMPLETE_MAKER_BUFFER = 5000;
+  /**
+   * The time threshold in milliseconds after which we consider a counterparty abusive if they
+   * settle payment for a timed out swap.
+   */
+  private static readonly SWAP_ABUSE_TIME_LIMIT = 60000;
   /** The maximum time in milliseconds we will wait to receive an expected sanity swap init packet. */
   private static readonly SANITY_SWAP_INIT_TIMEOUT = 3000;
   /** The maximum time in milliseconds we will wait for a swap to be completed before failing it. */
@@ -202,19 +217,7 @@ class Swaps extends EventEmitter {
     this.pool.on('packet.swapAccepted', this.handleSwapAccepted);
     this.pool.on('packet.swapFailed', this.handleSwapFailed);
 
-    this.swapClientManager.on('htlcAccepted', async (swapClient, rHash, amount, currency) => {
-      try {
-        const rPreimage = await this.resolveHash(rHash, amount, currency);
-        await swapClient.settleInvoice(rHash, rPreimage, currency);
-
-        const deal = this.getDeal(rHash);
-        if (deal) {
-          await this.setDealPhase(deal, SwapPhase.PaymentReceived);
-        }
-      } catch (err) {
-        this.logger.error('could not settle invoice', err);
-      }
-    });
+    this.swapClientManager.on('htlcAccepted', this.handleHtlcAccepted);
     this.swapClientManager.on('lndUpdate', this.pool.updateLndState);
     this.swapClientManager.on('raidenUpdate', this.pool.updateRaidenState);
     this.swapClientManager.on('connextUpdate', this.pool.updateConnextState);
@@ -455,8 +458,6 @@ class Swaps extends EventEmitter {
       createTime: Date.now(),
     };
 
-    this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, Swaps.SWAP_ACCEPT_TIMEOUT, rHash, SwapFailureReason.DealTimedOut));
-
     this.addDeal(deal);
 
     // Make sure we are connected to both swap clients
@@ -560,8 +561,6 @@ class Swaps extends EventEmitter {
       role: SwapRole.Maker,
       createTime: Date.now(),
     };
-
-    this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, Swaps.SWAP_COMPLETE_TIMEOUT, rHash, SwapFailureReason.SwapTimedOut));
 
     // add the deal. Going forward we can "record" errors related to this deal.
     this.addDeal(deal);
@@ -677,6 +676,52 @@ class Swaps extends EventEmitter {
     return true;
   }
 
+  private handleHtlcAccepted = async (swapClient: SwapClient, rHash: string, amount: number, currency: string) => {
+    let rPreimage: string;
+
+    const deal = this.getDeal(rHash);
+    if (deal?.state === SwapState.Error) {
+      // we double check here to ensure that we don't attempt to resolve a hash
+      // and/or send payment for a stale deal that has already failed but
+      // eventually gets an incoming htlc accepted
+      this.logger.warn(`htlc accepted for failed deal ${rHash}`);
+      return;
+    }
+
+    try {
+      rPreimage = await this.resolveHash(rHash, amount, currency);
+    } catch (err) {
+      this.logger.error(`could not resolve hash for deal ${rHash}`, err);
+      return;
+    }
+
+    if (!deal) {
+      // if there's no deal associated with this hash, we treat it as a sanity swap
+      // and attempt to settle our incoming payment
+      await swapClient.settleInvoice(rHash, rPreimage, currency).catch(this.logger.error);
+    } else if (deal.state === SwapState.Active) {
+      // we check that the deal is still active before we try to settle the invoice
+      // if the swap has already been failed, then we leave the swap recovery module
+      // to attempt to settle the invoice and claim funds rather than do it here
+      try {
+        await swapClient.settleInvoice(rHash, rPreimage, currency);
+      } catch (err) {
+        // if we couldn't settle the invoice then we fail the deal which throws
+        // it into recovery where we will try to settle our payment again
+        this.logger.error(`could not settle invoice for deal ${rHash}`, err);
+        await this.failDeal({
+          deal,
+          failureReason: SwapFailureReason.UnexpectedClientError,
+          errorMessage: err.message,
+        });
+        return;
+      }
+
+      // if we succeeded in settling our incoming payment we update the deal phase & state
+      await this.setDealPhase(deal, SwapPhase.PaymentReceived);
+    }
+  }
+
   /**
    * Handles a response from a peer to confirm a swap deal and updates the deal. If the deal is
    * accepted, initiates the swap.
@@ -707,7 +752,7 @@ class Swaps extends EventEmitter {
     // clear the timer waiting for acceptance of our swap offer, and set a new timer waiting for
     // the swap to be completed
     clearTimeout(this.timeouts.get(rHash));
-    this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, Swaps.SWAP_COMPLETE_TIMEOUT, rHash, SwapFailureReason.SwapTimedOut));
+    this.timeouts.delete(rHash);
 
     // update deal with maker's cltv delta
     deal.makerCltvDelta = makerCltvDelta;
@@ -961,42 +1006,60 @@ class Swaps extends EventEmitter {
 
       try {
         deal.rPreimage = await swapClient.sendPayment(deal);
-        return deal.rPreimage;
       } catch (err) {
-        // the payment failed but we are unsure of its final status, so we fail
-        // the deal and assign the payment to be checked in swap recovery.
-        // we don't remove our incoming invoice because we are not yet certain
-        // whether our outgoing payment can be claimed by the taker or not
-        switch (err.code) {
-          case errorCodes.FINAL_PAYMENT_ERROR:
-            await this.failDeal({
-              deal,
-              peer,
-              failedCurrency: deal.takerCurrency,
-              failureReason: SwapFailureReason.SendPaymentFailure,
-              errorMessage: err.message,
-            });
-            break;
-          case errorCodes.PAYMENT_REJECTED:
-            await this.failDeal({
-              deal,
-              failureReason: SwapFailureReason.PaymentRejected,
-              errorMessage: err.message,
-            });
-            break;
-          default:
-            await this.failDeal({
-              deal,
-              peer,
-              failedCurrency: deal.takerCurrency,
-              failureReason: SwapFailureReason.UnknownError,
-              errorMessage: err.message,
-            });
-            break;
-        }
+        this.logger.debug(`sendPayment in resolveHash failed due to ${err.message}`);
 
-        throw err;
+        const failDeal = async (paymentState: PaymentState) => {
+          switch (err.code) {
+            case errorCodes.FINAL_PAYMENT_ERROR:
+              await this.failDeal({
+                deal,
+                peer,
+                paymentState,
+                failedCurrency: deal.takerCurrency,
+                failureReason: SwapFailureReason.SendPaymentFailure,
+                errorMessage: err.message,
+              });
+              break;
+            case errorCodes.PAYMENT_REJECTED:
+              await this.failDeal({
+                deal,
+                paymentState,
+                failureReason: SwapFailureReason.PaymentRejected,
+                errorMessage: err.message,
+              });
+              break;
+            default:
+              await this.failDeal({
+                deal,
+                peer,
+                paymentState,
+                failedCurrency: deal.takerCurrency,
+                failureReason: SwapFailureReason.UnknownError,
+                errorMessage: err.message,
+              });
+              break;
+          }
+        };
+
+        // the payment failed but we first double check its final status, so we
+        // only fail the deal when we know our payment won't go through. otherwise
+        // we extract the preimage if the payment went through in spite of the error
+        // or we fail the deal and go to SwapRecovery if it's still pending
+        const paymentStatus = await swapClient.lookupPayment(rHash, deal.takerCurrency, deal.destination);
+        if (paymentStatus.state === PaymentState.Succeeded) {
+          deal.rPreimage = paymentStatus.preimage!;
+        } else {
+          await failDeal(paymentStatus.state);
+          throw err;
+        }
       }
+
+      // we update the deal phase but we don't wait for the updated deal to be persisted
+      // to the database because we don't want to delay claiming the incoming payment
+      // using the preimage we've just resolved
+      this.setDealPhase(deal, SwapPhase.PreimageResolved).catch(this.logger.error);
+      return deal.rPreimage;
     } else {
       // If we are here we are the taker
       assert(deal.rPreimage, 'preimage must be known if we are the taker');
@@ -1011,16 +1074,6 @@ class Swaps extends EventEmitter {
     const { amount, rHash } = resolveRequest;
 
     this.logger.debug(`handleResolveRequest starting with hash ${rHash}`);
-
-    // first check if we have recovered this deal from a previous swap attempt
-    const recoveredSwap = this.swapRecovery.recoveredPreimageSwaps.get(rHash);
-    if (recoveredSwap && recoveredSwap.rPreimage) {
-      recoveredSwap.state = SwapState.Recovered;
-      recoveredSwap.save().catch(this.logger.error);
-      this.swapRecovery.recoveredPreimageSwaps.delete(rHash);
-      this.logger.info(`handleResolveRequest returning recovered preimage ${recoveredSwap.rPreimage} for hash ${rHash}`);
-      return recoveredSwap.rPreimage;
-    }
 
     const deal = this.getDeal(rHash);
 
@@ -1047,7 +1100,7 @@ class Swaps extends EventEmitter {
       this.logger.debug(`handleResolveRequest returning preimage ${preimage} for hash ${rHash}`);
       return preimage;
     } catch (err) {
-      this.logger.error(err.message);
+      this.logger.error(`could not resolve hash for deal ${rHash}`, err);
       throw err;
     }
   }
@@ -1056,17 +1109,38 @@ class Swaps extends EventEmitter {
     const deal = this.getDeal(rHash)!;
     const peer = this.pool.tryGetPeer(deal.peerPubKey);
 
-    await this.failDeal({
-      deal,
-      peer,
-      failureReason: reason,
-    });
+    if (deal.role === SwapRole.Taker || deal.phase === SwapPhase.SwapAccepted || deal.phase === SwapPhase.SwapRequested) {
+      // if we are the taker, we control the preimage and can decisively fail the deal and swap
+      // also, if we haven't yet started sending payment then we can simply call off the deal
+      await this.failDeal({
+        deal,
+        peer,
+        failureReason: reason,
+      });
+    } else {
+      // if we are the maker, and we've begun sending payment, then the fate of this swap is up to
+      // the taker and we can't consider it failed until the taker cancels its incoming htlc/payment
+      // we do, however, want to ensure that the taker doesn't complete a swap that should have timed
+      // out, as this indicates dishonest behavior and possible exploitation of a free option
+
+      this.logger.verbose(`swap with hash ${rHash} has timed out during payments and should be failed by the counterparty`);
+      if (peer) {
+        // we tell the peer (taker) that this deal should be failed, in case they're using longer
+        // timeouts than we are and won't fail it on their own
+        await this.sendErrorToPeer({
+          peer,
+          rHash,
+          failureReason: reason,
+        });
+      }
+      this.timeouts.delete(rHash);
+    }
   }
 
   /**
    * Fails a deal and optionally sends a SwapFailurePacket to a peer, if provided.
    */
-  private failDeal = async ({ deal, failureReason, failedCurrency, errorMessage, peer, reqId }:
+  private failDeal = async ({ deal, failureReason, failedCurrency, errorMessage, peer, reqId, paymentState }:
     {
       deal: SwapDeal,
       failureReason: SwapFailureReason,
@@ -1078,6 +1152,8 @@ class Swaps extends EventEmitter {
       peer?: Peer,
       /** An optional reqId in case the SwapFailedPacket is in response to a swap request. */
       reqId?: string,
+      /** The state of the outgoing payment involved with this swap. */
+      paymentState?: PaymentState,
     }) => {
     assert(deal.state !== SwapState.Completed, 'Can not fail a completed deal.');
 
@@ -1155,8 +1231,10 @@ class Swaps extends EventEmitter {
         // then we should cancel the invoice for our incoming payment if one exists
         const swapClient = this.swapClientManager.get(deal.makerCurrency)!;
         swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
-      } else if (deal.phase === SwapPhase.SendingPayment && deal.role === SwapRole.Maker) {
+      } else if ((paymentState === undefined || paymentState === PaymentState.Pending) &&
+        (deal.phase === SwapPhase.SendingPayment || deal.phase === SwapPhase.PreimageResolved)) {
         // if the swap fails while we are in the middle of sending payment as the maker
+        // and we haven't confirmed that our outgoing payment is no longer pending
         // we need to make sure that the taker doesn't claim our payment without us having a chance
         // to claim ours. we will send this swap to recovery to monitor its outcome
         const swapDealInstance = await this.repository.getSwapDeal(deal.rHash);
@@ -1183,7 +1261,31 @@ class Swaps extends EventEmitter {
    * including persisting the deal state to the database.
    */
   private setDealPhase = async (deal: SwapDeal, newPhase: SwapPhase) => {
-    assert(deal.state === SwapState.Active, `deal ${deal.rHash} is not Active. Can not change deal phase`);
+    const { rHash } = deal;
+    assert(deal.state === SwapState.Active, `deal ${rHash} is not Active. Can not change deal phase`);
+
+    const succeedSwap = (wasMaker: boolean) => {
+      // the maker will have cleared the timer in the PreimageResolved phase
+      clearTimeout(this.timeouts.get(deal.rHash));
+      this.timeouts.delete(deal.rHash);
+
+      const swapSuccess = {
+        orderId: deal.orderId,
+        localId: deal.localId,
+        pairId: deal.pairId,
+        quantity: deal.quantity!,
+        amountReceived: wasMaker ? deal.makerAmount : deal.takerAmount,
+        amountSent: wasMaker ? deal.takerAmount : deal.makerAmount,
+        currencyReceived: wasMaker ? deal.makerCurrency : deal.takerCurrency,
+        currencySent: wasMaker ? deal.takerCurrency : deal.makerCurrency,
+        rHash: deal.rHash,
+        rPreimage: deal.rPreimage,
+        price: deal.price,
+        peerPubKey: deal.peerPubKey,
+        role: deal.role,
+      };
+      this.emit('swap.paid', swapSuccess);
+    };
 
     switch (newPhase) {
       case SwapPhase.SwapCreated:
@@ -1192,45 +1294,70 @@ class Swaps extends EventEmitter {
       case SwapPhase.SwapRequested:
         assert(deal.role === SwapRole.Taker, 'SwapRequested can only be set by the taker');
         assert(deal.phase === SwapPhase.SwapCreated, 'SwapRequested can be only be set after SwapCreated');
+        this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, Swaps.SWAP_ACCEPT_TIMEOUT, rHash, SwapFailureReason.DealTimedOut));
         this.logger.debug(`Requesting deal: ${JSON.stringify(deal)}`);
         break;
       case SwapPhase.SwapAccepted:
         assert(deal.role === SwapRole.Maker, 'SwapAccepted can only be set by the maker');
         assert(deal.phase === SwapPhase.SwapCreated, 'SwapAccepted can be only be set after SwapCreated');
-        this.logger.debug(`Setting SwapAccepted phase for deal ${deal.rHash}`);
+
+        if (deal.role === SwapRole.Maker) {
+          // the maker begins execution of the swap upon accepting the deal
+          this.timeouts.set(rHash, setTimeout(
+            this.handleSwapTimeout,
+            Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_COMPLETE_MAKER_BUFFER,
+            rHash,
+            SwapFailureReason.SwapTimedOut,
+          ));
+        }
+        this.logger.debug(`Setting SwapAccepted phase for deal ${rHash}`);
         break;
       case SwapPhase.SendingPayment:
         assert(deal.role === SwapRole.Taker && deal.phase === SwapPhase.SwapRequested ||
           deal.role === SwapRole.Maker && deal.phase === SwapPhase.SwapAccepted,
             'SendingPayment can only be set after SwapRequested (taker) or SwapAccepted (maker)');
-        deal.executeTime = Date.now();
-        this.logger.debug(`Setting SendingPayment phase for deal ${deal.rHash}`);
+
+        if (deal.role === SwapRole.Taker) {
+          // the taker begins execution of the swap upon sending payment
+          deal.executeTime = Date.now();
+          this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, Swaps.SWAP_COMPLETE_TIMEOUT, rHash, SwapFailureReason.SwapTimedOut));
+        }
+
+        this.logger.debug(`Setting SendingPayment phase for deal ${rHash}`);
+        break;
+      case SwapPhase.PreimageResolved:
+        assert(deal.role === SwapRole.Maker, 'PreimageResolved can only be set by the maker');
+        assert(deal.phase === SwapPhase.SendingPayment, 'PreimageResolved can only be set after SendingPayment');
+
+        // we treat the swap as having succeeded once we have resolved the preimage as the maker
+        succeedSwap(true);
+
+        /** The number of milliseconds elapsed since we started execting this swap. */
+        const elapsedMilliseconds = Date.now() - deal.executeTime!;
+
+        // we check that the taker did not release the preimage after the swap has timed out
+        // if so, they are misbehaving by completing a swap too late and possibly exploiting
+        // us with the free option problem
+        if (elapsedMilliseconds > Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_ABUSE_TIME_LIMIT) {
+          this.logger.warn(`taker accepted payment for ${rHash} after ${elapsedMilliseconds} ms, exceeding abuse threshold of ${Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_COMPLETE_MAKER_BUFFER} ms`);
+          // TODO: ban peer
+        } else if (elapsedMilliseconds > Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_COMPLETE_MAKER_BUFFER) {
+          this.logger.warn(`taker accepted payment for ${rHash} after ${elapsedMilliseconds} ms, exceeding swap timeout of ${Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_COMPLETE_MAKER_BUFFER} ms`);
+          // TODO: penalize peer
+        }
+
+        this.logger.debug(`Setting PreimageResolved phase for deal ${rHash}`);
         break;
       case SwapPhase.PaymentReceived:
-        assert(deal.phase === SwapPhase.SendingPayment, 'PaymentReceived can be only be set after SendingPayment');
+        assert(deal.phase === SwapPhase.SendingPayment || deal.phase === SwapPhase.PreimageResolved,
+          'PaymentReceived can be only be set after SendingPayment or PreimageResolved');
         deal.completeTime = Date.now();
         deal.state = SwapState.Completed;
 
-        clearTimeout(this.timeouts.get(deal.rHash));
-        this.timeouts.delete(deal.rHash);
-
-        const wasMaker = deal.role === SwapRole.Maker;
-        const swapSuccess = {
-          orderId: deal.orderId,
-          localId: deal.localId,
-          pairId: deal.pairId,
-          quantity: deal.quantity!,
-          amountReceived: wasMaker ? deal.makerAmount : deal.takerAmount,
-          amountSent: wasMaker ? deal.takerAmount : deal.makerAmount,
-          currencyReceived: wasMaker ? deal.makerCurrency : deal.takerCurrency,
-          currencySent: wasMaker ? deal.takerCurrency : deal.makerCurrency,
-          rHash: deal.rHash,
-          rPreimage: deal.rPreimage,
-          price: deal.price,
-          peerPubKey: deal.peerPubKey,
-          role: deal.role,
-        };
-        this.emit('swap.paid', swapSuccess);
+        if (deal.role === SwapRole.Taker) {
+          // we mark the swap as succeeded upon receiving payment when we are the taker
+          succeedSwap(false);
+        }
 
         this.logger.debug(`Setting PaymentReceived phase for deal ${deal.rHash} - preimage is ${deal.rPreimage}`);
         break;
@@ -1250,6 +1377,7 @@ class Swaps extends EventEmitter {
   private handleSwapFailed = async (packet: packets.SwapFailedPacket) => {
     const { rHash, errorMessage, failureReason } = packet.body!;
     const deal = this.getDeal(rHash);
+
     // TODO: penalize for unexpected swap failed packets
     if (!deal) {
       const dealInstance = await this.repository.getSwapDeal(rHash);
@@ -1267,6 +1395,10 @@ class Swaps extends EventEmitter {
       } else {
         this.logger.warn(`received swap failed packet for unknown deal with payment hash ${rHash}`);
       }
+      return;
+    } else if (deal.phase === SwapPhase.PreimageResolved || deal.phase === SwapPhase.PaymentReceived) {
+      // we don't want to fail a deal if any one of its payments is already completed
+      this.logger.warn(`received swap failed packet for deal in phase ${SwapPhase[deal.phase]} with payment hash ${rHash}`);
       return;
     }
 

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -709,6 +709,7 @@ class Swaps extends EventEmitter {
         // if we couldn't settle the invoice then we fail the deal which throws
         // it into recovery where we will try to settle our payment again
         this.logger.error(`could not settle invoice for deal ${rHash}`, err);
+        this.logger.alert(`incoming ${currency} payment with hash ${rHash} could not be settled with preimage ${rPreimage}, this is not expected and funds may be at risk`);
         await this.failDeal({
           deal,
           failureReason: SwapFailureReason.UnexpectedClientError,

--- a/lib/swaps/types.ts
+++ b/lib/swaps/types.ts
@@ -62,7 +62,7 @@ export type SwapDeal = {
   destination?: string;
   /** The time when we created this swap deal locally. */
   createTime: number;
-  /** The time when we began executing the swap by sending payment. */
+  /** The time when we began executing the swap for an accepted deal. */
   executeTime?: number;
   /** The time when the swap either completed successfully or failed. */
   completeTime?: number;

--- a/test/integration/Swaps.spec.ts
+++ b/test/integration/Swaps.spec.ts
@@ -1,15 +1,15 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon, { SinonSandbox } from 'sinon';
-import Pool from '../../lib/p2p/Pool';
-import Peer from '../../lib/p2p/Peer';
-import Swaps from '../../lib/swaps/Swaps';
-import SwapClientManager from '../../lib/swaps/SwapClientManager';
-import Logger, { Level } from '../../lib/Logger';
-import DB from '../../lib/db/DB';
-import { waitForSpy } from '../utils';
 import { SwapFailureReason } from '../../lib/constants/enums';
+import DB from '../../lib/db/DB';
+import Logger, { Level } from '../../lib/Logger';
+import Peer from '../../lib/p2p/Peer';
+import Pool from '../../lib/p2p/Pool';
 import SwapClient from '../../lib/swaps/SwapClient';
+import SwapClientManager from '../../lib/swaps/SwapClientManager';
+import Swaps from '../../lib/swaps/Swaps';
+import { getValidDeal, waitForSpy } from '../utils';
 
 chai.use(chaiAsPromised);
 
@@ -55,35 +55,6 @@ const validSwapSuccess = () => {
     price: 0.008,
     peerPubKey: '020c9a0fb8dac5b91756fb21509aefc4e95b585510c4de6e6311f18348a4723cdd',
     role: 0,
-  };
-};
-
-const validSwapDeal = () => {
-  return {
-    takerCltvDelta: 144,
-    rHash: '29bcb9097a6afe26826100919917c9044062cba1d4f6ac694029f6b8af2041c7',
-    orderId: '20998481-e689-11e8-95ee-e3e71c57fbb3',
-    pairId: 'LTC/BTC',
-    proposedQuantity: 1000,
-    takerCurrency: 'BTC',
-    makerCurrency: 'LTC',
-    takerAmount: 8,
-    makerAmount: 1000,
-    takerUnits: 8,
-    makerUnits: 1000,
-    peerPubKey: '030130758847ada485520016a075833b8638c7e5a56889cb4b76e10c0f61f3520c',
-    localId: '20b63440-e689-11e8-aa83-51505ebd3ca7',
-    price: 0.008,
-    isBuy: true,
-    phase: 3,
-    state: 1,
-    rPreimage: 'eab3fe55ce502b702bca13cbb9f1e4239502911d4c8823b73708c4a4433ed87a',
-    role: 0,
-    createTime: 1542033726862,
-    makerCltvDelta: 1152,
-    quantity: 1000,
-    executeTime: 1542033726871,
-    errorMessage: 'UnknownPaymentHash',
   };
 };
 
@@ -169,7 +140,7 @@ describe('Swaps.Integration', () => {
       const swapListenersAdded = sandbox.spy(swaps, 'on');
       const addDealSpy = sandbox.spy(swaps, 'addDeal');
       const swapListenersRemoved = sandbox.spy(swaps, 'removeListener');
-      const swapDeal = validSwapDeal();
+      const swapDeal = getValidDeal();
       expect(swaps.executeSwap(validMakerOrder(), validTakerOrder()))
         .to.eventually.be.rejected;
       await waitForSpy(swapListenersAdded);
@@ -219,7 +190,5 @@ describe('Swaps.Integration', () => {
       expect(swaps.executeSwap(validMakerOrder(), validTakerOrder()))
         .to.eventually.be.rejected.and.equal(SwapFailureReason.UnexpectedClientError);
     });
-
   });
-
 });

--- a/test/jest/SwapRecovery.spec.ts
+++ b/test/jest/SwapRecovery.spec.ts
@@ -131,14 +131,46 @@ describe('SwapRecovery', () => {
     swapRecovery = new SwapRecovery(swapClientManager, logger);
     const preimage = 'preimage';
     lndLtc.lookupPayment = jest.fn().mockReturnValue({ preimage, state: PaymentState.Succeeded });
+    const claimPaymentSpy = jest.spyOn(swapRecovery as any, 'claimPayment');
+    const recoveredEventCallback = jest.fn();
+    swapRecovery.on('recovered', recoveredEventCallback);
 
     await swapRecovery.recoverDeal(deal);
+    expect(claimPaymentSpy).toHaveBeenCalledTimes(1);
+    expect(recoveredEventCallback).toHaveBeenCalledTimes(1);
+    expect(recoveredEventCallback).toHaveBeenCalledWith(deal);
     expect(lndLtc.lookupPayment).toHaveBeenCalledTimes(1);
     expect(lndLtc.lookupPayment).toHaveBeenCalledWith(deal.rHash, deal.takerCurrency);
     expect(lndBtc.settleInvoice).toHaveBeenCalledTimes(1);
     expect(lndBtc.settleInvoice).toHaveBeenCalledWith(deal.rHash, preimage, deal.makerCurrency);
     expect(deal.state).toEqual(SwapState.Recovered);
-    expect(save).toHaveBeenCalledTimes(1);
+    expect(deal.rPreimage).toEqual(preimage);
+    expect(swapRecovery['pendingSwaps'].has(deal.rHash)).toBeFalsy();
+    // should save once after we retrieve preimage, once after we settle incoming payment
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  test('it completes a successful payment when we had resolved preimage as maker but not claimed payment', async () => {
+    const deal: any = { ...swapDealInstance };
+    deal.phase = SwapPhase.PreimageResolved;
+    swapRecovery = new SwapRecovery(swapClientManager, logger);
+    const preimage = 'preimage';
+    lndLtc.lookupPayment = jest.fn().mockReturnValue({ preimage, state: PaymentState.Succeeded });
+    const claimPaymentSpy = jest.spyOn(swapRecovery as any, 'claimPayment');
+    const recoveredEventCallback = jest.fn();
+    swapRecovery.on('recovered', recoveredEventCallback);
+
+    await swapRecovery.recoverDeal(deal);
+    expect(claimPaymentSpy).toHaveBeenCalledTimes(1);
+    expect(recoveredEventCallback).toHaveBeenCalledTimes(1);
+    expect(recoveredEventCallback).toHaveBeenCalledWith(deal);
+    expect(lndBtc.settleInvoice).toHaveBeenCalledTimes(1);
+    expect(lndBtc.settleInvoice).toHaveBeenCalledWith(deal.rHash, preimage, deal.makerCurrency);
+    expect(deal.state).toEqual(SwapState.Recovered);
+    expect(deal.rPreimage).toEqual(preimage);
+    expect(swapRecovery['pendingSwaps'].has(deal.rHash)).toBeFalsy();
+    // should save once after we retrieve preimage, once after we settle incoming payment
+    expect(save).toHaveBeenCalledTimes(2);
   });
 
   test('it fails a failed payment when we were sending payment as maker', async () => {

--- a/test/jest/Swaps.spec.ts
+++ b/test/jest/Swaps.spec.ts
@@ -1,5 +1,5 @@
-import Swaps from '../../lib/swaps/Swaps';
 import LndClient from '../../lib/lndclient/LndClient';
+import Swaps from '../../lib/swaps/Swaps';
 
 describe('Swaps', () => {
   describe('calculateLockBuffer', () => {

--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -15,10 +15,10 @@ index 08402caa8..c9972d258 100644
        if (!this.config.rpc.disable) {
          // start rpc server first, it will respond with UNAVAILABLE error
 diff --git a/lib/swaps/SwapRecovery.ts b/lib/swaps/SwapRecovery.ts
-index dc868b894..a9b98f814 100644
+index 090618c4b..cd33a5d58 100644
 --- a/lib/swaps/SwapRecovery.ts
 +++ b/lib/swaps/SwapRecovery.ts
-@@ -21,7 +21,15 @@ class SwapRecovery {
+@@ -28,7 +28,15 @@ class SwapRecovery extends EventEmitter {
  
    public beginTimer = () => {
      if (!this.pendingSwapsTimer) {
@@ -36,20 +36,17 @@ index dc868b894..a9b98f814 100644
    }
  
 diff --git a/lib/swaps/Swaps.ts b/lib/swaps/Swaps.ts
-index 1002dbb57..f7a88019c 100644
+index d236d8931..d6a8ed2a9 100644
 --- a/lib/swaps/Swaps.ts
 +++ b/lib/swaps/Swaps.ts
-@@ -205,9 +205,28 @@ class Swaps extends EventEmitter {
-     this.swapClientManager.on('htlcAccepted', async (swapClient, rHash, amount, currency) => {
+@@ -710,6 +710,24 @@ class Swaps extends EventEmitter {
+       // if the swap has already been failed, then we leave the swap recovery module
+       // to attempt to settle the invoice and claim funds rather than do it here
        try {
-         const rPreimage = await this.resolveHash(rHash, amount, currency);
--        await swapClient.settleInvoice(rHash, rPreimage, currency);
 +        if (rPreimage === '') {
 +          this.logger.info('NOT SETTLING INVOICE');
 +          return;
 +        }
- 
-         const deal = this.getDeal(rHash);
 +
 +        if (deal && deal.role === SwapRole.Taker && process.env.CUSTOM_SCENARIO === 'INSTABILITY::TAKER_DELAY_BEFORE_SETTLE') {
 +          this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
@@ -64,26 +61,10 @@ index 1002dbb57..f7a88019c 100644
 +        }
 +
 +        this.logger.info('SETTLING INVOICE');
-+        await swapClient.settleInvoice(rHash, rPreimage, currency);
-+
-         if (deal) {
-           await this.setDealPhase(deal, SwapPhase.PaymentReceived);
-         }
-@@ -546,7 +565,12 @@ class Swaps extends EventEmitter {
-       createTime: Date.now(),
-     };
- 
--    this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, Swaps.SWAP_COMPLETE_TIMEOUT, rHash, SwapFailureReason.SwapTimedOut));
-+    let interval = Swaps.SWAP_COMPLETE_TIMEOUT;
-+    if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_LND_CRASHED_BEFORE_SETTLE') {
-+      interval = 5000;
-+    }
-+
-+    this.timeouts.set(rHash, setTimeout(this.handleSwapTimeout, interval, rHash, SwapFailureReason.SwapTimedOut));
- 
-     // add the deal. Going forward we can "record" errors related to this deal.
-     this.addDeal(deal);
-@@ -679,6 +703,16 @@ class Swaps extends EventEmitter {
+         await swapClient.settleInvoice(rHash, rPreimage, currency);
+       } catch (err) {
+         // if we couldn't settle the invoice then we fail the deal which throws
+@@ -734,6 +752,16 @@ class Swaps extends EventEmitter {
     * accepted, initiates the swap.
     */
    private handleSwapAccepted = async (responsePacket: packets.SwapAcceptedPacket, peer: Peer) => {
@@ -100,7 +81,7 @@ index 1002dbb57..f7a88019c 100644
      assert(responsePacket.body, 'SwapAcceptedPacket does not contain a body');
      const { quantity, rHash, makerCltvDelta } = responsePacket.body;
      const deal = this.getDeal(rHash);
-@@ -758,6 +792,11 @@ class Swaps extends EventEmitter {
+@@ -821,6 +849,11 @@ class Swaps extends EventEmitter {
  
      try {
        await makerSwapClient.sendPayment(deal);
@@ -112,7 +93,7 @@ index 1002dbb57..f7a88019c 100644
      } catch (err) {
        // first we must handle the edge case where the maker has paid us but failed to claim our payment
        // in this case, we've already marked the swap as having been paid and completed
-@@ -939,6 +978,18 @@ class Swaps extends EventEmitter {
+@@ -1002,6 +1035,18 @@ class Swaps extends EventEmitter {
  
        this.logger.debug('Executing maker code to resolve hash');
  
@@ -131,7 +112,7 @@ index 1002dbb57..f7a88019c 100644
        const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
  
        // we update the phase persist the deal to the database before we attempt to send payment
-@@ -949,6 +1000,13 @@ class Swaps extends EventEmitter {
+@@ -1012,6 +1057,13 @@ class Swaps extends EventEmitter {
        assert(deal.state !== SwapState.Error, `cannot send payment for failed swap ${deal.rHash}`);
  
        try {
@@ -143,9 +124,9 @@ index 1002dbb57..f7a88019c 100644
 +        }
 +
          deal.rPreimage = await swapClient.sendPayment(deal);
-         return deal.rPreimage;
        } catch (err) {
-@@ -992,6 +1050,16 @@ class Swaps extends EventEmitter {
+         this.logger.debug(`sendPayment in resolveHash failed due to ${err.message}`);
+@@ -1073,6 +1125,16 @@ class Swaps extends EventEmitter {
        assert(htlcCurrency === undefined || htlcCurrency === deal.takerCurrency, 'incoming htlc does not match expected deal currency');
        this.logger.debug('Executing taker code to resolve hash');
  
@@ -162,3 +143,19 @@ index 1002dbb57..f7a88019c 100644
        return deal.rPreimage;
      }
    }
+@@ -1310,9 +1372,14 @@ class Swaps extends EventEmitter {
+ 
+         if (deal.role === SwapRole.Maker) {
+           // the maker begins execution of the swap upon accepting the deal
++
++          let interval = Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_COMPLETE_MAKER_BUFFER;
++          if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_LND_CRASHED_BEFORE_SETTLE') {
++            interval = 5000;
++          }
+           this.timeouts.set(rHash, setTimeout(
+             this.handleSwapTimeout,
+-            Swaps.SWAP_COMPLETE_TIMEOUT + Swaps.SWAP_COMPLETE_MAKER_BUFFER,
++            interval,
+             rHash,
+             SwapFailureReason.SwapTimedOut,
+           ));

--- a/test/simulation/docker-run.sh
+++ b/test/simulation/docker-run.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+# we create the temp directory with the current user so it is the owner for permissions 
+mkdir -p $PWD/temp/logs
 docker-compose run -v $PWD/temp/logs:/app/temp/logs test go test -v -timeout 20m -run=$@

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import { ms } from '../lib/utils/utils';
 import { PeerOrder, OwnOrder } from '../lib/orderbook/types';
+import { SwapPhase } from '../lib/constants/enums';
 
 /**
  * Discovers and returns a dynamically assigned, unused port available for testing.
@@ -90,7 +91,7 @@ export const createPeerOrder = (
   id: uuidv1(),
 });
 
-export const getValidDeal = () => {
+export const getValidDeal = (phase?: SwapPhase) => {
   return {
     proposedQuantity: 10000,
     pairId: 'LTC/BTC',
@@ -111,7 +112,7 @@ export const getValidDeal = () => {
     destination: '034c5266591bff232d1647f45bcf6bbc548d3d6f70b2992d28aba0afae067880ac',
     peerPubKey: '021ea6d67c850a0811b01c78c8117dca044b224601791a4186bf5748f667f73517',
     localId: '53bc8a30-81f0-11e9-9259-a5617f44d209',
-    phase: 3,
+    phase: phase ?? 3,
     state: 0,
     role: 1,
     createTime: 1559120485138,


### PR DESCRIPTION
This creates a new phase for SwapDeals called `PreimageResolved` that represents the part after the maker has completed its payment to taker and resolved the preimage, but before it has settled its incoming payment using the preimage.

Swaps that have reached this phase are considered atomic - our outgoing payment has been settle and we've acquired the ability to settle our incoming payment - even if they're not complete. Therefore, the maker ends the swap timeout and gives the call to settle the incoming payment as long as it needs to complete while keeping the hold on the order to prevent it from being filled a second time.

Should a swap fail the `settleInvoice` call, it enters swap SwapRecovery where settling the payment will be attempted one more time but only after ensuring we are connected to the SwapClient responsible for that payment. Previously, deals that hit an error upon the `settleInvoice` would not fail the deal and send it to recovery until the timeout was reached.

We persist the preimage to the database immediately upon reaching the `PreimageResolved` phase and then use that preimage in SwapRecovery if it is available, rather than querying the swap client for the outgoing payment to lookup the preimage again.

It also introduces a new level of alert logging, with greater severity than the error level, to be used only for warning a user when loss of funds is possible and cannot be handled automatically by xud due to unexpected errors or conditions.

Resolves #1654. Resolves #1659.

