### PR TITLE
fix(rpc): don't block TradingLimits on failure

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -168,7 +168,7 @@ class Service {
     return balances;
   }
 
-  /** Gets the trading limits (max outbound and inbound capacities for a distinct channel) for a given currency. */
+  /** Gets the trading limits (max outbound and inbound capacities for a distinct channel) for one or all currencies. */
   public tradingLimits = async (args: { currency: string }) => {
     const { currency } = args;
     const tradingLimitsMap = new Map<string, TradingLimits>();
@@ -189,7 +189,7 @@ class Service {
         if (swapClient.isConnected()) {
           promises.push(swapClient.tradingLimits(currency).then((tradingLimits) => {
             tradingLimitsMap.set(currency, tradingLimits);
-          }));
+          }).catch(this.logger.error));
         }
       });
       await Promise.all(promises);


### PR DESCRIPTION
This doesn't fail the entire `TradingLimits` call when a subset of the swap clients hit an error when checking their inbound/outbound capacity. If we get an error for one client, we will log it but still return limits from other clients.

Fixes #1766. This is a similar change/fix as what #1736 did for the `GetBalance` call.