### PR TITLE
fix(p2p): remove socket listeners after destroy

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -340,7 +340,6 @@ class Peer extends EventEmitter {
     this.status = PeerStatus.Closed;
 
     if (this.socket) {
-      this.socket.removeAllListeners();
       if (!this.socket.destroyed) {
         if (reason !== undefined) {
           this.logger.debug(`Peer ${this.label}: closing socket. reason: ${DisconnectionReason[reason]}`);
@@ -349,6 +348,7 @@ class Peer extends EventEmitter {
         }
 
         this.socket.destroy();
+        this.socket.removeAllListeners();
       }
       delete this.socket;
     }
@@ -555,7 +555,7 @@ class Peer extends EventEmitter {
         } else {
           this.socket = net.connect(this.address.port, this.address.host);
           this.socket.once('connect', onConnect);
-          this.socket.once('error', onError);
+          this.socket.on('error', onError);
         }
       };
 


### PR DESCRIPTION
This ensures we don't remove listeners from the peer TCP socket before the socket is destroyed. This prevents edge case errors where a socket emits an error in the split second before it is destroyed.

This is a follow-up to #1777 - it's something I encountered just now when running tests repeatedly locally and hitting an occasional unhandled error - but I was a few minutes too late with pushing a fix for it to the PR branch before it was merged.