### PR TITLE
feat: don't deactivate pairs with debug.testing

### DIFF
--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -169,7 +169,13 @@ class Xud extends EventEmitter {
 
       const initPromises: Promise<any>[] = [];
 
-      this.swaps = new Swaps(loggers.swaps, this.db.models, this.pool, this.swapClientManager);
+      this.swaps = new Swaps({
+        logger: loggers.swaps,
+        models: this.db.models,
+        pool: this.pool,
+        swapClientManager: this.swapClientManager,
+        testing: this.config.debug.testing,
+      });
       initPromises.push(this.swaps.init());
 
       this.orderBook = new OrderBook({

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -929,7 +929,7 @@ class Pool extends EventEmitter {
       this.logger.debug(`Peer (${peer.label}): reputation event: ${ReputationEvent[event]}`);
       if (peer.nodePubKey) {
         if (this.testing && event !== ReputationEvent.ManualBan && event !== ReputationEvent.ManualUnban) {
-          // we don't add non-manual reputation events when in debug/testing mode to preven unintentional bans
+          // we don't add non-manual reputation events when in debug/testing mode to prevent unintentional bans
           return;
         }
         await this.addReputationEvent(peer.nodePubKey, event);

--- a/test/integration/Swaps.spec.ts
+++ b/test/integration/Swaps.spec.ts
@@ -113,7 +113,12 @@ describe('Swaps.Integration', () => {
       }
       return client;
     };
-    swaps = new Swaps(loggers.swaps, db.models, pool, swapClientManager);
+    swaps = new Swaps({
+      pool,
+      swapClientManager,
+      logger: loggers.swaps,
+      models: db.models,
+    });
   });
 
   afterEach(() => {

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -146,7 +146,12 @@ describe('OrderBook', () => {
     unitConverter = new UnitConverter();
     unitConverter.init();
     swapClientManager = new SwapClientManager(config, loggers, unitConverter);
-    swaps = new Swaps(loggers.swaps, db.models, pool, swapClientManager);
+    swaps = new Swaps({
+      pool,
+      swapClientManager,
+      logger: loggers.swaps,
+      models: db.models,
+    });
     swaps.swapClientManager = swapClientManager;
     orderbook = new Orderbook({
       pool,

--- a/test/jest/integration/Swaps.spec.ts
+++ b/test/jest/integration/Swaps.spec.ts
@@ -104,7 +104,12 @@ describe('Swaps Integration', () => {
     makerCurrency = 'LTC';
     takerCurrency = 'BTC';
 
-    swaps = new Swaps(logger, db.models, pool, swapClientManager);
+    swaps = new Swaps({
+      logger,
+      pool,
+      swapClientManager,
+      models: db.models,
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
This prevents trading pairs from being deactivated due to failed swaps while in `debug.testing` mode. Previously we would automatically reactivate pairs in this mode, but this change ensures they don't get deactivated in the first place.