### PR TITLE
test(sim): PreimageResolved phase instability tests

### DIFF
--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/Xud.ts b/lib/Xud.ts
-index 08402caa8..c9972d258 100644
+index 08402caa..c9972d25 100644
 --- a/lib/Xud.ts
 +++ b/lib/Xud.ts
 @@ -87,6 +87,11 @@ class Xud extends EventEmitter {
@@ -15,10 +15,10 @@ index 08402caa8..c9972d258 100644
        if (!this.config.rpc.disable) {
          // start rpc server first, it will respond with UNAVAILABLE error
 diff --git a/lib/swaps/SwapRecovery.ts b/lib/swaps/SwapRecovery.ts
-index 090618c4b..cd33a5d58 100644
+index 090618c4..820f8909 100644
 --- a/lib/swaps/SwapRecovery.ts
 +++ b/lib/swaps/SwapRecovery.ts
-@@ -28,7 +28,15 @@ class SwapRecovery extends EventEmitter {
+@@ -28,7 +28,21 @@ class SwapRecovery extends EventEmitter {
 
    public beginTimer = () => {
      if (!this.pendingSwapsTimer) {
@@ -27,7 +27,13 @@ index 090618c4b..cd33a5d58 100644
 +      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CLIENT_CRASHED_BEFORE_SETTLE') {
 +        interval = 2000;
 +      }
-+      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND') {
++      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_WHILE_SENDING') {
++        interval = 2000;
++      }
++      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_BEFORE_PREIMAGE_RESOLVED') {
++        interval = 2000;
++      }
++      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_AFTER_PREIMAGE_RESOLVED') {
 +        interval = 2000;
 +      }
 +
@@ -36,10 +42,10 @@ index 090618c4b..cd33a5d58 100644
    }
 
 diff --git a/lib/swaps/Swaps.ts b/lib/swaps/Swaps.ts
-index 7fd02cbb8..2bc60fe51 100644
+index 908f4cc3..b72ab4dc 100644
 --- a/lib/swaps/Swaps.ts
 +++ b/lib/swaps/Swaps.ts
-@@ -710,6 +710,24 @@ class Swaps extends EventEmitter {
+@@ -721,6 +721,24 @@ class Swaps extends EventEmitter {
        // if the swap has already been failed, then we leave the swap recovery module
        // to attempt to settle the invoice and claim funds rather than do it here
        try {
@@ -64,7 +70,7 @@ index 7fd02cbb8..2bc60fe51 100644
          await swapClient.settleInvoice(rHash, rPreimage, currency);
        } catch (err) {
          // if we couldn't settle the invoice then we fail the deal which throws
-@@ -734,6 +752,16 @@ class Swaps extends EventEmitter {
+@@ -745,6 +763,16 @@ class Swaps extends EventEmitter {
     * accepted, initiates the swap.
     */
    private handleSwapAccepted = async (responsePacket: packets.SwapAcceptedPacket, peer: Peer) => {
@@ -81,7 +87,7 @@ index 7fd02cbb8..2bc60fe51 100644
      assert(responsePacket.body, 'SwapAcceptedPacket does not contain a body');
      const { quantity, rHash, makerCltvDelta } = responsePacket.body;
      const deal = this.getDeal(rHash);
-@@ -821,6 +849,11 @@ class Swaps extends EventEmitter {
+@@ -832,6 +860,11 @@ class Swaps extends EventEmitter {
 
      try {
        await makerSwapClient.sendPayment(deal);
@@ -93,7 +99,7 @@ index 7fd02cbb8..2bc60fe51 100644
      } catch (err) {
        // first we must handle the edge case where the maker has paid us but failed to claim our payment
        // in this case, we've already marked the swap as having been paid and completed
-@@ -1002,6 +1035,18 @@ class Swaps extends EventEmitter {
+@@ -1013,6 +1046,18 @@ class Swaps extends EventEmitter {
 
        this.logger.debug('Executing maker code to resolve hash');
 
@@ -112,11 +118,11 @@ index 7fd02cbb8..2bc60fe51 100644
        const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
 
        // we update the phase persist the deal to the database before we attempt to send payment
-@@ -1012,6 +1057,13 @@ class Swaps extends EventEmitter {
+@@ -1023,6 +1068,13 @@ class Swaps extends EventEmitter {
        assert(deal.state !== SwapState.Error, `cannot send payment for failed swap ${deal.rHash}`);
 
        try {
-+        if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND') {
++        if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_WHILE_SENDING') {
 +          setTimeout(() => {
 +            this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
 +            process.exit();
@@ -126,7 +132,30 @@ index 7fd02cbb8..2bc60fe51 100644
          deal.rPreimage = await swapClient.sendPayment(deal);
        } catch (err) {
          this.logger.debug(`sendPayment in resolveHash failed due to ${err.message}`);
-@@ -1073,6 +1125,16 @@ class Swaps extends EventEmitter {
+@@ -1073,10 +1125,21 @@ class Swaps extends EventEmitter {
+         }
+       }
+
++      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_BEFORE_PREIMAGE_RESOLVED') {
++        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
++        process.exit();
++      }
++
+       // we update the deal phase but we don't wait for the updated deal to be persisted
+       // to the database because we don't want to delay claiming the incoming payment
+       // using the preimage we've just resolved
+-      this.setDealPhase(deal, SwapPhase.PreimageResolved).catch(this.logger.error);
++      await this.setDealPhase(deal, SwapPhase.PreimageResolved).catch(this.logger.error);
++
++      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_AFTER_PREIMAGE_RESOLVED') {
++        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
++        process.exit();
++      }
++
+       return deal.rPreimage;
+     } else {
+       // If we are here we are the taker
+@@ -1084,6 +1147,16 @@ class Swaps extends EventEmitter {
        assert(htlcCurrency === undefined || htlcCurrency === deal.takerCurrency, 'incoming htlc does not match expected deal currency');
        this.logger.debug('Executing taker code to resolve hash');
 
@@ -143,7 +172,7 @@ index 7fd02cbb8..2bc60fe51 100644
        return deal.rPreimage;
      }
    }
-@@ -1248,8 +1310,11 @@ class Swaps extends EventEmitter {
+@@ -1259,8 +1332,11 @@ class Swaps extends EventEmitter {
          await this.swapRecovery.recoverDeal(swapDealInstance!);
        }
      } else if (deal.phase === SwapPhase.SendingPayment) {
@@ -157,7 +186,7 @@ index 7fd02cbb8..2bc60fe51 100644
      }
 
      this.logger.trace(`emitting swap.failed event for ${deal.rHash}`);
-@@ -1313,9 +1378,14 @@ class Swaps extends EventEmitter {
+@@ -1324,9 +1400,14 @@ class Swaps extends EventEmitter {
 
          if (deal.role === SwapRole.Maker) {
            // the maker begins execution of the swap upon accepting the deal

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -19,8 +19,20 @@ var instabilityTestCases = []*testCase{
 		test: testNetworkInit,
 	},
 	{
-		name: "maker crashed after send payment", // replacing Alice
-		test: testMakerCrashedAfterSend,
+		name: "maker crashed after send payment before preimage resolved; incoming: lnd, outgoing: lnd", // replacing Alice
+		test: testMakerCrashedAfterSendBeforePreimageResolved,
+	},
+	{
+		name: "maker crashed after send payment before preimage resolved; incoming: connext, outgoing: lnd", // replacing Alice
+		test: testMakerCrashedAfterSendBeforePreimageResolvedConnextIn,
+	},
+	{
+		name: "maker crashed after send payment after preimage resolved; incoming: lnd, outgoing: lnd", // replacing Alice
+		test: testMakerCrashedAfterSendAfterPreimageResolved,
+	},
+	{
+		name: "maker crashed after send payment after preimage resolved; incoming: connext, outgoing: lnd", // replacing Alice
+		test: testMakerCrashedAfterSendAfterPreimageResolvedConnextIn,
 	},
 	{
 		name: "maker lnd crashed before order settlement", // replacing Alice
@@ -44,10 +56,26 @@ var instabilityTestCases = []*testCase{
 	},
 }
 
-// testMakerLndCrashedBeforeSettlement
-func testMakerCrashedAfterSend(net *xudtest.NetworkHarness, ht *harnessTest) {
+func testMakerCrashedAfterSendBeforePreimageResolved(net *xudtest.NetworkHarness, ht *harnessTest) {
+	testMakerCrashedDuringSwap(net, ht, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND_BEFORE_PREIMAGE_RESOLVED"})
+}
+
+func testMakerCrashedAfterSendBeforePreimageResolvedConnextIn(net *xudtest.NetworkHarness, ht *harnessTest) {
+	ht.act.initConnext(net, net.Bob, true)
+	testMakerCrashedDuringSwapConnextIn(net, ht, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND_BEFORE_PREIMAGE_RESOLVED"})
+}
+
+func testMakerCrashedAfterSendAfterPreimageResolved(net *xudtest.NetworkHarness, ht *harnessTest) {
+	testMakerCrashedDuringSwap(net, ht, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND_AFTER_PREIMAGE_RESOLVED"})
+}
+
+func testMakerCrashedAfterSendAfterPreimageResolvedConnextIn(net *xudtest.NetworkHarness, ht *harnessTest) {
+	testMakerCrashedDuringSwapConnextIn(net, ht, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND_AFTER_PREIMAGE_RESOLVED"})
+}
+
+func testMakerCrashedDuringSwap(net *xudtest.NetworkHarness, ht *harnessTest, customXudMakerEnvVars []string) {
 	var err error
-	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, customXudMakerEnvVars)
 	ht.assert.NoError(err)
 	ht.act.init(net.Alice)
 
@@ -95,6 +123,66 @@ func testMakerCrashedAfterSend(net *xudtest.NetworkHarness, ht *harnessTest) {
 	ht.assert.NoError(err)
 	aliceLtcBalance := aliceBalance.ltc.channel.GetBalance()
 	ht.assert.Equal(alicePrevLtcBalance+ltcQuantity, aliceLtcBalance, "alice did not receive LTC")
+}
+
+func testMakerCrashedDuringSwapConnextIn(net *xudtest.NetworkHarness, ht *harnessTest, makerEnvArgs []string) {
+	var err error
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, makerEnvArgs)
+	ht.assert.NoError(err)
+	ht.act.init(net.Alice)
+	ht.act.initConnext(net, net.Alice, false)
+
+	// Connect Alice to Bob.
+	ht.act.connect(net.Alice, net.Bob)
+	ht.act.verifyConnectivity(net.Alice, net.Bob)
+
+	err = openETHChannel(ht.ctx, net.Bob, 400, 0)
+	ht.assert.NoError(err)
+
+	// Save the initial balances.
+	alicePrevBalance, err := net.Alice.Client.GetBalance(ht.ctx, &xudrpc.GetBalanceRequest{Currency: "ETH"})
+	ht.assert.NoError(err)
+	alicePrevEthBalance := alicePrevBalance.Balances["ETH"]
+
+	// Place an order on Alice.
+	aliceOrderReq := &xudrpc.PlaceOrderRequest{
+		OrderId:  "maker_order_id",
+		Price:    40,
+		Quantity: 1,
+		PairId:   "BTC/ETH",
+		Side:     xudrpc.OrderSide_SELL,
+	}
+	ht.act.placeOrderAndBroadcast(net.Alice, net.Bob, aliceOrderReq)
+
+	// Place a matching order on Bob.
+	bobOrderReq := &xudrpc.PlaceOrderRequest{
+		OrderId:  "taker_order_id",
+		Price:    aliceOrderReq.Price,
+		Quantity: aliceOrderReq.Quantity,
+		PairId:   aliceOrderReq.PairId,
+		Side:     xudrpc.OrderSide_BUY,
+	}
+
+	_, err = net.Bob.Client.PlaceOrderSync(ht.ctx, bobOrderReq)
+	ht.assert.NoError(err)
+
+	<-net.Alice.ProcessExit
+
+	err = net.Alice.Start(nil)
+	ht.assert.NoError(err)
+
+	err = waitConnextReady(net.Alice)
+	ht.assert.NoError(err)
+
+	// Brief delay to allow for swap to be recovered consistently.
+	time.Sleep(2 * time.Second)
+
+	// Verify that Alice recovered ETH funds.
+	aliceBalance, err := net.Alice.Client.GetBalance(ht.ctx, &xudrpc.GetBalanceRequest{Currency: "ETH"})
+	ht.assert.NoError(err)
+	aliceEthBalance := aliceBalance.Balances["ETH"]
+	diff := uint64(float64(aliceOrderReq.Quantity) * aliceOrderReq.Price)
+	ht.assert.Equal(alicePrevEthBalance.ChannelBalance+diff, aliceEthBalance.ChannelBalance, "alice did not recover ETH funds")
 }
 
 func testMakerLndCrashedBeforeSettlement(net *xudtest.NetworkHarness, ht *harnessTest) {
@@ -171,7 +259,7 @@ func testMakerConnextClientCrashedBeforeSettlement(net *xudtest.NetworkHarness, 
 	ht.act.init(net.Alice)
 
 	ht.act.initConnext(net, net.Alice, false)
-	ht.act.initConnext(net, net.Bob, true)
+	ht.assert.NoError(waitConnextReady(net.Bob))
 
 	// Connect Alice to Bob.
 	ht.act.connect(net.Alice, net.Bob)
@@ -243,7 +331,7 @@ func testMakerConnextClientCrashedBeforeSettlement(net *xudtest.NetworkHarness, 
 
 func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_WHILE_SENDING"})
 	ht.assert.NoError(err)
 
 	net.Bob, err = net.SetCustomXud(ht.ctx, ht, net.Bob, []string{"CUSTOM_SCENARIO=INSTABILITY::TAKER_DELAY_BEFORE_SETTLE"})
@@ -305,7 +393,7 @@ func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht 
 
 func testMakerCrashedAfterSendDelayedSettlementConnextOut(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_WHILE_SENDING"})
 	ht.assert.NoError(err)
 
 	net.Bob, err = net.SetCustomXud(ht.ctx, ht, net.Bob, []string{"CUSTOM_SCENARIO=INSTABILITY::TAKER_DELAY_BEFORE_SETTLE"})
@@ -393,7 +481,7 @@ func testMakerCrashedAfterSendDelayedSettlementConnextOut(net *xudtest.NetworkHa
 
 func testMakerCrashedAfterSendDelayedSettlementConnextIn(net *xudtest.NetworkHarness, ht *harnessTest) {
 	var err error
-	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_AFTER_SEND"})
+	net.Alice, err = net.SetCustomXud(ht.ctx, ht, net.Alice, []string{"CUSTOM_SCENARIO=INSTABILITY::MAKER_CRASH_WHILE_SENDING"})
 	ht.assert.NoError(err)
 
 	net.Bob, err = net.SetCustomXud(ht.ctx, ht, net.Bob, []string{"CUSTOM_SCENARIO=INSTABILITY::TAKER_DELAY_BEFORE_SETTLE"})

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -175,7 +175,7 @@ func testMakerCrashedDuringSwapConnextIn(net *xudtest.NetworkHarness, ht *harnes
 	ht.assert.NoError(err)
 
 	// Brief delay to allow for swap to be recovered consistently.
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// Verify that Alice recovered ETH funds.
 	aliceBalance, err := net.Alice.Client.GetBalance(ht.ctx, &xudrpc.GetBalanceRequest{Currency: "ETH"})


### PR DESCRIPTION
Closing https://github.com/ExchangeUnion/xud/issues/1712.

The previously existing `makerCrashedAfterSend` test wasn’t working well, as it was simulating a crash after swap already completed, due to an issue in the test code.

Instead, 4 tests were added:

* maker crash after send payment, before `PreimageResolved` phase; lnd
* maker crash after send payment, before `PreimageResolved` phase; connext
* maker crash after send payment, after `PreimageResolved` phase; lnd
* maker crash after send payment, after `PreimageResolved` phase; connext

As before, code structure is still messy, waiting for the upcoming refactoring. 

