### PR TITLE
fix(p2p): handle multiple socket errors

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -401,19 +401,29 @@ class Peer extends EventEmitter {
 
   public sendPacket = async (packet: Packet): Promise<void> => {
     const data = await this.framer.frame(packet, this.outEncryptionKey);
-    if (this.socket && !this.socket.destroyed) {
-      try {
-        this.socket.write(data);
-        this.logger.trace(`Sent ${PacketType[packet.type]} packet to ${this.label}: ${JSON.stringify(packet)}`);
+    try {
+      await new Promise((resolve, reject) => {
+        if (this.socket && !this.socket.destroyed) {
+          this.socket.write(data, (err) => {
+            if (err) {
+              this.logger.trace(`could not send ${PacketType[packet.type]} packet to ${this.label}: ${JSON.stringify(packet)}`);
+              reject(err);
+            } else {
+              this.logger.trace(`Sent ${PacketType[packet.type]} packet to ${this.label}: ${JSON.stringify(packet)}`);
 
-        if (packet.direction === PacketDirection.Request) {
-          this.addResponseTimeout(packet.header.id, packet.responseType, Peer.RESPONSE_TIMEOUT);
+              if (packet.direction === PacketDirection.Request) {
+                this.addResponseTimeout(packet.header.id, packet.responseType, Peer.RESPONSE_TIMEOUT);
+              }
+              resolve();
+            }
+          });
+        } else {
+          this.logger.warn(`could not send packet to ${this.label} because socket is nonexistent or destroyed`);
+          resolve();
         }
-      } catch (err) {
-        this.logger.error(`failed sending data to ${this.label}`, err);
-      }
-    } else {
-      this.logger.trace(`could not send ${PacketType[packet.type]} packet to ${this.label}: ${JSON.stringify(packet)}`);
+      });
+    } catch (err) {
+      this.logger.error(`failed sending data to ${this.label}`, err);
     }
   }
 

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -340,6 +340,7 @@ class Peer extends EventEmitter {
     this.status = PeerStatus.Closed;
 
     if (this.socket) {
+      this.socket.removeAllListeners();
       if (!this.socket.destroyed) {
         if (reason !== undefined) {
           this.logger.debug(`Peer ${this.label}: closing socket. reason: ${DisconnectionReason[reason]}`);
@@ -724,11 +725,11 @@ class Peer extends EventEmitter {
   private bindSocket = () => {
     assert(this.socket);
 
-    this.socket.once('error', (err) => {
+    this.socket.on('error', (err) => {
       this.logger.error(`Peer (${this.label}) error`, err);
     });
 
-    this.socket.once('close', async (hadError) => {
+    this.socket.on('close', async (hadError) => {
       // emitted once the socket is fully closed
       if (this.nodePubKey === undefined) {
         this.logger.info(`Socket closed prior to handshake with ${this.label}`);


### PR DESCRIPTION
Fixes #1773

This changes the peer socket error handling to use `on` instead of `once` when listening for `error` events to ensure that an unexpected second `error` event doesn't crash xud after the `once` handler stops listening. Instead we use `on` to listen to all error events and then manually remove all listeners from the socket after it's destroyed.

This also adds a callback to handle errors from the `socket.write` function when sending packets to peers. Previously we would not specify a callback at all, and errors would only get handled by the generic `socket.on('error')` event handler.


