### PR TITLE
fix(p2p): allow connections with alias conflict 

### DIFF
--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -79,8 +79,19 @@ class NodeList extends EventEmitter {
     return this.nodes.get(nodePubKey)?.id;
   }
 
+  public get = (nodePubKey: string) => {
+    return this.nodes.get(nodePubKey);
+  }
+
   public getPubKeyForAlias = (alias: string) => {
-    return this.aliasToPubKeyMap.get(alias);
+    const nodePubKey = this.aliasToPubKeyMap.get(alias);
+    if (!nodePubKey) {
+      throw errors.UNKNOWN_ALIAS(alias);
+    }
+    if (nodePubKey === 'CONFLICT') {
+      throw errors.ALIAS_CONFLICT(alias);
+    }
+    return nodePubKey;
   }
 
   /**
@@ -88,7 +99,7 @@ class NodeList extends EventEmitter {
    * @returns true if the node was banned, false otherwise
    */
   public ban = async (nodePubKey: string): Promise<boolean> => {
-    return this.addReputationEvent(nodePubKey, ReputationEvent.ManualBan);
+    return await this.addReputationEvent(nodePubKey, ReputationEvent.ManualBan);
   }
 
   /**
@@ -96,7 +107,7 @@ class NodeList extends EventEmitter {
    * @returns true if ban was removed, false otherwise
    */
   public unBan = async (nodePubKey: string): Promise<boolean> => {
-    return this.addReputationEvent(nodePubKey, ReputationEvent.ManualUnban);
+    return await this.addReputationEvent(nodePubKey, ReputationEvent.ManualUnban);
   }
 
   public isBanned = (nodePubKey: string): boolean => {
@@ -251,13 +262,14 @@ class NodeList extends EventEmitter {
     const { nodePubKey } = node;
     const alias = pubKeyToAlias(nodePubKey);
     if (this.aliasToPubKeyMap.has(alias)) {
-      throw errors.ALIAS_CONFLICT(alias);
+      this.aliasToPubKeyMap.set(alias, 'CONFLICT');
+    } else {
+      this.aliasToPubKeyMap.set(alias, nodePubKey);
     }
 
     this.nodes.set(nodePubKey, node);
     this.nodeIdMap.set(node.id, node);
     this.pubKeyToAliasMap.set(nodePubKey, alias);
-    this.aliasToPubKeyMap.set(alias, nodePubKey);
   }
 }
 

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -412,7 +412,7 @@ class Pool extends EventEmitter {
    * @return true if the specified node exists and the event was added, false otherwise
    */
   public getNodeReputation = async (nodePubKey: string): Promise<NodeReputationInfo> => {
-    const node = await this.repository.getNode(nodePubKey);
+    const node = this.nodes.get(nodePubKey);
     if (node) {
       const { reputationScore, banned } = node;
       return {
@@ -645,7 +645,7 @@ class Pool extends EventEmitter {
         throw errors.NODE_UNKNOWN(nodePubKey);
       }
 
-      const node = await this.repository.getNode(nodePubKey);
+      const node = this.nodes.get(nodePubKey);
       if (node) {
         const Node: NodeConnectionInfo = {
           nodePubKey,
@@ -1030,11 +1030,7 @@ class Pool extends EventEmitter {
    * pub key cannot be found for the provided alias.
    */
   public resolveAlias = (alias: string) => {
-    const nodePubKey = this.nodes.getPubKeyForAlias(alias);
-    if (!nodePubKey) {
-      throw errors.UNKNOWN_ALIAS(alias);
-    }
-    return nodePubKey;
+    return this.nodes.getPubKeyForAlias(alias);
   }
 }
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -266,20 +266,20 @@ class Service {
     let remoteIdentifier: string | undefined;
     let uris: string[] | undefined;
 
-    try {
-      if (nodeIdentifier) {
-        const nodePubKey = isNodePubKey(nodeIdentifier) ? nodeIdentifier : this.pool.resolveAlias(nodeIdentifier);
-        const swapClientType = this.swapClientManager.getType(currency);
-        if (swapClientType === undefined) {
-          throw swapsErrors.SWAP_CLIENT_NOT_FOUND(currency);
-        }
-        const peer = this.pool.getPeer(nodePubKey);
-        remoteIdentifier = peer.getIdentifier(swapClientType, currency);
-        if (swapClientType === SwapClientType.Lnd) {
-          uris = peer.getLndUris(currency);
-        }
+    if (nodeIdentifier) {
+      const nodePubKey = isNodePubKey(nodeIdentifier) ? nodeIdentifier : this.pool.resolveAlias(nodeIdentifier);
+      const swapClientType = this.swapClientManager.getType(currency);
+      if (swapClientType === undefined) {
+        throw swapsErrors.SWAP_CLIENT_NOT_FOUND(currency);
       }
+      const peer = this.pool.getPeer(nodePubKey);
+      remoteIdentifier = peer.getIdentifier(swapClientType, currency);
+      if (swapClientType === SwapClientType.Lnd) {
+        uris = peer.getLndUris(currency);
+      }
+    }
 
+    try {
       await this.swapClientManager.openChannel({
         remoteIdentifier,
         uris,

--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -81,27 +81,10 @@ describe('P2P Pool Tests', async () => {
     expect(pool['peers'].size).to.equal(0);
   });
 
-  it('should ban a peer', async () => {
-    await pool['nodes'].createNode({ nodePubKey: nodeKeyOne.pubKey, addresses: [] });
-    const banPromise = pool.banNode(nodeKeyOne.pubKey);
-    expect(banPromise).to.be.fulfilled;
-    await banPromise;
-    const nodeReputationPromise = await pool.getNodeReputation(nodeKeyOne.pubKey);
-    expect(nodeReputationPromise.banned).to.be.true;
-  });
-
   it('should throw error when connecting to tor node with tor disabled', async () => {
     const address = addressUtils.fromString('3g2upl4pq6kufc4m.onion');
     const addPromise = pool.addOutbound(address, nodeKeyOne.pubKey, false, false);
     await expect(addPromise).to.be.rejectedWith(errors.NODE_TOR_ADDRESS(nodeKeyOne.pubKey, address).message);
-  });
-
-  it('should unban a peer', async () => {
-    const unbanPromise = pool.unbanNode(nodeKeyOne.pubKey, false);
-    expect(unbanPromise).to.be.fulfilled;
-    await unbanPromise;
-    const nodeReputationPromise = await pool.getNodeReputation(nodeKeyOne.pubKey);
-    expect(nodeReputationPromise.banned).to.be.false;
   });
 
   it('should update a node on new handshake', async () => {

--- a/test/jest/Service.spec.ts
+++ b/test/jest/Service.spec.ts
@@ -91,13 +91,14 @@ describe('Service', () => {
       expect.assertions(1);
       service = new Service(components);
       const args = getArgs();
+      const peerNotFoundError = new Error('peer not found');
       components.pool.getPeer = jest.fn().mockImplementation(() => {
-        throw new Error('peer not found');
+        throw peerNotFoundError;
       });
       try {
         await service.openChannel(args);
       } catch (e) {
-        expect(e).toMatchSnapshot();
+        expect(e).toEqual(peerNotFoundError);
       }
     });
 

--- a/test/jest/__snapshots__/Service.spec.ts.snap
+++ b/test/jest/__snapshots__/Service.spec.ts.snap
@@ -21,13 +21,6 @@ Object {
 }
 `;
 
-exports[`Service openChannel throws when peer not found 1`] = `
-Object {
-  "code": "6.5",
-  "message": "failed to open BTC channel for 16000000 with 02f8895eb03c37b2665415be4d83b20228acc0abc55ebf6728565141c66cfc164a: peer not found",
-}
-`;
-
 exports[`Service tradingLimits throws in case of invalid currency 1`] = `
 Object {
   "code": "6.1",


### PR DESCRIPTION
This ensures that we don't prevent ourselves from connecting to nodes that have alias conflicts with other known nodes. Instead, we only throw errors when we try to use a conflicted alias for rpc calls, since we cannot resolve the alias to a unique node.

Fixes #1687.