### PR TITLE
fix(swaps): no remote fail when sending payment

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1429,8 +1429,13 @@ class Swaps extends EventEmitter {
         this.logger.warn(`received swap failed packet for unknown deal with payment hash ${rHash}`);
       }
       return;
-    } else if (deal.phase === SwapPhase.PreimageResolved || deal.phase === SwapPhase.PaymentReceived) {
+    }
+
+    if (deal.phase === SwapPhase.PreimageResolved
+      || deal.phase === SwapPhase.PaymentReceived
+      || (deal.role === SwapRole.Maker && deal.phase === SwapPhase.SendingPayment)) {
       // we don't want to fail a deal if any one of its payments is already completed
+      // or if we are the maker sending a payment that may be claimed by taker
       this.logger.warn(`received swap failed packet for deal in phase ${SwapPhase[deal.phase]} with payment hash ${rHash}`);
       return;
     }

--- a/test/simulation/go.mod
+++ b/test/simulation/go.mod
@@ -12,8 +12,6 @@ require (
 	github.com/ltcsuite/ltcd v0.0.0-20191214120725-004941532b74
 	github.com/ltcsuite/ltcutil v0.0.0-20190507133322-23cdfa9fcc3d
 	github.com/miguelmota/go-ethereum-hdwallet v0.0.0-20200123000308-a60dcd172b4c
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/roasbeef/btcd v0.0.0-20180418012700-a03db407e40d
 	github.com/roasbeef/btcutil v0.0.0-20180406014609-dfb640c57141

--- a/test/simulation/tests-security.go
+++ b/test/simulation/tests-security.go
@@ -347,10 +347,15 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 	amt := int64(15000000)
 	pushAmt := int64(7500000)
-	aliceLtcChanPoint, err := openLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, net.Bob.LndLtcNode, amt, pushAmt)
+	_, err = openLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, net.Bob.LndLtcNode, amt, pushAmt)
 	ht.assert.NoError(err)
 	_, err = openBtcChannel(ht.ctx, net.LndBtcNetwork, net.Bob.LndBtcNode, net.Alice.LndBtcNode, amt, pushAmt)
 	ht.assert.NoError(err)
+
+	alicePrevLtcChanList, err := net.Alice.LndLtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
+	ht.assert.NoError(err)
+	ht.assert.Equal(len(alicePrevLtcChanList.Channels), 1)
+	alicePrevLtcChan := alicePrevLtcChanList.Channels[0]
 
 	bobPrevBtcChanList, err := net.Bob.LndBtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
 	ht.assert.NoError(err)
@@ -392,21 +397,9 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.Equal(res.RemainingOrder.GetLocalId(), aliceOrderReq.OrderId)
 	ht.assert.Equal(res.RemainingOrder.Quantity, aliceOrderReq.Quantity)
 
-	e := <-bobSwapFailuresChan
-	ht.assert.NoError(e.err)
-	ht.assert.NotNil(e.swapFailure)
-	ht.assert.Equal(e.swapFailure.PeerPubKey, net.Alice.PubKey())
-	ht.assert.Equal(e.swapFailure.FailureReason, "SwapTimedOut")
-	ht.assert.Equal(e.swapFailure.OrderId, bobOrder.Id)
-
 	// Cleanup.
 
-	removalRes, err := net.Bob.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: bobOrderReq.OrderId})
-	ht.assert.NoError(err)
-	ht.assert.NotNil(removalRes)
-	ht.assert.Equal(removalRes.QuantityOnHold, uint64(0))
-
-	removalRes, err = net.Alice.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: aliceOrderReq.OrderId})
+	removalRes, err := net.Alice.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: aliceOrderReq.OrderId})
 	ht.assert.NoError(err)
 	ht.assert.NotNil(removalRes)
 	ht.assert.Equal(removalRes.QuantityOnHold, uint64(0))
@@ -459,12 +452,57 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 		"bob Btc wallet balance mismatch (prev: %v, current: %v)", bobPrevBalance.btc.wallet.TotalBalance, bobBalance.btc.wallet.TotalBalance)
 
 	// Closing taker LTC channel and checking balance.
-	// It has no pending HTLC because the maker cancelled his invoice during his the swap recovery procedure.
-	time.Sleep(10 * time.Second) // wait a bit more for Bob to cancel the invoice.
-	err = closeLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, aliceLtcChanPoint, false)
+	// First, find the pending HTLC expiration height.
+
+	aliceLtcChanList, err := net.Alice.LndLtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
+	ht.assert.Equal(len(aliceLtcChanList.Channels), 1)
+	aliceLtcChan := aliceLtcChanList.Channels[0]
+	ht.assert.Greater(alicePrevLtcChan.LocalBalance-aliceLtcChan.LocalBalance, int64(float64(aliceOrderReq.Quantity)*aliceOrderReq.Price))
+	ht.assert.Equal(aliceLtcChan.RemoteBalance, aliceLtcChan.RemoteBalance)
+	ht.assert.Equal(len(aliceLtcChan.PendingHtlcs), 1)
+	expirationHeight = aliceLtcChan.PendingHtlcs[0].ExpirationHeight
+
+	// Expire the HTLC.
+
+	ltcInfo, err := net.LndLtcNetwork.LtcMiner.Node.GetInfo()
+	ht.assert.NoError(err)
+	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(expirationHeight - uint32(ltcInfo.Blocks))
+	ht.assert.NoError(err)
+	ltcInfo, err = net.LndLtcNetwork.LtcMiner.Node.GetInfo()
+	ht.assert.True(ltcInfo.Blocks >= int32(expirationHeight))
+
+	e := <-bobSwapFailuresChan
+	ht.assert.NoError(e.err)
+	ht.assert.NotNil(e.swapFailure)
+	ht.assert.Equal(e.swapFailure.PeerPubKey, net.Alice.PubKey())
+	ht.assert.Equal(e.swapFailure.FailureReason, "SendPaymentFailure")
+	ht.assert.Equal(e.swapFailure.OrderId, bobOrder.Id)
+
+	removalRes, err = net.Bob.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: bobOrderReq.OrderId})
+	ht.assert.NoError(err)
+	ht.assert.NotNil(removalRes)
+	ht.assert.Equal(removalRes.QuantityOnHold, uint64(0))
+
+	// Verify channel was closed (by force-close, as the outgoing HTLC got expired).
+
+	waitForChannelClose(net.Alice.LndLtcNode, ht)
+
+	// Wait for publishing CLTV-delayed HTLC output using timeout tx.
+
+	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(1)
 	ht.assert.NoError(err)
 
+	time.Sleep(5 * time.Second)
+
+	// Wait for HTLC output to be fully confirmed.
+
+	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(6)
+	ht.assert.NoError(err)
+
+	time.Sleep(35 * time.Second)
+
 	// Check balance.
+
 	onchainFeesThreshold = int64(200000)
 	aliceBalance, err := getBalance(ht.ctx, net.Alice)
 	ht.assert.NoError(err)


### PR DESCRIPTION
This prevents the maker from failing a swap due to a swap failed packet received from the taker if the maker has already started sending its payment. This is because the taker may still claim the payment, and the maker needs to continue monitoring its outgoing payment until it is certain that the payment cannot be claimed.

Fixes #1749.