### PR TITLE
feat(p2p): improved ban handling

### DIFF
--- a/lib/p2p/P2PRepository.ts
+++ b/lib/p2p/P2PRepository.ts
@@ -22,6 +22,7 @@ class P2PRepository {
       where: {
         nodeId: node.id,
       },
+      order: [['createdAt', 'DESC']],
     });
   }
 

--- a/test/jest/NodeList.spec.ts
+++ b/test/jest/NodeList.spec.ts
@@ -1,0 +1,67 @@
+import NodeList from '../../lib/p2p/NodeList';
+import P2PRepository from '../../lib/p2p/P2PRepository';
+import { ReputationEvent } from '../../lib/constants/enums';
+
+jest.mock('../../lib/p2p/P2PRepository');
+const mockedP2pRepo = <jest.Mock<P2PRepository>><any>P2PRepository;
+
+describe('NodeList', () => {
+  let nodeList: NodeList;
+  const p2pRepo = new mockedP2pRepo();
+
+  beforeEach(async () => {
+    nodeList = new NodeList(p2pRepo);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  describe('getNegativeReputationEvents', () => {
+    const nodeInstance = { id: 1 } as any;
+
+    test('it should return an empty array when there are no events', async () => {
+      p2pRepo.getReputationEvents = jest.fn().mockImplementation(() => []);
+      const negativeReputationEvents = await nodeList['getNegativeReputationEvents'](nodeInstance);
+      expect(negativeReputationEvents.length).toEqual(0);
+    });
+
+    test('it should only return negative events', async () => {
+      p2pRepo.getReputationEvents = jest.fn().mockImplementation(() => [
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapSuccess, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+      ]);
+      const negativeReputationEvents = await nodeList['getNegativeReputationEvents'](nodeInstance);
+      expect(negativeReputationEvents).toEqual([ReputationEvent.PacketTimeout, ReputationEvent.SwapFailure]);
+    });
+
+    test('it should append a new event to the beginning of the array', async () => {
+      p2pRepo.getReputationEvents = jest.fn().mockImplementation(() => [
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+      ]);
+      const negativeReputationEvents = await nodeList['getNegativeReputationEvents'](nodeInstance, ReputationEvent.SwapDelay);
+      expect(negativeReputationEvents).toEqual([ReputationEvent.SwapDelay, ReputationEvent.PacketTimeout, ReputationEvent.SwapFailure]);
+    });
+
+    test('it should return no more than 10 events', async () => {
+      p2pRepo.getReputationEvents = jest.fn().mockImplementation(() => [
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+        { event: ReputationEvent.PacketTimeout, nodeId: 1 },
+        { event: ReputationEvent.SwapFailure, nodeId: 1 },
+      ]);
+      const negativeReputationEvents = await nodeList['getNegativeReputationEvents'](nodeInstance, ReputationEvent.SwapDelay);
+      expect(negativeReputationEvents.length).toEqual(10);
+    });
+  });
+});


### PR DESCRIPTION
This makes several improvements to the way xud behaves when a node is banned.

1. Only emit the `node.ban` event a single time when a node is banned, previously it was possible for this to fire multiple times when multiple negative reputation events occur at roughly the same time, polluting the logs and sending multiple disconnecting packets to the peer.

2. Log the name of the reputation event that triggered the ban.

3. Only send the recent reputation events to a peer when we ban them, rather than JSON stringifying the entire ReputationEventInstance db object which contains a lot of internal metadata that's irrelevent to
peers.