### PR TITLE
feat(orderbook): prevent sub-satoshi order & match

### DIFF
--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -353,6 +353,9 @@ class TradingPair {
       if (matchingQuantity <= 0) {
         // there's no match with the best available maker order, so end the matching routine
         break;
+      } else if (makerOrder.quantity * makerOrder.price < 1) {
+        // there's a match but it doesn't meet the 1 satoshi minimum on both sides of the trade
+        break;
       } else {
         /** Whether the maker order is fully matched and should be removed from the queue. */
         const makerFullyMatched = makerOrder.quantity === matchingQuantity;

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -67,8 +67,8 @@ const errors = {
     message: `${currency} outbound balance of ${availableAmount} is not sufficient for order amount of ${amount}`,
     code: errorCodes.INSUFFICIENT_OUTBOUND_BALANCE,
   }),
-  MIN_QUANTITY_VIOLATED: (id: string) => ({
-    message: `order ${id} has surpassed the minimum quantity`,
+  MIN_QUANTITY_VIOLATED: (quantity: number, currency: string) => ({
+    message: `order does not meet the minimum ${currency} quantity of ${quantity} satoshis`,
     code: errorCodes.MIN_QUANTITY_VIOLATED,
   }),
   QUANTITY_ON_HOLD: (localId: string, holdQuantity: number) => ({

--- a/lib/orderbook/types.ts
+++ b/lib/orderbook/types.ts
@@ -38,7 +38,7 @@ export enum PlaceOrderEventType {
 
 /** An order without a price that is intended to match against any available orders on the opposite side of the book for its trading pair. */
 type MarketOrder = {
-  /** The number of currently satoshis (or equivalent) for the order. */
+  /** The quantity denominated in satoshis (or equivalent) for the order. */
   quantity: number;
   /** A trading pair symbol with the base currency first followed by a '/' separator and the quote currency */
   pairId: string;

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -108,7 +108,7 @@ describe('OrderBook', () => {
   });
 
   it('should append two new ownOrder', async () => {
-    const order = { pairId: PAIR_ID, quantity: 5, price: 55, isBuy: true, hold: 0 };
+    const order = { pairId: PAIR_ID, quantity: 500, price: 55, isBuy: true, hold: 0 };
     const { remainingOrder } = await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
     expect(remainingOrder).to.not.be.undefined;
     expect(orderBook.getOwnOrder(remainingOrder!.id, PAIR_ID)).to.not.be.undefined;
@@ -116,7 +116,7 @@ describe('OrderBook', () => {
   });
 
   it('should fully match new ownOrder and remove matches', async () => {
-    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 6, price: 55, isBuy: false, hold: 0 };
+    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 600, price: 55, isBuy: false, hold: 0 };
     const matches = await orderBook.placeLimitOrder(order);
     expect(matches.remainingOrder).to.be.undefined;
 
@@ -129,11 +129,11 @@ describe('OrderBook', () => {
     const secondMakerOrder = getOwnOrder(secondMatch);
     expect(firstMakerOrder).to.be.undefined;
     expect(secondMakerOrder).to.not.be.undefined;
-    expect(secondMakerOrder!.quantity).to.equal(4);
+    expect(secondMakerOrder!.quantity).to.equal(400);
   });
 
   it('should partially match new market order and discard remaining order', async () => {
-    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 10, isBuy: false, hold: 0 };
+    const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 1000, isBuy: false, hold: 0 };
     const result = await orderBook.placeMarketOrder(order);
     const match = result.internalMatches[0];
     expect(result.remainingOrder).to.be.undefined;
@@ -141,15 +141,15 @@ describe('OrderBook', () => {
   });
 
   it('should create, partially match, and remove an order', async () => {
-    const order: orders.OwnOrder = createOwnOrder(10, 10, true);
+    const order: orders.OwnOrder = createOwnOrder(10, 1000, true);
     await orderBook.placeLimitOrder(order);
-    const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 5, isBuy: false };
+    const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 500, isBuy: false };
     await orderBook.placeMarketOrder(takerOrder);
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
   });
 
   it('should not add a new own order with a duplicated localId', async () => {
-    const order: orders.OwnOrder = createOwnOrder(0.01, 10, false);
+    const order: orders.OwnOrder = createOwnOrder(0.01, 1000, false);
 
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
 
@@ -216,53 +216,53 @@ describe('nomatching OrderBook', () => {
   });
 
   it('should should not accept market orders', () => {
-    const order = createOwnOrder(0.01, 10, true);
+    const order = createOwnOrder(0.01, 1000, true);
     expect(orderBook.placeMarketOrder(order)).to.be.rejected;
   });
 
   it('should accept but not match limit orders', async () => {
-    const buyOrder = createOwnOrder(0.01, 10, true);
+    const buyOrder = createOwnOrder(0.01, 1000, true);
     const buyOrderResult = await orderBook.placeLimitOrder(buyOrder);
     expect(buyOrderResult.remainingOrder!.localId).to.be.equal(buyOrder.localId);
     expect(buyOrderResult.remainingOrder!.quantity).to.be.equal(buyOrder.quantity);
 
-    const sellOrder = createOwnOrder(0.01, 10, false);
+    const sellOrder = createOwnOrder(0.01, 1000, false);
     const sellOrderResult = await orderBook.placeLimitOrder(sellOrder);
     expect(sellOrderResult.remainingOrder!.localId).to.be.equal(sellOrder.localId);
     expect(sellOrderResult.remainingOrder!.quantity).to.be.equal(sellOrder.quantity);
   });
 
   it('should not place the same order twice', async () => {
-    const order = createOwnOrder(0.01, 10, true);
+    const order = createOwnOrder(0.01, 1000, true);
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
     await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
   });
 
   it('should not remove the same order twice', async () => {
-    const order = createOwnOrder(0.01, 10, true);
+    const order = createOwnOrder(0.01, 1000, true);
     await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
   });
 
   it('should allow own order partial removal, but should not find the order localId after it was fully removed', async () => {
-    const order = createOwnOrder(0.01, 10, true);
+    const order = createOwnOrder(0.01, 1000, true);
     const { remainingOrder } = await orderBook.placeLimitOrder(order);
 
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 1);
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 1);
+    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 100);
+    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100);
 
-    expect(() => orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 1)).to.throw;
+    expect(() => orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100)).to.throw;
   });
 
   it('should allow own order partial removal, but should not find the order id after it was fully removed', async () => {
-    const order = createOwnOrder(0.01, 10, true);
+    const order = createOwnOrder(0.01, 1000, true);
     const { remainingOrder } = await orderBook.placeLimitOrder(order);
 
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 1);
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 1);
+    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 100);
+    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100);
 
-    expect(() => orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 1)).to.throw;
+    expect(() => orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100)).to.throw;
   });
 
   describe('stampOwnOrder', () => {
@@ -270,7 +270,7 @@ describe('nomatching OrderBook', () => {
       return {
         pairId: 'LTC/BTC',
         price: 0.008,
-        quantity: 1000,
+        quantity: 100000,
         isBuy: false,
         localId: '',
         hold: 0,

--- a/test/unit/TradingPair.spec.ts
+++ b/test/unit/TradingPair.spec.ts
@@ -152,11 +152,11 @@ describe('TradingPair.match', () => {
   });
 
   it('should split taker order when makers are insufficient', () => {
-    tp.addPeerOrder(createPeerOrder(5, 4, false));
-    tp.addPeerOrder(createPeerOrder(5, 5, false));
-    const { remainingOrder } = tp.match(createOwnOrder(5, 10, true));
+    tp.addPeerOrder(createPeerOrder(5, 40, false));
+    tp.addPeerOrder(createPeerOrder(5, 50, false));
+    const { remainingOrder } = tp.match(createOwnOrder(5, 100, true));
     expect(remainingOrder).to.not.be.undefined;
-    expect(remainingOrder!.quantity).to.equal(1);
+    expect(remainingOrder!.quantity).to.equal(10);
   });
 
   it('should split one maker order when taker is insufficient', () => {
@@ -246,11 +246,11 @@ describe('TradingPair.removePeerOrders', () => {
     const firstPeerPubKey = '026a848ebd1792001ff10c6e212f6077aec5669af3de890e1ae196b4e9730d75b9';
     const secondPeerPubKey = '029a96c975d301c1c8787fcb4647b5be65a3b8d8a70153ff72e3eac73759e5e345';
 
-    const firstHostOrders = [createPeerOrder(0.01, 5, false, ms(), firstPeerPubKey),
-      createPeerOrder(0.01, 5, false, ms(), firstPeerPubKey)];
+    const firstHostOrders = [createPeerOrder(0.01, 500, false, ms(), firstPeerPubKey),
+      createPeerOrder(0.01, 500, false, ms(), firstPeerPubKey)];
     tp.addPeerOrder(firstHostOrders[0]);
     tp.addPeerOrder(firstHostOrders[1]);
-    tp.addPeerOrder(createPeerOrder(0.01, 5, false, ms(), secondPeerPubKey));
+    tp.addPeerOrder(createPeerOrder(0.01, 500, false, ms(), secondPeerPubKey));
     expect(tp.getPeersOrders().sellArray.length).to.equal(3);
 
     const removedOrders = tp.removePeerOrders(firstPeerPubKey);
@@ -259,9 +259,9 @@ describe('TradingPair.removePeerOrders', () => {
     expect(tp.queues!.sellQueue.size).to.equal(1);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const matchingResult = tp.match(createOwnOrder(0.01, 15, true));
+    const matchingResult = tp.match(createOwnOrder(0.01, 1500, true));
     expect(matchingResult.remainingOrder).to.not.be.undefined;
-    expect(matchingResult.remainingOrder!.quantity).to.equal(10);
+    expect(matchingResult.remainingOrder!.quantity).to.equal(1000);
   });
 
   it('should add a new peerOrder and then remove it partially', () => {
@@ -319,41 +319,41 @@ describe('TradingPair queues and maps integrity', () => {
   });
 
   it('queue and map should have the same order instance after a partial peer order removal', () => {
-    const peerOrder = createPeerOrder(0.01, 10, false, ms());
+    const peerOrder = createPeerOrder(0.01, 1000, false, ms());
     tp.addPeerOrder(peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const removeResult = tp.removePeerOrder(peerOrder.id, peerOrder.peerPubKey, 3);
-    expect(removeResult.order.quantity).to.equal(3);
+    const removeResult = tp.removePeerOrder(peerOrder.id, peerOrder.peerPubKey, 300);
+    expect(removeResult.order.quantity).to.equal(300);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
     const listRemainingOrder = tp.getPeerOrder(peerOrder.id, peerOrder.peerPubKey);
     const queueRemainingOrder = tp.queues!.sellQueue.peek();
-    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(7);
+    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(700);
     expect(listRemainingOrder).to.equal(queueRemainingOrder);
   });
 
   it('queue and map should have the same order instance after a partial match / maker order split', () => {
-    const peerOrder = createPeerOrder(0.01, 10, false, ms());
+    const peerOrder = createPeerOrder(0.01, 1000, false, ms());
     tp.addPeerOrder(peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const ownOrder = createOwnOrder(0.01, 3, true);
+    const ownOrder = createOwnOrder(0.01, 300, true);
     const matchingResult = tp.match(ownOrder);
     expect(matchingResult.remainingOrder).to.be.undefined;
 
     const listRemainingOrder = tp.getPeerOrder(peerOrder.id, peerOrder.peerPubKey);
     const queueRemainingOrder = tp.queues!.sellQueue.peek();
-    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(7);
+    expect(listRemainingOrder && listRemainingOrder.quantity).to.equal(700);
     expect(listRemainingOrder).to.equal(queueRemainingOrder);
   });
 
   it('queue and map should both have the maker order removed after a full match', () => {
-    const peerOrder = createPeerOrder(0.01, 10, false, ms());
+    const peerOrder = createPeerOrder(0.01, 1000, false, ms());
     tp.addPeerOrder(peerOrder);
     expect(tp.getPeersOrders().sellArray.length).to.equal(1);
 
-    const ownOrder = createOwnOrder(0.01, 10, true);
+    const ownOrder = createOwnOrder(0.01, 1000, true);
     const matchingResult = tp.match(ownOrder);
     expect(matchingResult.remainingOrder).to.be.undefined;
 


### PR DESCRIPTION
This prevents xud from accepting and matching orders that would result in less than a full satoshi from being exchanged for both currencies involved in the swap. It does this three ways:

1. Preventing limit orders from being placed locally that do not meet the satoshi requirement.

2. Preventing peer orders from being added to the order book if they do not meet the satoshi requirement.

3. Preventing matches that do not meet the satoshi requirement, this is needed for handling locally placed market orders since they do not have a price assigned to them until they match with an order.

It is still possible for "dust" orders that cannot be traded to get stuck in the orderbook if they are partially removed or matched leaving a tiny fraction behind. A follow-up PR can automatically remove these.

Closes #1594.