### PR TITLE
fix(swaps): don't log non-existent route

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -870,7 +870,7 @@ class LndClient extends SwapClient {
     if (route) {
       this.logger.debug(`found a route to ${destination} for ${units} units with finalCltvDelta ${finalLock}: ${route}`);
     } else {
-      this.logger.debug(`could not find a route to ${destination} for ${units} units with finalCltvDelta ${finalLock}: ${route}`);
+      this.logger.debug(`could not find a route to ${destination} for ${units} units with finalCltvDelta ${finalLock}`);
     }
     return route;
   }


### PR DESCRIPTION
This fixes a log statement to not attempt to log a route when none exists, which would cause `undefined` to be logged.