### PR TITLE
feat: better "alias not found" message

### DIFF
--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -99,7 +99,7 @@ class NodeList extends EventEmitter {
   public getPubKeyForAlias = (alias: string) => {
     const nodePubKey = this.aliasToPubKeyMap.get(alias);
     if (!nodePubKey) {
-      throw errors.UNKNOWN_ALIAS(alias);
+      throw errors.ALIAS_NOT_FOUND(alias);
     }
     if (nodePubKey === 'CONFLICT') {
       throw errors.ALIAS_CONFLICT(alias);

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -421,7 +421,7 @@ class Pool extends EventEmitter {
       };
     } else {
       this.logger.warn(`node ${nodePubKey} (${pubKeyToAlias(nodePubKey)}) not found`);
-      throw errors.NODE_UNKNOWN(nodePubKey);
+      throw errors.NODE_NOT_FOUND(nodePubKey);
     }
   }
 
@@ -633,7 +633,7 @@ class Pool extends EventEmitter {
     } else {
       const banned = await this.nodes.ban(nodePubKey);
       if (!banned) {
-        throw errors.NODE_UNKNOWN(nodePubKey);
+        throw errors.NODE_NOT_FOUND(nodePubKey);
       }
     }
   }
@@ -642,7 +642,7 @@ class Pool extends EventEmitter {
     if (this.nodes.isBanned(nodePubKey)) {
       const unbanned = await this.nodes.unBan(nodePubKey);
       if (!unbanned) {
-        throw errors.NODE_UNKNOWN(nodePubKey);
+        throw errors.NODE_NOT_FOUND(nodePubKey);
       }
 
       const node = this.nodes.get(nodePubKey);

--- a/lib/p2p/errors.ts
+++ b/lib/p2p/errors.ts
@@ -80,8 +80,8 @@ const errors = {
     message: `could not connect to peer at ${addressUtils.toString(address)}: ${err.message}`,
     code: errorCodes.COULD_NOT_CONNECT,
   }),
-  NODE_UNKNOWN: (nodePubKey: string) => ({
-    message: `node ${nodePubKey} is unknown`,
+  NODE_NOT_FOUND: (nodePubKey: string) => ({
+    message: `node with pub key ${nodePubKey} not found`,
     code: errorCodes.NODE_UNKNOWN,
   }),
   NODE_ALREADY_BANNED: (nodePubKey: string) => ({
@@ -152,8 +152,8 @@ const errors = {
     message: `alias ${alias} refers to more than one node`,
     code: errorCodes.ALIAS_CONFLICT,
   }),
-  UNKNOWN_ALIAS: (alias: string) => ({
-    message: `alias ${alias} is unknown`,
+  ALIAS_NOT_FOUND: (alias: string) => ({
+    message: `node with alias ${alias} not found`,
     code: errorCodes.UNKNOWN_ALIAS,
   }),
 };

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -172,13 +172,13 @@ describe('API Service', () => {
   it('should fail to ban a node by alias that does not exist', async () => {
     const alias = 'doesNotExist';
     const banNodePromise = service.ban({ nodeIdentifier: alias });
-    await expect(banNodePromise).to.be.rejectedWith(p2pErrors.UNKNOWN_ALIAS(alias).message);
+    await expect(banNodePromise).to.be.rejectedWith(p2pErrors.ALIAS_NOT_FOUND(alias).message);
   });
 
   it('should fail to ban a node by nodePubKey that does not exist', async () => {
     const nodePubKey = '028599d05b18c0c3f8028915a17d603416f7276c822b6b2d20e71a3502bd0f9e0b';
     const banNodePromise = service.ban({ nodeIdentifier: nodePubKey });
-    await expect(banNodePromise).to.be.rejectedWith(p2pErrors.NODE_UNKNOWN(nodePubKey).message);
+    await expect(banNodePromise).to.be.rejectedWith(p2pErrors.NODE_NOT_FOUND(nodePubKey).message);
   });
 
   it('should shutdown', async () => {


### PR DESCRIPTION
This uses a clearer error message when an rpc command specifies an alias that we have never encountered.

Closes #1670.