### PR TITLE
feat(connext): better empty request logging

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -665,7 +665,7 @@ class ConnextClient extends SwapClient {
         };
       }
 
-      this.logger.trace(`sending request to ${endpoint}: ${payloadStr}`);
+      this.logger.trace(`sending request to ${endpoint}${payloadStr ? `: ${payloadStr}` : ''}`);
       const req = http.request(options, async (res) => {
         let err: XudError | undefined;
         switch (res.statusCode) {


### PR DESCRIPTION
Previously we would log "undefined" for every connext request that does not have a payload, this simply logs nothing for that case.