### PR TITLE
fix(unitconverter): USDT unit conversion

### DIFF
--- a/lib/utils/UnitConverter.ts
+++ b/lib/utils/UnitConverter.ts
@@ -4,7 +4,7 @@ class UnitConverter {
     BTC: 1,
     LTC: 1,
     ETH: 10 ** 10,
-    USDT: 10 ** 10,
+    USDT: 10 ** -2,
     WETH: 10 ** 10,
     DAI: 10 ** 10,
     XUC: 10 ** 10,


### PR DESCRIPTION
This fixes the USDT unit conversion to reflect the mainnet USDT contract which only uses 6 decimal places instead of 18.