### PR TITLE
test: fix openPeer await

### DIFF
--- a/test/integration/Pool.spec.ts
+++ b/test/integration/Pool.spec.ts
@@ -71,8 +71,10 @@ describe('P2P Pool Tests', async () => {
     const peer = createPeer(nodeKeyOne.pubKey, addresses);
 
     const openPromise = pool['openPeer'](peer, nodeKeyOne.pubKey);
-    expect(openPromise).to.be.fulfilled;
-    await openPromise;
+    await Promise.all([
+      openPromise,
+      new Promise(resolve => pool.on('peer.active', resolve)),
+    ]);
   });
 
   it('should close a peer', async () => {
@@ -91,7 +93,10 @@ describe('P2P Pool Tests', async () => {
     const addresses = [{ host: '86.75.30.9', port: 8885 }];
     const peer = createPeer(nodeKeyOne.pubKey, addresses);
 
-    await pool['openPeer'](peer, nodeKeyOne.pubKey);
+    await Promise.all([
+      await pool['openPeer'](peer, nodeKeyOne.pubKey),
+      new Promise(resolve => pool.on('peer.active', resolve)),
+    ]);
 
     const nodeInstance = await db.models.Node.findOne({
       where: {
@@ -114,8 +119,10 @@ describe('P2P Pool Tests', async () => {
       tryConnectNodeStub = sinon.stub();
       pool['tryConnectNode'] = tryConnectNodeStub;
       const openPromise = pool['openPeer'](dcPeer, nodeKeyOne.pubKey);
-      expect(openPromise).to.be.fulfilled;
-      await openPromise;
+      await Promise.all([
+        openPromise,
+        new Promise(resolve => pool.on('peer.active', resolve)),
+      ]);
     });
 
     it('should not reconnect upon shutdown inbound', async () => {


### PR DESCRIPTION
This fixes test flakiness with the mocha integration tests by ensuring that we wait for all follow-up actions to an opened peer to occur before continuing with test cases that may rely on those follow-up actions, such as database writes.

I'm going to restart the github actions tests several times to ensure we don't see the test failures this aims to fix.