### PR TITLE
fix(simtest): nil pointer deref bug

### DIFF
--- a/test/simulation/docker-run.sh
+++ b/test/simulation/docker-run.sh
@@ -9,11 +9,16 @@ popd
 
 export DOCKER_CLIENT_TIMEOUT=120
 export COMPOSE_HTTP_TIMEOUT=120
-docker-compose run -v $PWD/temp/logs:/app/temp/logs test go test -v -timeout 20m -run=$@
-res=$?
+docker-compose run -v $PWD/temp/logs:/app/temp/logs test go test -v -timeout 30m -run=$@
+retVal=$?
 
 pushd temp/indra
 make reset
 popd
 
-exit $res
+if [[ retVal != 0 ]]
+then
+    ./logs.sh
+fi
+
+exit $retVal

--- a/test/simulation/logs.sh
+++ b/test/simulation/logs.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 find $PWD/temp/logs -type f -name xud*.log -printf "\n%f\n\n" -exec cat {} \;
-find $PWD/temp/logs -type f -name connext*.log -printf "\n%f\n\n" -exec cat {} \;

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -352,11 +352,7 @@ func (hn *HarnessNode) stop(kill bool) error {
 	}
 
 	if hn.Client != nil {
-		ctx := context.Background()
-		req := xudrpc.ShutdownRequest{}
-		if _, err := hn.Client.Shutdown(ctx, &req); err != nil {
-			return fmt.Errorf("RPC Shutdown failure: %v", err)
-		}
+		_, _ = hn.Client.Shutdown(context.Background(), &xudrpc.ShutdownRequest{})
 	}
 
 	// Wait for xud process and other goroutines to exit.

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -255,7 +255,6 @@ func (hn *HarnessNode) Start(errorChan chan<- *XudError) error {
 
 		// Signal any onlookers that this process has exited.
 		close(hn.ProcessExit)
-		hn.Client = nil
 	}()
 
 	// Since Stop uses the XudClient to stop the node, if we fail to get a
@@ -377,7 +376,6 @@ func (hn *HarnessNode) stop(kill bool) error {
 
 	hn.quit = nil
 	hn.ProcessExit = nil
-	hn.Client = nil
 	return nil
 }
 


### PR DESCRIPTION
Closing https://github.com/ExchangeUnion/xud/issues/1714.

The problem was with having a nil pointer dereference in a scenario where xud shutdown shortly after launch. This was fixed, but not the shutdown itself, which happens when trying to use an already-used port. I didn't manage to figure out what's causing this known instability, but I might try to use a different free-port generator technique if this happens too frequently. 

Also:
* Added log printing in case of failure, since we lost that after migrating to GitHub Actions. 
* Extended test timeout to 30m, so it will be longer than the test context timeout (for better error messages)

I managed to reproduce the problem after a few attempts, and this is how it looks now:

test
```
2020/07/08 06:12:46 xud: launching network...
2020/07/08 06:13:08 cannot start xud network: timeout waiting for xud to be ready
exit status 1
FAIL	github.com/ExchangeUnion/xud-simulation	164.413s
```

xud
```
08/07/2020 06:12:52.167 [GLOBAL] error: Unexpected error during initialization, shutting down...: Error: listen EADDRINUSE: address already in use 127.0.0.1:34365
    at Server.setupListenHandle [as _listen2] (net.js:1313:16)
    at listenInCluster (net.js:1361:12)
    at GetAddrInfoReqWrap.doListen [as callback] (net.js:1498:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:68:8)
```



