### PR TITLE
fix(swaps): cancel taker invoice on swap fail

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1247,6 +1247,9 @@ class Swaps extends EventEmitter {
         const swapDealInstance = await this.repository.getSwapDeal(deal.rHash);
         await this.swapRecovery.recoverDeal(swapDealInstance!);
       }
+    } else if (deal.phase === SwapPhase.SendingPayment) {
+      const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
+      swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
     }
 
     this.logger.trace(`emitting swap.failed event for ${deal.rHash}`);

--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -36,7 +36,7 @@ index 090618c4b..cd33a5d58 100644
    }
  
 diff --git a/lib/swaps/Swaps.ts b/lib/swaps/Swaps.ts
-index d236d8931..d6a8ed2a9 100644
+index 7fd02cbb8..2bc60fe51 100644
 --- a/lib/swaps/Swaps.ts
 +++ b/lib/swaps/Swaps.ts
 @@ -710,6 +710,24 @@ class Swaps extends EventEmitter {
@@ -143,7 +143,21 @@ index d236d8931..d6a8ed2a9 100644
        return deal.rPreimage;
      }
    }
-@@ -1310,9 +1372,14 @@ class Swaps extends EventEmitter {
+@@ -1248,8 +1310,11 @@ class Swaps extends EventEmitter {
+         await this.swapRecovery.recoverDeal(swapDealInstance!);
+       }
+     } else if (deal.phase === SwapPhase.SendingPayment) {
+-      const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
+-      swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
++      // don't cancel any invoices if the taker is stalling
++      if (process.env.CUSTOM_SCENARIO !== 'SECURITY::TAKER_2ND_HTLC_STALL') {
++        const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
++        swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
++      }
+     }
+ 
+     this.logger.trace(`emitting swap.failed event for ${deal.rHash}`);
+@@ -1313,9 +1378,14 @@ class Swaps extends EventEmitter {
  
          if (deal.role === SwapRole.Maker) {
            // the maker begins execution of the swap upon accepting the deal

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,12 +1,12 @@
+import fs from 'fs';
 import net from 'net';
-import { SinonSpy } from 'sinon';
-import uuidv1 from 'uuid';
 import os from 'os';
 import path from 'path';
-import fs from 'fs';
+import { SinonSpy } from 'sinon';
+import uuidv1 from 'uuid';
+import { SwapPhase, SwapRole, SwapState } from '../lib/constants/enums';
+import { OwnOrder, PeerOrder } from '../lib/orderbook/types';
 import { ms } from '../lib/utils/utils';
-import { PeerOrder, OwnOrder } from '../lib/orderbook/types';
-import { SwapPhase } from '../lib/constants/enums';
 
 /**
  * Discovers and returns a dynamically assigned, unused port available for testing.
@@ -91,8 +91,10 @@ export const createPeerOrder = (
   id: uuidv1(),
 });
 
-export const getValidDeal = (phase?: SwapPhase) => {
+export const getValidDeal = (phase = SwapPhase.SendingPayment, role = SwapRole.Maker) => {
   return {
+    phase,
+    role,
     proposedQuantity: 10000,
     pairId: 'LTC/BTC',
     orderId: '53bc8a30-81f0-11e9-9259-a5617f44d209',
@@ -112,9 +114,7 @@ export const getValidDeal = (phase?: SwapPhase) => {
     destination: '034c5266591bff232d1647f45bcf6bbc548d3d6f70b2992d28aba0afae067880ac',
     peerPubKey: '021ea6d67c850a0811b01c78c8117dca044b224601791a4186bf5748f667f73517',
     localId: '53bc8a30-81f0-11e9-9259-a5617f44d209',
-    phase: phase ?? 3,
-    state: 0,
-    role: 1,
+    state: SwapState.Active,
     createTime: 1559120485138,
     takerMaxTimeLock: 100,
   };


### PR DESCRIPTION
This commit ensures that the taker cancels its incoming invoice when it fails while attempting to send payment.

Fixes #1695