### PR TITLE
feat(connext): removeInvoice

### DIFF
--- a/lib/connextclient/types.ts
+++ b/lib/connextclient/types.ts
@@ -100,6 +100,7 @@ export type ExpectedIncomingTransfer = {
   units: number;
   expiry: number;
   tokenAddress: string;
+  paymentId?: string;
 };
 
 export type ConnextPreimageRequest = {
@@ -160,4 +161,5 @@ export type TransferReceivedEvent = {
   rHash: string;
   timelock: number;
   units: number;
+  paymentId: string;
 };

--- a/lib/http/HttpService.ts
+++ b/lib/http/HttpService.ts
@@ -52,6 +52,7 @@ class HttpService {
       const {
         amount: amountHex,
         assetId,
+        paymentId,
       } = incomingTransferRequest.data;
       const {
         lockHash,
@@ -64,6 +65,7 @@ class HttpService {
         rHash,
         timelock,
         units,
+        paymentId,
         tokenAddress: assetId,
       });
       return {};


### PR DESCRIPTION
This implements the new functionality to cancel incoming hash lock transfers in Connext, automatically freeing any HTLCs.

Closes #1730.

This is still a draft as it needs testing with the newest connext versions. I also believe this might require some modifications to the rest-api-client to ensure the `resolveCondition` call is happening properly, and it might make sense to create a separate endpoint for hashlock cancellations only such as `/hashlock-cancel`. I can open a PR for that the way I created `/withdraw`