### PR TITLE
feat(orderbook): better replace order hold message

### DIFF
--- a/lib/grpc/getGrpcError.ts
+++ b/lib/grpc/getGrpcError.ts
@@ -49,6 +49,7 @@ const getGrpcError = (err: any) => {
     case orderErrorCodes.MARKET_ORDERS_NOT_ALLOWED:
     case serviceErrorCodes.NOMATCHING_MODE_IS_REQUIRED:
     case orderErrorCodes.INSUFFICIENT_OUTBOUND_BALANCE:
+    case orderErrorCodes.QUANTITY_ON_HOLD:
     case swapErrorCodes.SWAP_CLIENT_NOT_FOUND:
     case swapErrorCodes.SWAP_CLIENT_MISCONFIGURED:
       code = status.FAILED_PRECONDITION;

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -480,9 +480,10 @@ class OrderBook extends EventEmitter {
       }
     }
 
-    assert(!(replaceOrderId && discardRemaining), 'can not replace order and discard remaining order');
     let replacedOrderIdentifier: OrderIdentifier | undefined;
     if (replaceOrderId) {
+      assert(!discardRemaining, 'can not replace order and discard remaining order');
+
       // put the order we are replacing on hold while we place the new order
       replacedOrderIdentifier = this.localIdMap.get(replaceOrderId);
       if (!replacedOrderIdentifier) {

--- a/lib/orderbook/errors.ts
+++ b/lib/orderbook/errors.ts
@@ -72,7 +72,7 @@ const errors = {
     code: errorCodes.MIN_QUANTITY_VIOLATED,
   }),
   QUANTITY_ON_HOLD: (localId: string, holdQuantity: number) => ({
-    message: `order with local id ${localId} has a quantity of ${holdQuantity} on hold`,
+    message: `order with local id ${localId} has a quantity of ${holdQuantity} satoshis on hold, try again later`,
     code: errorCodes.QUANTITY_DOES_NOT_MATCH,
   }),
 };


### PR DESCRIPTION
This returns a clearer error message when the user attempts to replace an order that is on hold via rpc, which is not allowed.