### PR TITLE
fix: don't add back orders for inactive peer

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -576,7 +576,11 @@ class OrderBook extends EventEmitter {
     }
 
     failedMakerOrders.forEach((peerOrder) => {
-      this.tradingPairs.get(peerOrder.pairId)?.addPeerOrder(peerOrder);
+      const peer = this.pool.getPeer(peerOrder.peerPubKey);
+      if (peer?.active && peer?.isPairActive(peerOrder.pairId)) {
+        // if this peer and its trading pair is still active then we add the order back to the book
+        this.tradingPairs.get(peerOrder.pairId)?.addPeerOrder(peerOrder);
+      }
     });
 
     return {


### PR DESCRIPTION
This change ensures that we do not add orders that failed a swap back to the order book if the peer which that order belongs to is no longer active/connected.

Closes #1622.