### PR TITLE
feat(cli): tradehistory --all

### DIFF
--- a/lib/cli/commands/tradehistory.ts
+++ b/lib/cli/commands/tradehistory.ts
@@ -79,11 +79,19 @@ export const builder = (argv: Argv) => argv
     type: 'number',
     default: 15,
   })
+  .option('all', {
+    description: 'whether to display the complete trade history',
+    type: 'boolean',
+    default: false,
+  })
   .example('$0 tradehistory', 'list most recent trades')
   .example('$0 tradehistory 50', 'list the 50 most recent trades');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new TradeHistoryRequest();
-  request.setLimit(argv.limit);
+  if (!argv.all) {
+    // don't set a limit if the --all flag is specified
+    request.setLimit(argv.limit);
+  }
   (await loadXudClient(argv)).tradeHistory(request, callback(argv, displayTrades));
 };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -527,7 +527,7 @@ class Service {
    */
   public tradeHistory = async (args: { limit: number }): Promise<ServiceTrade[]> => {
     const { limit } = args;
-    const trades = await this.orderBook.getTrades(limit);
+    const trades = await this.orderBook.getTrades(limit || undefined);
 
     const orderInstanceToServiceOrder = (order: OrderAttributes, quantity: number): ServiceOrder => {
       const isOwnOrder = !!order.localId;


### PR DESCRIPTION
This adds an `--all` flag to the `xucli tradehistory` command to return all trades in the database with no limit.

Closes #1744.