### PR TITLE
fix(orderbook): reject all dust peer orders

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -766,7 +766,8 @@ class OrderBook extends EventEmitter {
     }
 
     // TODO: penalize peers for sending ordes too small to swap?
-    if (order.quantity * order.price < TradingPair.QUANTITY_DUST_LIMIT) {
+    if (order.quantity * order.price < TradingPair.QUANTITY_DUST_LIMIT ||
+        order.quantity < TradingPair.QUANTITY_DUST_LIMIT) {
       this.logger.warn('incoming peer order is too small to swap');
       return false;
     }


### PR DESCRIPTION
This fixes an oversight where we would only reject peer orders where the price times quantity was below the dust limit, but not necessarily where the quantity itself was below the dust limit.