### PR TITLE
feat(orderbook): don't add back invalidated orders

### DIFF
--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -74,6 +74,7 @@ jest.mock('../../lib/p2p/Pool', () => {
     return {
       updatePairs: jest.fn(),
       on: jest.fn(),
+      removeListener: jest.fn(),
       getNetwork: () => XuNetwork.MainNet,
       getTokenIdentifier: (currency: string) => tokenIdentifiers[currency] as string,
       broadcastOrderInvalidation: jest.fn(),


### PR DESCRIPTION
This prevents matched orders from being added back to the order book after failing swaps if they were invalidated by the peer while the swap was being attempted.

Fixes #1838.