### PR TITLE
feat(config): rename debug.testing to strict

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -51,6 +51,7 @@ class Config {
   public logpath: string;
   public logdateformat: string;
   public network: XuNetwork;
+  public strict: boolean;
   public rpc: { disable: boolean, host: string, port: number };
   public http: { host: string, port: number };
   public lnd: { [currency: string]: LndClientConfig | undefined } = {};
@@ -59,7 +60,6 @@ class Config {
   public orderthresholds: OrderBookThresholds;
   public webproxy: { port: number, disable: boolean };
   public debug: {
-    testing: boolean,
     raidenDirectChannelChecks: boolean,
   };
   public instanceid = 0;
@@ -116,6 +116,7 @@ class Config {
     this.logdateformat = 'DD/MM/YYYY HH:mm:ss.SSS';
     this.network = XuNetwork.SimNet;
     this.dbpath = this.getDefaultDbPath();
+    this.strict = false;
 
     this.p2p = {
       listen: true,
@@ -141,7 +142,6 @@ class Config {
       port: 8080,
     };
     this.debug = {
-      testing: false,
       raidenDirectChannelChecks: true,
     };
     // TODO: add dynamic max/min price limits

--- a/lib/Xud.ts
+++ b/lib/Xud.ts
@@ -164,7 +164,7 @@ class Xud extends EventEmitter {
         xuNetwork: this.config.network,
         logger: loggers.p2p,
         models: this.db.models,
-        testing: this.config.debug.testing,
+        strict: this.config.strict,
       });
 
       const initPromises: Promise<any>[] = [];
@@ -174,7 +174,7 @@ class Xud extends EventEmitter {
         models: this.db.models,
         pool: this.pool,
         swapClientManager: this.swapClientManager,
-        testing: this.config.debug.testing,
+        strict: this.config.strict,
       });
       initPromises.push(this.swaps.init());
 
@@ -187,7 +187,7 @@ class Xud extends EventEmitter {
         swaps: this.swaps,
         nosanityswaps: this.config.nosanityswaps,
         nobalancechecks: this.config.nobalancechecks,
-        testing: this.config.debug.testing,
+        strict: this.config.strict,
       });
       initPromises.push(this.orderBook.init());
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -75,7 +75,7 @@ class OrderBook extends EventEmitter {
   private logger: Logger;
   private nosanityswaps: boolean;
   private nobalancechecks: boolean;
-  private testing: boolean;
+  private strict: boolean;
   private pool: Pool;
   private swaps: Swaps;
 
@@ -93,7 +93,7 @@ class OrderBook extends EventEmitter {
     return this.currencyInstances;
   }
 
-  constructor({ logger, models, thresholds, pool, swaps, nosanityswaps, nobalancechecks, nomatching = false, testing = false }:
+  constructor({ logger, models, thresholds, pool, swaps, nosanityswaps, nobalancechecks, nomatching = false, strict = true }:
   {
     logger: Logger,
     models: Models,
@@ -103,7 +103,7 @@ class OrderBook extends EventEmitter {
     nosanityswaps: boolean,
     nobalancechecks: boolean,
     nomatching?: boolean,
-    testing?: boolean,
+    strict?: boolean,
   }) {
     super();
 
@@ -114,7 +114,7 @@ class OrderBook extends EventEmitter {
     this.nosanityswaps = nosanityswaps;
     this.nobalancechecks = nobalancechecks;
     this.thresholds = thresholds;
-    this.testing = testing;
+    this.strict = strict;
 
     this.repository = new OrderBookRepository(models);
 
@@ -922,7 +922,7 @@ class OrderBook extends EventEmitter {
 
     // activate verified currencies
     currenciesToVerify.forEach((swappable, currency) => {
-      if (swappable || this.testing) { // always activate currencies if in debug/testing mode
+      if (swappable || !this.strict) { // always activate currencies if not in strict mode
         peer.activateCurrency(currency);
       }
     });

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -928,8 +928,15 @@ class Pool extends EventEmitter {
     peer.on('reputation', async (event) => {
       this.logger.debug(`Peer (${peer.label}): reputation event: ${ReputationEvent[event]}`);
       if (peer.nodePubKey) {
-        // we only add manual reputation events when not in strict mode to prevent unintentional bans
-        if (this.strict || event === ReputationEvent.ManualBan || event === ReputationEvent.ManualUnban) {
+        // when in strict mode, we add all reputation events
+        // otherwise, we only add manual or severe reputation events to prevent unintentional bans
+        if (this.strict
+          || event === ReputationEvent.ManualBan
+          || event === ReputationEvent.ManualUnban
+          || event === ReputationEvent.SwapAbuse
+          || event === ReputationEvent.SwapMisbehavior
+          || event === ReputationEvent.WireProtocolErr
+          || event === ReputationEvent.InvalidAuth) {
           await this.addReputationEvent(peer.nodePubKey, event);
         }
       }

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -92,20 +92,20 @@ class Pool extends EventEmitter {
   private listenPort?: number;
   /** Points to config comes during construction. */
   private config: PoolConfig;
-  private testing: boolean;
+  private strict: boolean;
   private repository: P2PRepository;
   private network: Network;
   private logger: Logger;
   private nodeKey: NodeKey;
 
-  constructor({ config, xuNetwork, logger, models, nodeKey, version, testing = false }: {
+  constructor({ config, xuNetwork, logger, models, nodeKey, version, strict = true }: {
     config: PoolConfig,
     xuNetwork: XuNetwork,
     logger: Logger,
     models: Models,
     nodeKey: NodeKey,
     version: string,
-    testing?: boolean,
+    strict?: boolean,
   }) {
     super();
 
@@ -115,7 +115,7 @@ class Pool extends EventEmitter {
     this.alias = pubKeyToAlias(nodeKey.pubKey);
     this.version = version;
     this.config = config;
-    this.testing = testing;
+    this.strict = strict;
     this.network = new Network(xuNetwork);
     this.repository = new P2PRepository(models);
     this.nodes = new NodeList(this.repository);
@@ -928,11 +928,10 @@ class Pool extends EventEmitter {
     peer.on('reputation', async (event) => {
       this.logger.debug(`Peer (${peer.label}): reputation event: ${ReputationEvent[event]}`);
       if (peer.nodePubKey) {
-        if (this.testing && event !== ReputationEvent.ManualBan && event !== ReputationEvent.ManualUnban) {
-          // we don't add non-manual reputation events when in debug/testing mode to prevent unintentional bans
-          return;
+        // we only add manual reputation events when not in strict mode to prevent unintentional bans
+        if (this.strict || event === ReputationEvent.ManualBan || event === ReputationEvent.ManualUnban) {
+          await this.addReputationEvent(peer.nodePubKey, event);
         }
-        await this.addReputationEvent(peer.nodePubKey, event);
       }
     });
   }

--- a/sample-xud.conf
+++ b/sample-xud.conf
@@ -37,6 +37,7 @@ nobalancechecks = false
 noencrypt = false
 nomatching = false
 nosanityswaps = true
+strict = false
 
 [connext]
 disable = false
@@ -47,7 +48,6 @@ webhookport = 8887
 
 [debug]
 raidenDirectChannelChecks = true
-testing = false
 
 [http]
 host = "localhost"

--- a/test/jest/SwapClientManager.spec.ts
+++ b/test/jest/SwapClientManager.spec.ts
@@ -127,8 +127,8 @@ describe('Swaps.SwapClientManager', () => {
     };
     config.debug = {
       raidenDirectChannelChecks: true,
-      testing: false,
     };
+    config.strict = true;
     db = new DB(loggers.db, config.dbpath);
     unitConverter = new UnitConverter();
     unitConverter.init();

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -3,7 +3,6 @@ package xudtest
 import (
 	"bytes"
 	"fmt"
-	"github.com/ExchangeUnion/xud-simulation/connexttest"
 	"net"
 	"os"
 	"os/exec"
@@ -13,7 +12,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ExchangeUnion/xud-simulation/connexttest"
+
 	"context"
+
 	"github.com/ExchangeUnion/xud-simulation/lntest"
 	"github.com/ExchangeUnion/xud-simulation/xudrpc"
 	"github.com/go-errors/errors"
@@ -64,6 +66,7 @@ func (cfg nodeConfig) genArgs() []string {
 	args = append(args, "--regtest")
 	args = append(args, "--loglevel=trace")
 	args = append(args, "--noencrypt")
+	args = append(args, "--strict")
 
 	if cfg.NoBalanceChecks {
 		args = append(args, "--nobalancechecks=true")


### PR DESCRIPTION
This replaces the `debug.testing` option with a `strict` option and makes the default behavior non-strict, equivalent to running xud with `debug.testing` before.

I went with `strict` as opposed to `production.strict` because it's less to type out that way and because I can't envision any other options that would go under a "production" category of config options.

It also allows severe reputation events to be registered even when not running in strict mode. Previously only manual reputation events were allowed when not in strict mode.

Closes #1757.