### PR TITLE
test(sim): fix after latest connext upgrade 

### DIFF
--- a/.github/workflows/simtest.yml
+++ b/.github/workflows/simtest.yml
@@ -1,6 +1,6 @@
 name: Simulation tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/test/simulation/tests-integration.go
+++ b/test/simulation/tests-integration.go
@@ -323,8 +323,8 @@ func testOrderMatchingAndSwapConnext(net *xudtest.NetworkHarness, ht *harnessTes
 
 	// Verify Alice ETH balance.
 	resBal, err = net.Alice.Client.GetBalance(ht.ctx, &xudrpc.GetBalanceRequest{Currency: "ETH"})
-	ht.assert.Equal(uint64(199979000), resBal.Balances["ETH"].TotalBalance)
-	ht.assert.Equal(uint64(199978600), resBal.Balances["ETH"].WalletBalance)
+	ht.assert.Equal(uint64(199997900), resBal.Balances["ETH"].TotalBalance)
+	ht.assert.Equal(resBal.Balances["ETH"].TotalBalance-400, resBal.Balances["ETH"].WalletBalance)
 	ht.assert.Equal(uint64(400), resBal.Balances["ETH"].ChannelBalance)
 
 	// Place an order on Alice.
@@ -351,8 +351,8 @@ func testOrderMatchingAndSwapConnext(net *xudtest.NetworkHarness, ht *harnessTes
 
 	// Verify Alice ETH balance.
 	resBal, err = net.Alice.Client.GetBalance(ht.ctx, &xudrpc.GetBalanceRequest{Currency: "ETH"})
-	ht.assert.Equal(uint64(199978960), resBal.Balances["ETH"].TotalBalance)
-	ht.assert.Equal(uint64(199978600), resBal.Balances["ETH"].WalletBalance)
+	ht.assert.Equal(uint64(199997860), resBal.Balances["ETH"].TotalBalance)
+	ht.assert.Equal(resBal.Balances["ETH"].TotalBalance-360, resBal.Balances["ETH"].WalletBalance)
 	ht.assert.Equal(uint64(360), resBal.Balances["ETH"].ChannelBalance)
 
 	// Verify Bob ETH balance.

--- a/test/simulation/tests-security.go
+++ b/test/simulation/tests-security.go
@@ -460,6 +460,7 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 	// Closing taker LTC channel and checking balance.
 	// It has no pending HTLC because the maker cancelled his invoice during his the swap recovery procedure.
+	time.Sleep(10 * time.Second) // wait a bit more for Bob to cancel the invoice.
 	err = closeLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, aliceLtcChanPoint, false)
 	ht.assert.NoError(err)
 

--- a/test/simulation/xud_test.go
+++ b/test/simulation/xud_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ExchangeUnion/xud-simulation/connexttest"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -290,17 +289,11 @@ func verifyEthProviderReachability() error {
 }
 
 func verifyConnextNodeReachability() error {
-	url := connexttest.NodeURL + "/config"
-	res, err := http.Get(url)
+	res, err := http.Get(connexttest.NodeURL)
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		data, _ := ioutil.ReadAll(res.Body)
-		return fmt.Errorf("invalid response at %v: %v", url, data)
-	}
+	_ = res.Body.Close()
 
 	return nil
 }


### PR DESCRIPTION
Simulation tests got broken after latest connext upgrade (https://github.com/ExchangeUnion/xud/pull/1767).
* connext node reachability check: `http://{nodeUrl}/config` returns 404, and I didn't manage to find a different valid endpoint, but I thought that checking for a connection would be good enough. 
* Balances changed a bit due to what seems as smaller fees. 

---

This PR also changes GitHub Actions `simtest` worflow to run on `[pull_request]` instead of `[push, pull_request]`, for reducing some CI overhead.  