### PR TITLE
feat(p2p): log whether socket is inbound/outbound

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -450,6 +450,8 @@ class Pool extends EventEmitter {
       throw errors.NODE_ALREADY_CONNECTED(nodePubKey, address);
     }
 
+    this.logger.debug(`creating new outbound socket connection to ${address.host}:${address.port}`);
+
     const pendingPeer = this.pendingOutboundPeers.get(nodePubKey);
     if (pendingPeer) {
       if (revokeConnectionRetries) {
@@ -729,6 +731,8 @@ class Pool extends EventEmitter {
   }
 
   private addInbound = async (socket: Socket) => {
+    const address = addressUtils.fromSocket(socket);
+    this.logger.debug(`new inbound socket connection from ${address.host}:${address.port}`);
     const peer = Peer.fromInbound(socket, this.logger, this.network);
     this.bindPeer(peer);
     this.pendingInboundPeers.add(peer);


### PR DESCRIPTION
It's currently not clear from the logs whether new peers were created via inbound or outbound connections, this attempts to clear that up.