### PR TITLE
fix: strict command arg

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -72,15 +72,15 @@ const { argv } = require('yargs')
       type: 'boolean',
       default: undefined,
     },
+    strict: {
+      describe: 'strict mode for production use',
+      type: 'boolean',
+      default: undefined,
+    },
     xudir: {
       describe: 'Data directory for xud',
       type: 'string',
       alias: 'x',
-    },
-    'debug.testing': {
-      describe: 'Developer mode to facilitate testing swaps',
-      type: 'boolean',
-      default: undefined,
     },
     'debug.raidenDirectChannelChecks': {
       describe: 'Whether to require direct channels for raiden payments',


### PR DESCRIPTION
This replaces the obsolete `debug.testing` command line argument with the `strict` option that replaced it.