### PR TITLE
feat(p2p): replace order in single packet

### DIFF
--- a/lib/orderbook/types.ts
+++ b/lib/orderbook/types.ts
@@ -99,7 +99,9 @@ export type PeerOrder = LimitOrder & Stamp & Remote;
 export type Order = OwnOrder | PeerOrder;
 
 /** An outgoing local order which only includes fields that are relevant to peers. */
-export type OutgoingOrder = Pick<OwnOrder, Exclude<keyof OwnOrder, 'localId' | 'createdAt' | 'hold' | 'initialQuantity'>>;
+export type OutgoingOrder = Pick<OwnOrder, Exclude<keyof OwnOrder, 'localId' | 'createdAt' | 'hold' | 'initialQuantity'>> & {
+  replaceOrderId?: string;
+};
 
 /** An incoming peer order which only includes fields that are relevant to us. */
 export type IncomingOrder = OutgoingOrder & Remote;
@@ -108,6 +110,11 @@ export type IncomingOrder = OutgoingOrder & Remote;
 export type OrderPortion = OrderIdentifier & {
   quantity: number;
   localId?: string;
+};
+
+export type OrderInvalidation = OrderIdentifier & {
+  /** The quantity of the order being removed, or the entire order if quantity is undefined */
+  quantity?: number;
 };
 
 export type Currency = {

--- a/lib/p2p/packets/types/OrderPacket.ts
+++ b/lib/p2p/packets/types/OrderPacket.ts
@@ -42,6 +42,7 @@ class OrderPacket extends Packet<OutgoingOrder> {
         price: obj.order!.price,
         quantity: obj.order!.quantity,
         isBuy: obj.order!.isBuy,
+        replaceOrderId: obj.order!.replaceOrderId || undefined,
       },
     });
   }
@@ -53,6 +54,9 @@ class OrderPacket extends Packet<OutgoingOrder> {
     pbOrder.setPrice(this.body!.price);
     pbOrder.setQuantity(this.body!.quantity);
     pbOrder.setIsBuy(this.body!.isBuy);
+    if (this.body?.replaceOrderId) {
+      pbOrder.setReplaceOrderId(this.body.replaceOrderId);
+    }
 
     const msg = new pb.OrderPacket();
     msg.setId(this.header.id);

--- a/lib/proto/xudp2p_pb.d.ts
+++ b/lib/proto/xudp2p_pb.d.ts
@@ -46,6 +46,9 @@ export class Order extends jspb.Message {
     getIsBuy(): boolean;
     setIsBuy(value: boolean): void;
 
+    getReplaceOrderId(): string;
+    setReplaceOrderId(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): Order.AsObject;
@@ -64,6 +67,7 @@ export namespace Order {
         price: number,
         quantity: number,
         isBuy: boolean,
+        replaceOrderId: string,
     }
 }
 

--- a/lib/proto/xudp2p_pb.js
+++ b/lib/proto/xudp2p_pb.js
@@ -253,7 +253,8 @@ proto.xudp2p.Order.toObject = function(includeInstance, msg) {
     pairId: jspb.Message.getFieldWithDefault(msg, 2, ""),
     price: +jspb.Message.getFieldWithDefault(msg, 3, 0.0),
     quantity: jspb.Message.getFieldWithDefault(msg, 4, 0),
-    isBuy: jspb.Message.getFieldWithDefault(msg, 5, false)
+    isBuy: jspb.Message.getFieldWithDefault(msg, 5, false),
+    replaceOrderId: jspb.Message.getFieldWithDefault(msg, 6, "")
   };
 
   if (includeInstance) {
@@ -309,6 +310,10 @@ proto.xudp2p.Order.deserializeBinaryFromReader = function(msg, reader) {
     case 5:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setIsBuy(value);
+      break;
+    case 6:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setReplaceOrderId(value);
       break;
     default:
       reader.skipField();
@@ -371,6 +376,13 @@ proto.xudp2p.Order.serializeBinaryToWriter = function(message, writer) {
   if (f) {
     writer.writeBool(
       5,
+      f
+    );
+  }
+  f = message.getReplaceOrderId();
+  if (f.length > 0) {
+    writer.writeString(
+      6,
       f
     );
   }
@@ -451,6 +463,21 @@ proto.xudp2p.Order.prototype.getIsBuy = function() {
 /** @param {boolean} value */
 proto.xudp2p.Order.prototype.setIsBuy = function(value) {
   jspb.Message.setProto3BooleanField(this, 5, value);
+};
+
+
+/**
+ * optional string replace_order_id = 6;
+ * @return {string}
+ */
+proto.xudp2p.Order.prototype.getReplaceOrderId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/** @param {string} value */
+proto.xudp2p.Order.prototype.setReplaceOrderId = function(value) {
+  jspb.Message.setProto3StringField(this, 6, value);
 };
 
 

--- a/proto/xudp2p.proto
+++ b/proto/xudp2p.proto
@@ -13,6 +13,7 @@ message Order {
     double price = 3;
     uint64 quantity = 4;
     bool is_buy = 5;
+    string replace_order_id = 6;
 }
 
 message Node {

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -109,15 +109,15 @@ describe('OrderBook', () => {
 
   it('should append two new ownOrder', async () => {
     const order = { pairId: PAIR_ID, quantity: 500, price: 55, isBuy: true, hold: 0 };
-    const { remainingOrder } = await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
+    const { remainingOrder } = await orderBook.placeLimitOrder({ order: { localId: uuidv1(), ...order } });
     expect(remainingOrder).to.not.be.undefined;
     expect(orderBook.getOwnOrder(remainingOrder!.id, PAIR_ID)).to.not.be.undefined;
-    await orderBook.placeLimitOrder({ localId: uuidv1(), ...order });
+    await orderBook.placeLimitOrder({ order: { localId: uuidv1(), ...order } });
   });
 
   it('should fully match new ownOrder and remove matches', async () => {
     const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 600, price: 55, isBuy: false, hold: 0 };
-    const matches = await orderBook.placeLimitOrder(order);
+    const matches = await orderBook.placeLimitOrder({ order });
     expect(matches.remainingOrder).to.be.undefined;
 
     const firstMatch = matches.internalMatches[0];
@@ -134,7 +134,7 @@ describe('OrderBook', () => {
 
   it('should partially match new market order and discard remaining order', async () => {
     const order = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 1000, isBuy: false, hold: 0 };
-    const result = await orderBook.placeMarketOrder(order);
+    const result = await orderBook.placeMarketOrder({ order });
     const match = result.internalMatches[0];
     expect(result.remainingOrder).to.be.undefined;
     expect(getOwnOrder(match)).to.be.undefined;
@@ -142,39 +142,39 @@ describe('OrderBook', () => {
 
   it('should create, partially match, and remove an order', async () => {
     const order: orders.OwnOrder = createOwnOrder(10, 1000, true);
-    await orderBook.placeLimitOrder(order);
+    await orderBook.placeLimitOrder({ order });
     const takerOrder: orders.OwnMarketOrder = { pairId: 'LTC/BTC', localId: uuidv1(), quantity: 500, isBuy: false };
-    await orderBook.placeMarketOrder(takerOrder);
+    await orderBook.placeMarketOrder({ order: takerOrder });
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
   });
 
   it('should not add a new own order with a duplicated localId', async () => {
     const order: orders.OwnOrder = createOwnOrder(0.01, 1000, false);
 
-    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.fulfilled;
 
-    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.rejected;
 
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
 
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
 
-    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.fulfilled;
 
-    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.rejected;
   });
 
   it('should place order with quantity higher than min quantity', async () => {
     orderBook['thresholds'] = { minQuantity : 10000 };
     const order: orders.OwnOrder = createOwnOrder(0.01, 1000000, false);
 
-    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.fulfilled;
   });
 
   it('should throw error if the order quantity exceeds min quantity', async () => {
     const order: orders.OwnOrder = createOwnOrder(0.01, 100, false);
 
-    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.rejected;
   });
 
   after(async () => {
@@ -217,52 +217,76 @@ describe('nomatching OrderBook', () => {
 
   it('should should not accept market orders', () => {
     const order = createOwnOrder(0.01, 1000, true);
-    expect(orderBook.placeMarketOrder(order)).to.be.rejected;
+    expect(orderBook.placeMarketOrder({ order })).to.be.rejected;
   });
 
   it('should accept but not match limit orders', async () => {
     const buyOrder = createOwnOrder(0.01, 1000, true);
-    const buyOrderResult = await orderBook.placeLimitOrder(buyOrder);
+    const buyOrderResult = await orderBook.placeLimitOrder({ order: buyOrder });
     expect(buyOrderResult.remainingOrder!.localId).to.be.equal(buyOrder.localId);
     expect(buyOrderResult.remainingOrder!.quantity).to.be.equal(buyOrder.quantity);
 
     const sellOrder = createOwnOrder(0.01, 1000, false);
-    const sellOrderResult = await orderBook.placeLimitOrder(sellOrder);
+    const sellOrderResult = await orderBook.placeLimitOrder({ order: sellOrder });
     expect(sellOrderResult.remainingOrder!.localId).to.be.equal(sellOrder.localId);
     expect(sellOrderResult.remainingOrder!.quantity).to.be.equal(sellOrder.quantity);
   });
 
   it('should not place the same order twice', async () => {
     const order = createOwnOrder(0.01, 1000, true);
-    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
-    await expect(orderBook.placeLimitOrder(order)).to.be.rejected;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.rejected;
   });
 
   it('should not remove the same order twice', async () => {
     const order = createOwnOrder(0.01, 1000, true);
-    await expect(orderBook.placeLimitOrder(order)).to.be.fulfilled;
+    await expect(orderBook.placeLimitOrder({ order })).to.be.fulfilled;
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.not.throw();
     expect(() => orderBook.removeOwnOrderByLocalId(order.localId)).to.throw();
   });
 
   it('should allow own order partial removal, but should not find the order localId after it was fully removed', async () => {
     const order = createOwnOrder(0.01, 1000, true);
-    const { remainingOrder } = await orderBook.placeLimitOrder(order);
+    const { remainingOrder } = await orderBook.placeLimitOrder({ order });
 
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 100);
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100);
+    orderBook['removeOwnOrder']({
+      orderId: remainingOrder!.id,
+      pairId: order.pairId,
+      quantityToRemove: remainingOrder!.quantity - 100,
+    });
+    orderBook['removeOwnOrder']({
+      orderId: remainingOrder!.id,
+      pairId: order.pairId,
+      quantityToRemove: 100,
+    });
 
-    expect(() => orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100)).to.throw;
+    expect(() => orderBook['removeOwnOrder']({
+      orderId: remainingOrder!.id,
+      pairId: order.pairId,
+      quantityToRemove: 100,
+    })).to.throw;
   });
 
   it('should allow own order partial removal, but should not find the order id after it was fully removed', async () => {
     const order = createOwnOrder(0.01, 1000, true);
-    const { remainingOrder } = await orderBook.placeLimitOrder(order);
+    const { remainingOrder } = await orderBook.placeLimitOrder({ order });
 
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, remainingOrder!.quantity - 100);
-    orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100);
+    orderBook['removeOwnOrder']({
+      orderId: remainingOrder!.id,
+      pairId: order.pairId,
+      quantityToRemove: remainingOrder!.quantity - 100,
+    });
+    orderBook['removeOwnOrder']({
+      orderId: remainingOrder!.id,
+      pairId: order.pairId,
+      quantityToRemove: 100,
+    });
 
-    expect(() => orderBook['removeOwnOrder'](remainingOrder!.id, order.pairId, 100)).to.throw;
+    expect(() => orderBook['removeOwnOrder']({
+      orderId: remainingOrder!.id,
+      pairId: order.pairId,
+      quantityToRemove: 100,
+    })).to.throw;
   });
 
   describe('stampOwnOrder', () => {
@@ -303,6 +327,19 @@ describe('nomatching OrderBook', () => {
       });
       expect(() => orderBook['stampOwnOrder'](ownOrderWithLocalId))
         .to.throw(`order with local id ${ownOrderWithLocalId.localId} already exists`);
+    });
+
+    it('does not throw an error when replacing an existing localId', async () => {
+      const ownOrderWithLocalId = {
+        ...ownOrder(),
+        localId: uuidv1(),
+      };
+      orderBook['localIdMap'].set(ownOrderWithLocalId.localId, {
+        id: ownOrderWithLocalId.localId,
+        pairId: ownOrderWithLocalId.pairId,
+      });
+      const stampedOrder = orderBook['stampOwnOrder'](ownOrderWithLocalId, ownOrderWithLocalId.localId);
+      expect(stampedOrder.localId).to.equal(ownOrderWithLocalId.localId);
     });
   });
 

--- a/test/integration/Service.spec.ts
+++ b/test/integration/Service.spec.ts
@@ -21,6 +21,7 @@ describe('API Service', () => {
     quantity: 1,
     side: OrderSide.Buy,
     immediateOrCancel: false,
+    replaceOrderId: '',
   };
 
   before(async () => {

--- a/test/unit/Parser.spec.ts
+++ b/test/unit/Parser.spec.ts
@@ -272,7 +272,8 @@ describe('Parser', () => {
       isBuy: false,
     };
     testValidPacket(new packets.OrderPacket(orderPacketBody));
-    testValidPacket(new packets.OrderPacket(removeUndefinedProps({ ...orderPacketBody, isBuy: true })));
+    testValidPacket(new packets.OrderPacket({ ...orderPacketBody, isBuy: true }));
+    testValidPacket(new packets.OrderPacket({ ...orderPacketBody, replaceOrderId: uuid() }));
     testInvalidPacket(new packets.OrderPacket(orderPacketBody, uuid()));
     testInvalidPacket(new packets.OrderPacket(removeUndefinedProps({ ...orderPacketBody, id: undefined })));
     testInvalidPacket(new packets.OrderPacket(removeUndefinedProps({ ...orderPacketBody, pairId: undefined })));


### PR DESCRIPTION
This modifies the procedure for replacing an order in the order book. Previously, it would go like this:

1. Remove old order & send order invalidation to peers.
2. Place new order and wait for matching to complete (which may take
some time if it involves swap attempts).
3. Send new order to peers.

Now it goes:

1. Put the old order on hold, preventing further swaps/matching.
2. Place the new order and wait for matching to complete.
3. Remove the old order from the order book.
4. Send a single packet to peers with new order info and old order id.
5. Peers that receive this packet will remove the old order and add the new one sequentially.

By default, replaced orders will have the same local order id as the order they are replacing unless a different id is specified.

Closes #1805. Closes #1806.