### PR TITLE
feat(cli): print "no more matches" for place order

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -548,6 +548,7 @@ class OrderBook extends EventEmitter {
 
     if (remainingOrder) {
       if (discardRemaining) {
+        this.logger.verbose(`no more matches found for order ${order.id}, remaining order will be discarded`);
         remainingOrder = undefined;
       } else if (!retry) {
         // on recursive retries of placeOrder, we don't add remaining orders to the orderbook

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -94,6 +94,7 @@ const mockedNodeKey = <jest.Mock<NodeKey>><any>NodeKey;
 
 const logger = new Logger({});
 logger.trace = jest.fn();
+logger.verbose = jest.fn();
 logger.debug = jest.fn();
 logger.error = jest.fn();
 const loggers = {


### PR DESCRIPTION
This prints a message when placing orders via the cli when there are no more matches in the order book and a remainder of our order will be discarded. For limit orders, we print a message for the remainder to enter the order book in cases where we do not fully match right away. However there was no such message for market and IOC orders.

A similar message is also printed to the xud logs.

Closes #1656.