### PR TITLE
revert: feat: generate 2048-bit tls certs

### DIFF
--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -104,11 +104,11 @@ class GrpcServer {
    * @returns the cerificate and its private key
    */
   private generateCertificate = async (tlsCertPath: string, tlsKeyPath: string): Promise<{ tlsCert: string, tlsKey: string }> => {
-    const keys = pki.rsa.generateKeyPair(2048);
+    const keys = pki.rsa.generateKeyPair(1024);
     const cert = pki.createCertificate();
 
     cert.publicKey = keys.publicKey;
-    cert.serialNumber = `2048-${String(Math.floor(Math.random() * 100000000))}`;
+    cert.serialNumber = String(Math.floor(Math.random() * 1024) + 1);
 
     // TODO: handle expired certificates
     const date = new Date();


### PR DESCRIPTION
This reverts commit b6bc1ad234aa6e6472e81c422d51b914c5f7b2f5.

Related: #1692 & #1840. I guess we'll have to be more careful and run simulation tests multiple times before changing anything regarding the TLS cert generation in the future.