### PR TITLE
feat: trace log level for order updates

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -141,7 +141,7 @@ class TradingPair {
     }
 
     map.set(order.id, order);
-    this.logger.debug(`order added: ${JSON.stringify(order)}`);
+    this.logger.trace(`order added: ${JSON.stringify(order)}`);
 
     if (!this.nomatching) {
       const queue = order.isBuy ? this.queues!.buyQueue : this.queues!.sellQueue;
@@ -229,7 +229,7 @@ class TradingPair {
         assert(quantityToRemove <= order.quantity - order.hold, 'cannot remove more than available quantity after holds');
       }
       order.quantity = order.quantity - quantityToRemove;
-      this.logger.debug(`order quantity reduced by ${quantityToRemove}: ${orderId}`);
+      this.logger.trace(`order quantity reduced by ${quantityToRemove}: ${orderId}`);
       return { order: { ...order, quantity: quantityToRemove } as T, fullyRemoved: false } ;
     } else {
       // otherwise, remove the order entirely
@@ -244,7 +244,7 @@ class TradingPair {
         queue.remove(order);
       }
 
-      this.logger.debug(`order removed: ${orderId}`);
+      this.logger.trace(`order removed: ${orderId}`);
       return { order: order as T, fullyRemoved: true };
     }
   }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -756,7 +756,7 @@ class Pool extends EventEmitter {
     switch (packet.type) {
       case PacketType.Order: {
         const receivedOrder: OutgoingOrder = (packet as packets.OrderPacket).body!;
-        this.logger.verbose(`received order from ${peer.label}: ${JSON.stringify(receivedOrder)}`);
+        this.logger.trace(`received order from ${peer.label}: ${JSON.stringify(receivedOrder)}`);
         const incomingOrder: IncomingOrder = { ...receivedOrder, peerPubKey: peer.nodePubKey! };
 
         if (peer.isPairActive(incomingOrder.pairId)) {
@@ -768,7 +768,7 @@ class Pool extends EventEmitter {
       }
       case PacketType.OrderInvalidation: {
         const orderPortion = (packet as packets.OrderInvalidationPacket).body!;
-        this.logger.verbose(`received order invalidation from ${peer.label}: ${JSON.stringify(orderPortion)}`);
+        this.logger.trace(`received order invalidation from ${peer.label}: ${JSON.stringify(orderPortion)}`);
         this.emit('packet.orderInvalidation', orderPortion, peer.nodePubKey as string);
         break;
       }

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -93,6 +93,7 @@ jest.mock('../../lib/nodekey/NodeKey');
 const mockedNodeKey = <jest.Mock<NodeKey>><any>NodeKey;
 
 const logger = new Logger({});
+logger.trace = jest.fn();
 logger.debug = jest.fn();
 logger.error = jest.fn();
 const loggers = {


### PR DESCRIPTION
This aims to reduce the verbosity of logging at the `debug` level by lowering the log level of order updates to `trace`. With market makers, there may be a stream of near-constant order updates and logging all of them will quickly flood the logs.