### PR TITLE
fix(swaps): lookupPayment return Pending on error

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -430,9 +430,9 @@ class ConnextClient extends SwapClient {
         default:
           return { state: PaymentState.Pending };
       }
-    } catch (e) {
-      this.logger.error(e);
-      throw errors.SERVER_ERROR;
+    } catch (err) {
+      this.logger.error(`could not lookup payment for ${rHash}`, err);
+      return { state: PaymentState.Pending }; // return pending if we hit an error
     }
   }
 

--- a/lib/connextclient/errors.ts
+++ b/lib/connextclient/errors.ts
@@ -40,14 +40,14 @@ const errors = {
     message: 'request timed out',
     code: errorCodes.TIMEOUT,
   },
-  SERVER_ERROR: {
-    message: 'connext server error',
+  SERVER_ERROR: (statusCode: number, statusMessage?: string) => ({
+    message: `connext server error ${statusCode}: ${statusMessage ?? ''}`,
     code: errorCodes.SERVER_ERROR,
-  },
-  UNEXPECTED: {
-    message: 'unexpected error during connext request',
+  }),
+  UNEXPECTED: (statusCode: number, statusMessage?: string) => ({
+    message: `unexpected status from connext request ${statusCode}: ${statusMessage ?? ''}`,
     code: errorCodes.UNEXPECTED,
-  },
+  }),
   TOKEN_ADDRESS_NOT_FOUND: {
     message: 'connext token address not found',
     code: errorCodes.TOKEN_ADDRESS_NOT_FOUND,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,4 @@
+export type XudError = {
+  message: string,
+  code: string,
+};


### PR DESCRIPTION
This catches any errors within the `lookupPayment` swap client method and returns a "pending" status - since we weren't able to determine a resolution for the payment - rather than throwing an error. The error was not being handled in the Swaps module.

I believe this fixes #1701, however I wasn't able to reproduce the crash from that issue. @erkarl If you are able to reproduce could you try the same steps on this branch?