### PR TITLE
fix: restrict reputation events in non-strict mode

### DIFF
--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -1220,7 +1220,7 @@ class Swaps extends EventEmitter {
       case SwapFailureReason.SendPaymentFailure:
       case SwapFailureReason.NoRouteFound:
         // something is wrong with swaps for this currency with this peer
-        if (failedCurrency && !this.strict) { // only deactivate currencies due to failed swaps in strict mode
+        if (failedCurrency && this.strict) { // only deactivate currencies due to failed swaps in strict mode
           try {
             this.pool.getPeer(deal.peerPubKey).deactivateCurrency(failedCurrency);
           } catch (err) {

--- a/test/integration/Swaps.spec.ts
+++ b/test/integration/Swaps.spec.ts
@@ -85,7 +85,7 @@ describe('Swaps.Integration', () => {
     peer.getIdentifier = () => '1234567890';
     // pool
     pool = sandbox.createStubInstance(Pool) as any;
-    pool.addReputationEvent = () => Promise.resolve(true);
+    pool.addReputationEvent = () => Promise.resolve();
     pool.getPeer = () => peer;
     pool.tryGetPeer = () => peer;
     // getRoute response


### PR DESCRIPTION
This ensures we only add severe and manual reputation events to peers when not running in strict mode by filtering both events that arise from the peer itself as well as those originating from other sources, such as failed swaps. Previously we only checked on events arising from the peer, which, for example, would include packet delays but not a failure to find routes.

Fixes #1802