### PR TITLE
feat(connext): request collateral after deposit

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -591,6 +591,13 @@ class ConnextClient extends SwapClient {
       assetId,
       amount: BigInt(units).toString(),
     });
+    this.sendRequest('/request-collateral', 'POST', {
+      assetId,
+    }).then(() => {
+      this.logger.verbose(`collateralized channel for ${currency}`);
+    }).catch((err) => {
+      this.logger.error(`failed requesting collateral for ${currency}`, err);
+    });
   }
 
   public closeChannel = async ({ units, currency, destination }: CloseChannelParams): Promise<void> => {


### PR DESCRIPTION
This calls the new `/request-collateral` endpoint after depositing funds to a connext channel. We do not await a response from `/request-collateral` but rather allow it to complete asynchronously after the `/deposit` call finishes.

Closes #1756.