### PR TITLE
feat(swaps): monitor pending payments before fail

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -445,6 +445,7 @@ class ConnextClient extends SwapClient {
       const assetId = this.getTokenAddress(currency);
       const transferStatusResponse = await this.getHashLockStatus(rHash, assetId);
 
+      this.logger.trace(`hashlock status for payment with hash ${rHash} is ${transferStatusResponse.status}`);
       switch (transferStatusResponse.status) {
         case 'PENDING':
           return { state: PaymentState.Pending };
@@ -457,6 +458,7 @@ class ConnextClient extends SwapClient {
         case 'FAILED':
           return { state: PaymentState.Failed };
         default:
+          this.logger.debug(`no hashlock status for payment with hash ${rHash}: ${JSON.stringify(transferStatusResponse)}`);
           return { state: PaymentState.Pending };
       }
     } catch (err) {

--- a/lib/swaps/SwapRecovery.ts
+++ b/lib/swaps/SwapRecovery.ts
@@ -16,11 +16,12 @@ interface SwapRecovery {
  * ensuring that we do not lose funds on a partially completed swap.
  */
 class SwapRecovery extends EventEmitter {
+  public static readonly PENDING_SWAP_RECHECK_INTERVAL = 300000;
+
   /** A map of payment hashes to swaps where we have a pending outgoing payment but don't know the preimage. */
   private pendingSwaps: Map<string, SwapDealInstance> = new Map();
   private pendingSwapsTimer?: NodeJS.Timeout;
   /** The time in milliseconds between checks on the status of pending swaps. */
-  private static readonly PENDING_SWAP_RECHECK_INTERVAL = 300000;
 
   constructor(private swapClientManager: SwapClientManager, private logger: Logger) {
     super();

--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -1,11 +1,11 @@
 diff --git a/lib/Xud.ts b/lib/Xud.ts
-index 08402caa..c9972d25 100644
+index 52ed8b5b4..93c5029b3 100644
 --- a/lib/Xud.ts
 +++ b/lib/Xud.ts
 @@ -87,6 +87,11 @@ class Xud extends EventEmitter {
        this.logger.info('config file loaded');
      }
-
+ 
 +    this.logger.info('CUSTOM-XUD');
 +    if (process.env.CUSTOM_SCENARIO) {
 +      this.logger.info(`CUSTOM_SCENARIO=${process.env.CUSTOM_SCENARIO}`);
@@ -15,18 +15,15 @@ index 08402caa..c9972d25 100644
        if (!this.config.rpc.disable) {
          // start rpc server first, it will respond with UNAVAILABLE error
 diff --git a/lib/swaps/SwapRecovery.ts b/lib/swaps/SwapRecovery.ts
-index 090618c4..820f8909 100644
+index 3759f6a35..4089dc944 100644
 --- a/lib/swaps/SwapRecovery.ts
 +++ b/lib/swaps/SwapRecovery.ts
-@@ -28,7 +28,21 @@ class SwapRecovery extends EventEmitter {
-
+@@ -29,7 +29,18 @@ class SwapRecovery extends EventEmitter {
+ 
    public beginTimer = () => {
      if (!this.pendingSwapsTimer) {
 -      this.pendingSwapsTimer = setInterval(this.checkPendingSwaps, SwapRecovery.PENDING_SWAP_RECHECK_INTERVAL);
 +      let interval = SwapRecovery.PENDING_SWAP_RECHECK_INTERVAL;
-+      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CLIENT_CRASHED_BEFORE_SETTLE') {
-+        interval = 2000;
-+      }
 +      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_WHILE_SENDING') {
 +        interval = 2000;
 +      }
@@ -40,12 +37,12 @@ index 090618c4..820f8909 100644
 +      this.pendingSwapsTimer = setInterval(this.checkPendingSwaps, interval);
      }
    }
-
+ 
 diff --git a/lib/swaps/Swaps.ts b/lib/swaps/Swaps.ts
-index 908f4cc3..b72ab4dc 100644
+index 3a2367f52..ec1712119 100644
 --- a/lib/swaps/Swaps.ts
 +++ b/lib/swaps/Swaps.ts
-@@ -721,6 +721,24 @@ class Swaps extends EventEmitter {
+@@ -729,6 +729,24 @@ class Swaps extends EventEmitter {
        // if the swap has already been failed, then we leave the swap recovery module
        // to attempt to settle the invoice and claim funds rather than do it here
        try {
@@ -69,8 +66,19 @@ index 908f4cc3..b72ab4dc 100644
 +        this.logger.info('SETTLING INVOICE');
          await swapClient.settleInvoice(rHash, rPreimage, currency);
        } catch (err) {
-         // if we couldn't settle the invoice then we fail the deal which throws
-@@ -745,6 +763,16 @@ class Swaps extends EventEmitter {
+         this.logger.error(`could not settle invoice for deal ${rHash}`, err);
+@@ -749,7 +767,9 @@ class Swaps extends EventEmitter {
+               } catch (err) {
+                 this.logger.error(`could not settle invoice for deal ${rHash}`, err);
+               }
+-            }, SwapRecovery.PENDING_SWAP_RECHECK_INTERVAL);
++            }, process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CLIENT_CRASHED_BEFORE_SETTLE' ?
++              2000 :
++              SwapRecovery.PENDING_SWAP_RECHECK_INTERVAL);
+           });
+           await settleRetryPromise;
+         } else {
+@@ -773,6 +793,16 @@ class Swaps extends EventEmitter {
     * accepted, initiates the swap.
     */
    private handleSwapAccepted = async (responsePacket: packets.SwapAcceptedPacket, peer: Peer) => {
@@ -87,8 +95,8 @@ index 908f4cc3..b72ab4dc 100644
      assert(responsePacket.body, 'SwapAcceptedPacket does not contain a body');
      const { quantity, rHash, makerCltvDelta } = responsePacket.body;
      const deal = this.getDeal(rHash);
-@@ -832,6 +860,11 @@ class Swaps extends EventEmitter {
-
+@@ -860,6 +890,11 @@ class Swaps extends EventEmitter {
+ 
      try {
        await makerSwapClient.sendPayment(deal);
 +
@@ -99,10 +107,10 @@ index 908f4cc3..b72ab4dc 100644
      } catch (err) {
        // first we must handle the edge case where the maker has paid us but failed to claim our payment
        // in this case, we've already marked the swap as having been paid and completed
-@@ -1013,6 +1046,18 @@ class Swaps extends EventEmitter {
-
+@@ -1041,6 +1076,18 @@ class Swaps extends EventEmitter {
+ 
        this.logger.debug('Executing maker code to resolve hash');
-
+ 
 +      if (process.env.CUSTOM_SCENARIO === 'SECURITY::MAKER_1ST_HTLC_STALL') {
 +        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
 +        const makerSwapClient = this.swapClientManager.get(deal.makerCurrency)!;
@@ -116,11 +124,11 @@ index 908f4cc3..b72ab4dc 100644
 +      }
 +
        const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
-
+ 
        // we update the phase persist the deal to the database before we attempt to send payment
-@@ -1023,6 +1068,13 @@ class Swaps extends EventEmitter {
+@@ -1051,6 +1098,13 @@ class Swaps extends EventEmitter {
        assert(deal.state !== SwapState.Error, `cannot send payment for failed swap ${deal.rHash}`);
-
+ 
        try {
 +        if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_WHILE_SENDING') {
 +          setTimeout(() => {
@@ -131,11 +139,11 @@ index 908f4cc3..b72ab4dc 100644
 +
          deal.rPreimage = await swapClient.sendPayment(deal);
        } catch (err) {
-         this.logger.debug(`sendPayment in resolveHash failed due to ${err.message}`);
-@@ -1073,10 +1125,21 @@ class Swaps extends EventEmitter {
+         this.logger.debug(`sendPayment in resolveHash for swap ${deal.rHash} failed due to ${err.message}`);
+@@ -1128,10 +1182,21 @@ class Swaps extends EventEmitter {
          }
        }
-
+ 
 +      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_BEFORE_PREIMAGE_RESOLVED') {
 +        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
 +        process.exit();
@@ -155,10 +163,10 @@ index 908f4cc3..b72ab4dc 100644
        return deal.rPreimage;
      } else {
        // If we are here we are the taker
-@@ -1084,6 +1147,16 @@ class Swaps extends EventEmitter {
+@@ -1139,6 +1204,16 @@ class Swaps extends EventEmitter {
        assert(htlcCurrency === undefined || htlcCurrency === deal.takerCurrency, 'incoming htlc does not match expected deal currency');
        this.logger.debug('Executing taker code to resolve hash');
-
+ 
 +      if (process.env.CUSTOM_SCENARIO === 'SECURITY::TAKER_2ND_HTLC_STALL') {
 +        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
 +        return '';
@@ -172,8 +180,8 @@ index 908f4cc3..b72ab4dc 100644
        return deal.rPreimage;
      }
    }
-@@ -1259,8 +1332,11 @@ class Swaps extends EventEmitter {
-         await this.swapRecovery.recoverDeal(swapDealInstance!);
+@@ -1302,8 +1377,11 @@ class Swaps extends EventEmitter {
+         swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
        }
      } else if (deal.phase === SwapPhase.SendingPayment) {
 -      const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
@@ -184,10 +192,10 @@ index 908f4cc3..b72ab4dc 100644
 +        swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
 +      }
      }
-
+ 
      this.logger.trace(`emitting swap.failed event for ${deal.rHash}`);
-@@ -1324,9 +1400,14 @@ class Swaps extends EventEmitter {
-
+@@ -1367,9 +1445,14 @@ class Swaps extends EventEmitter {
+ 
          if (deal.role === SwapRole.Maker) {
            // the maker begins execution of the swap upon accepting the deal
 +

--- a/test/simulation/tests-security.go
+++ b/test/simulation/tests-security.go
@@ -347,7 +347,7 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 	amt := int64(15000000)
 	pushAmt := int64(7500000)
-	_, err = openLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, net.Bob.LndLtcNode, amt, pushAmt)
+	aliceLtcChanPoint, err := openLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, net.Bob.LndLtcNode, amt, pushAmt)
 	ht.assert.NoError(err)
 	_, err = openBtcChannel(ht.ctx, net.LndBtcNetwork, net.Bob.LndBtcNode, net.Alice.LndBtcNode, amt, pushAmt)
 	ht.assert.NoError(err)
@@ -451,26 +451,6 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.True(walletDiff < onchainFeesThreshold,
 		"bob Btc wallet balance mismatch (prev: %v, current: %v)", bobPrevBalance.btc.wallet.TotalBalance, bobBalance.btc.wallet.TotalBalance)
 
-	// Closing taker LTC channel and checking balance.
-	// First, find the pending HTLC expiration height.
-
-	aliceLtcChanList, err := net.Alice.LndLtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
-	ht.assert.Equal(len(aliceLtcChanList.Channels), 1)
-	aliceLtcChan := aliceLtcChanList.Channels[0]
-	ht.assert.Greater(alicePrevLtcChan.LocalBalance-aliceLtcChan.LocalBalance, int64(float64(aliceOrderReq.Quantity)*aliceOrderReq.Price))
-	ht.assert.Equal(aliceLtcChan.RemoteBalance, aliceLtcChan.RemoteBalance)
-	ht.assert.Equal(len(aliceLtcChan.PendingHtlcs), 1)
-	expirationHeight = aliceLtcChan.PendingHtlcs[0].ExpirationHeight
-
-	// Expire the HTLC.
-
-	ltcInfo, err := net.LndLtcNetwork.LtcMiner.Node.GetInfo()
-	ht.assert.NoError(err)
-	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(expirationHeight - uint32(ltcInfo.Blocks))
-	ht.assert.NoError(err)
-	ltcInfo, err = net.LndLtcNetwork.LtcMiner.Node.GetInfo()
-	ht.assert.True(ltcInfo.Blocks >= int32(expirationHeight))
-
 	e := <-bobSwapFailuresChan
 	ht.assert.NoError(e.err)
 	ht.assert.NotNil(e.swapFailure)
@@ -478,30 +458,23 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.Equal(e.swapFailure.FailureReason, "SendPaymentFailure")
 	ht.assert.Equal(e.swapFailure.OrderId, bobOrder.Id)
 
-	removalRes, err = net.Bob.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: bobOrderReq.OrderId})
-	ht.assert.NoError(err)
-	ht.assert.NotNil(removalRes)
-	ht.assert.Equal(removalRes.QuantityOnHold, uint64(0))
+	// After Bob's outgoing BTC payment fails, he should cancel the invoice
+	// for the incoming LTC payment since he's no longer at risk of losing funds
 
-	// Verify channel was closed (by force-close, as the outgoing HTLC got expired).
+	aliceLtcChanList, err := net.Alice.LndLtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
+	ht.assert.Equal(len(aliceLtcChanList.Channels), 1)
+	aliceLtcChan := aliceLtcChanList.Channels[0]
+	ht.assert.Equal(alicePrevLtcChan.LocalBalance, aliceLtcChan.LocalBalance)
+	ht.assert.Equal(alicePrevLtcChan.RemoteBalance, aliceLtcChan.RemoteBalance)
+	ht.assert.Equal(len(aliceLtcChan.PendingHtlcs), 0)
 
-	waitForChannelClose(net.Alice.LndLtcNode, ht)
+	// Closing taker LTC channel and checking balance.
+	// It has no pending HTLC because the maker cancelled his invoice after the swap timeout.
 
-	// Wait for publishing CLTV-delayed HTLC output using timeout tx.
-
-	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(1)
-	ht.assert.NoError(err)
-
-	time.Sleep(5 * time.Second)
-
-	// Wait for HTLC output to be fully confirmed.
-
-	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(6)
+	err = closeLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, aliceLtcChanPoint, false)
 	ht.assert.NoError(err)
 
-	time.Sleep(35 * time.Second)
-
-	// Check balance.
+	// Check LTC balance
 
 	onchainFeesThreshold = int64(200000)
 	aliceBalance, err := getBalance(ht.ctx, net.Alice)
@@ -510,6 +483,10 @@ func testTakerStallingAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.True(walletDiff < onchainFeesThreshold,
 		"alice ltc wallet balance mismatch (prev: %v, current: %v)", alicePrevBalance.ltc.wallet.TotalBalance, aliceBalance.ltc.wallet.TotalBalance)
 
+	removalRes, err = net.Bob.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: bobOrderReq.OrderId})
+	ht.assert.NoError(err)
+	ht.assert.NotNil(removalRes)
+	ht.assert.Equal(removalRes.QuantityOnHold, uint64(0))
 }
 
 func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest) {
@@ -525,7 +502,7 @@ func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 
 	amt := int64(15000000)
 	pushAmt := int64(7500000)
-	_, err = openLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, net.Bob.LndLtcNode, amt, pushAmt)
+	aliceLtcChanPoint, err := openLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, net.Bob.LndLtcNode, amt, pushAmt)
 	ht.assert.NoError(err)
 	_, err = openBtcChannel(ht.ctx, net.LndBtcNetwork, net.Bob.LndBtcNode, net.Alice.LndBtcNode, amt, pushAmt)
 	ht.assert.NoError(err)
@@ -568,8 +545,6 @@ func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	_, err = net.Alice.Client.PlaceOrderSync(ht.ctx, aliceOrderReq)
 	ht.assert.Error(err)
 
-	//<-net.Alice.ProcessExit
-
 	// Cleanup.
 
 	// Closing maker BTC channel and checking balance.
@@ -591,26 +566,6 @@ func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.NoError(err)
 	btcInfo, err = net.LndBtcNetwork.BtcMiner.Node.GetInfo()
 	ht.assert.True(btcInfo.Blocks >= int32(expirationHeight))
-
-	// Closing taker LTC channel and checking balance.
-	// First, find the pending HTLC expiration height.
-
-	aliceLtcChanList, err := net.Alice.LndLtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
-	ht.assert.Equal(len(aliceLtcChanList.Channels), 1)
-	aliceLtcChan := aliceLtcChanList.Channels[0]
-	ht.assert.Greater(alicePrevLtcChan.LocalBalance-aliceLtcChan.LocalBalance, int64(float64(aliceOrderReq.Quantity)*aliceOrderReq.Price))
-	ht.assert.Equal(aliceLtcChan.RemoteBalance, aliceLtcChan.RemoteBalance)
-	ht.assert.Equal(len(aliceLtcChan.PendingHtlcs), 1)
-	expirationHeight = aliceLtcChan.PendingHtlcs[0].ExpirationHeight
-
-	// Expire the LTC HTLC.
-
-	ltcInfo, err := net.LndLtcNetwork.LtcMiner.Node.GetInfo()
-	ht.assert.NoError(err)
-	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(expirationHeight - uint32(ltcInfo.Blocks))
-	ht.assert.NoError(err)
-	ltcInfo, err = net.LndLtcNetwork.LtcMiner.Node.GetInfo()
-	ht.assert.True(ltcInfo.Blocks >= int32(expirationHeight))
 
 	// Verify BTC channel was closed (by force-close, as the outgoing HTLC got expired).
 
@@ -639,40 +594,6 @@ func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.True(walletDiff < onchainFeesThreshold,
 		"bob Btc wallet balance mismatch (prev: %v, current: %v)", bobPrevBalance.btc.wallet.TotalBalance, bobBalance.btc.wallet.TotalBalance)
 
-	// TODO: return the cooperative channel closure once the maker invoice cancellation is enabled
-	//// Closing taker LTC channel and checking balance.
-	//// It has no pending HTLC because the maker cancelled his invoice after the swap timeout.
-	//
-	//err = closeLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, aliceLtcChanPoint, false)
-	//ht.assert.NoError(err)
-
-	// Verify LTC channel was closed (by force-close, as the outgoing HTLC got expired).
-
-	waitForChannelClose(net.Alice.LndLtcNode, ht)
-
-	// Wait for publishing CLTV-delayed LTC HTLC output using timeout tx.
-
-	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(1)
-	ht.assert.NoError(err)
-
-	time.Sleep(5 * time.Second)
-
-	// Wait for LTC HTLC output to be fully confirmed.
-
-	_, err = net.LndLtcNetwork.LtcMiner.Node.Generate(6)
-	ht.assert.NoError(err)
-
-	time.Sleep(35 * time.Second)
-
-	// Check balance.
-
-	onchainFeesThreshold = int64(200000)
-	aliceBalance, err := getBalance(ht.ctx, net.Alice)
-	ht.assert.NoError(err)
-	walletDiff = alicePrevBalance.ltc.wallet.TotalBalance - aliceBalance.ltc.wallet.TotalBalance - pushAmt
-	ht.assert.True(walletDiff < onchainFeesThreshold,
-		"alice ltc wallet balance mismatch (prev: %v, current: %v)", alicePrevBalance.ltc.wallet.TotalBalance, aliceBalance.ltc.wallet.TotalBalance)
-
 	// Wait for swap to fail
 
 	e := <-bobSwapFailuresChan
@@ -681,6 +602,31 @@ func testTakerShutdownAfter2ndHTLC(net *xudtest.NetworkHarness, ht *harnessTest)
 	ht.assert.Equal(e.swapFailure.PeerPubKey, net.Alice.PubKey())
 	ht.assert.Equal(e.swapFailure.FailureReason, "SendPaymentFailure")
 	ht.assert.Equal(e.swapFailure.OrderId, bobOrder.Id)
+
+	// After Bob's outgoing BTC payment fails, he should cancel the invoice
+	// for the incoming LTC payment since he's no longer at risk of losing funds
+
+	aliceLtcChanList, err := net.Alice.LndLtcNode.ListChannels(ht.ctx, &lnrpc.ListChannelsRequest{})
+	ht.assert.Equal(len(aliceLtcChanList.Channels), 1)
+	aliceLtcChan := aliceLtcChanList.Channels[0]
+	ht.assert.Equal(alicePrevLtcChan.LocalBalance, aliceLtcChan.LocalBalance)
+	ht.assert.Equal(alicePrevLtcChan.RemoteBalance, aliceLtcChan.RemoteBalance)
+	ht.assert.Equal(len(aliceLtcChan.PendingHtlcs), 0)
+
+	// Closing taker LTC channel and checking balance.
+	// It has no pending HTLC because the maker cancelled his invoice after the swap timeout.
+
+	err = closeLtcChannel(ht.ctx, net.LndLtcNetwork, net.Alice.LndLtcNode, aliceLtcChanPoint, false)
+	ht.assert.NoError(err)
+
+	// Check LTC balance
+
+	onchainFeesThreshold = int64(200000)
+	aliceBalance, err := getBalance(ht.ctx, net.Alice)
+	ht.assert.NoError(err)
+	walletDiff = alicePrevBalance.ltc.wallet.TotalBalance - aliceBalance.ltc.wallet.TotalBalance - pushAmt
+	ht.assert.True(walletDiff < onchainFeesThreshold,
+		"alice ltc wallet balance mismatch (prev: %v, current: %v)", alicePrevBalance.ltc.wallet.TotalBalance, aliceBalance.ltc.wallet.TotalBalance)
 
 	removalRes, err := net.Bob.Client.RemoveOrder(ht.ctx, &xudrpc.RemoveOrderRequest{OrderId: bobOrderReq.OrderId})
 	ht.assert.NoError(err)


### PR DESCRIPTION
This monitors all swap client payments until their resolution without putting deals into `SwapRecovery`. Previously, if a call to send payment failed but the payment was still in pending status (as has been the case with Connext), then we would fail the swap deal and monitor the payment in `SwapRecovery`. This had several downsides, namely:

1. Since the deal is marked as having failed in the database, if xud restarts while payment monitoring is ongoing, it won't resume monitoring because it sees the swap as having failed in the database. We only recover swaps that were "active" at the time xud shut down. See #1799.

2. When a deal is failed, the maker order it attempted to swap re-enters the order book and is available to be matched again. However, since the payment for the original deal is still pending, it may still go through, meaning that the order can be "double filled" in such a case. See #1794.

By monitoring all pending payments to their resolution, we ensure that we don't fail deals that wind up completing.

Fixes #1799. Fixes #1794.

Edit: This fixes PR 1794, not 1816.