### PR TITLE
feat(backup): stop backup on sigterm

### DIFF
--- a/bin/xud-backup
+++ b/bin/xud-backup
@@ -77,3 +77,8 @@ delete argv.$0;
 const backup = new Backup();
 
 backup.start(argv);
+
+process.on('SIGTERM', () => {
+  backup.stop();
+  console.info('SIGTERM signal received.');
+});


### PR DESCRIPTION
We weren't using the `stop` method in Backup anywhere, so this PR calls it upon sigterm. This is related to #1697 although I haven't tested this with docker yet and I wasn't able to reproduce the original issue outside of docker.