### PR TITLE
test: remove temp/indra folder on clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:sim:custom-xud:apply": "git apply --reject test/simulation/custom-xud.patch",
     "test:sim:custom-xud:reverse": "git apply -R test/simulation/custom-xud.patch",
     "test:sim:clean": "(cd test/simulation && ./docker-clean.sh)",
+    "test:sim:clean:indra": "rm -rf test/simulation/temp/indra",
     "test:sim:clean:xud": "(cd test/simulation && ./docker-clean.sh xud)",
     "test:sim:clean:lnd": "(cd test/simulation && ./docker-clean.sh lnd)",
     "test:sim:clean:connext": "(cd test/simulation && ./docker-clean.sh connext)",

--- a/test/simulation/docker-run.sh
+++ b/test/simulation/docker-run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# create the temp directory with the current user so it is the owner for permissions
+# create the temp directories with the current user so it is the owner for permissions
 mkdir -p $PWD/temp/logs
+mkdir -p $PWD/temp/indra
 
 pushd temp/indra
 make start


### PR DESCRIPTION
The `temp/indra` folder for simulation tests was not being removed when running `npm run:sim:clean`. A stale indra folder could cause tests to fail and would need to be manually deleted. This PR deletes it automatically with the clean script.