### PR TITLE
test(sim): auto retry, safer free ports

### DIFF
--- a/.github/workflows/simtest.yml
+++ b/.github/workflows/simtest.yml
@@ -1,6 +1,10 @@
 name: Simulation tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/test/simulation/connexttest/client.go
+++ b/test/simulation/connexttest/client.go
@@ -3,6 +3,7 @@ package connexttest
 import (
 	"bytes"
 	"fmt"
+	"github.com/ExchangeUnion/xud-simulation/shared"
 	"io"
 	"os"
 	"os/exec"
@@ -11,8 +12,6 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
-
-	"github.com/phayes/freeport"
 )
 
 var numActiveNodes int32
@@ -63,7 +62,7 @@ func newClient(name, path, ethProviderURL, nodeURL string) (*HarnessClient, erro
 		return nil, err
 	}
 
-	port, err := freeport.GetFreePort()
+	port, err := shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}

--- a/test/simulation/docker-run.sh
+++ b/test/simulation/docker-run.sh
@@ -10,11 +10,25 @@ popd
 
 export DOCKER_CLIENT_TIMEOUT=120
 export COMPOSE_HTTP_TIMEOUT=120
-docker-compose run -v $PWD/temp/logs:/app/temp/logs test go test -v -timeout 30m -run=$@
-retVal=$?
+testCmd="docker-compose run -v $PWD/temp/logs:/app/temp/logs test go test -v -timeout 30m -run=$@"
+eval $testCmd
+testRetCode=$?
+
+if [[ $testRetCode != 0 ]]; then
+    for i in 1 2 3; do
+        printf "\ndocker-run.sh: test failed, re-running... ($i/3)\n\n"
+
+        eval $testCmd
+        testRetCode=$?
+
+        if [[ $testRetCode == 0 ]]; then
+            break
+        fi
+    done
+fi
 
 pushd temp/indra
 make reset
 popd
 
-exit $retVal
+exit $testRetCode

--- a/test/simulation/lntest/node.go
+++ b/test/simulation/lntest/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"github.com/ExchangeUnion/xud-simulation/shared"
 	"io"
 	"io/ioutil"
 	"net"
@@ -23,7 +24,6 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
-	"github.com/phayes/freeport"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/wire"
 )
@@ -195,15 +195,15 @@ func newNode(cfg nodeConfig) (*HarnessNode, error) {
 	cfg.ReadMacPath = filepath.Join(cfg.DataDir, "readonly.macaroon")
 	cfg.InvoiceMacPath = filepath.Join(cfg.DataDir, "invoice.macaroon")
 
-	cfg.P2PPort, err = freeport.GetFreePort()
+	cfg.P2PPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}
-	cfg.RPCPort, err = freeport.GetFreePort()
+	cfg.RPCPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}
-	cfg.RESTPort, err = freeport.GetFreePort()
+	cfg.RESTPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}

--- a/test/simulation/shared/freeport.go
+++ b/test/simulation/shared/freeport.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"errors"
+	"github.com/phayes/freeport"
+	"sync"
+)
+
+var prevPorts = make(map[int]bool)
+var freePortMtx sync.Mutex
+
+func GetFreePort() (int, error) {
+	freePortMtx.Lock()
+	defer freePortMtx.Unlock()
+
+	for i := 0; i < 10; i++ {
+		port, err := freeport.GetFreePort()
+		if err != nil {
+			return 0, err
+		}
+
+		if !prevPorts[port] {
+			prevPorts[port] = true
+			return port, nil
+		}
+	}
+
+	return 0, errors.New("failed getting a new port")
+}

--- a/test/simulation/xudtest/node.go
+++ b/test/simulation/xudtest/node.go
@@ -3,6 +3,7 @@ package xudtest
 import (
 	"bytes"
 	"fmt"
+	"github.com/ExchangeUnion/xud-simulation/shared"
 	"net"
 	"os"
 	"os/exec"
@@ -19,7 +20,6 @@ import (
 	"github.com/ExchangeUnion/xud-simulation/lntest"
 	"github.com/ExchangeUnion/xud-simulation/xudrpc"
 	"github.com/go-errors/errors"
-	"github.com/phayes/freeport"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -165,21 +165,21 @@ func newNode(name string, xudPath string, noBalanceChecks bool) (*HarnessNode, e
 	cfg.LogPath = fmt.Sprintf("./temp/logs/xud-%s-%d.log", name, epoch)
 
 	cfg.TLSCertPath = filepath.Join(cfg.DataDir, "tls.cert")
-	cfg.P2PPort, err = freeport.GetFreePort()
+	cfg.P2PPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}
-	cfg.RPCPort, err = freeport.GetFreePort()
+	cfg.RPCPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}
-	cfg.HTTPPort, err = freeport.GetFreePort()
+	cfg.HTTPPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}
 
 	cfg.RaidenHost = "127.0.0.1"
-	cfg.RaidenPort, err = freeport.GetFreePort()
+	cfg.RaidenPort, err = shared.GetFreePort()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introducing changes for improving simtests stability.

* Retry tests after failure (up to 3 times).
We discussed that this should be done only after unique failures, but after spending some time on that and trying different ways to capture stdout/stderr for comparison, my conclusion is that it won't be stable enough, especially if we'll do it from the bash script, and dealing with `docker-compose` output (which isn't very consistent).
Doing that from within the test code is better, but involves with some issues: 1) logging the output in real-time and capturing it at the same time isn't very straightforward, and 2) we still sometimes log data with some uniqueness, and trying to enforce the test code to not do that isn't worthwhile IMO.
So I ended up doing 3 re-runs after every failure, and the downside of that is that if we have a genuine/consistent failure, the last 2 retries could have been avoided.
* Wrapping `phayes/freeport` util with some additional thread safety code and checking of ports re-use.

In addition, returning the tests to run on `master` branch CI (on `push` event). We previously removed `push` so that it won't need to run twice on every PR, but it caused the tests to be left out of `master` CI.

