### PR TITLE
feat(p2p): increase reconnection delay backoff

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -120,9 +120,9 @@ class Peer extends EventEmitter {
   /** Connection retries min delay. */
   private static readonly CONNECTION_RETRIES_MIN_DELAY = 5000;
   /** Connection retries max delay. */
-  private static readonly CONNECTION_RETRIES_MAX_DELAY = 300000;
+  private static readonly CONNECTION_RETRIES_MAX_DELAY = 3600000; // 1 hour
   /** Connection retries max period. */
-  private static readonly CONNECTION_RETRIES_MAX_PERIOD = 604800000;
+  private static readonly CONNECTION_RETRIES_MAX_PERIOD = 259200000; // 3 days
 
   /** The version of xud this peer is using, or an empty string if it is still not known. */
   public get version() {


### PR DESCRIPTION
This increases the maximum backoff to wait between reconnection attempts to a peer from 5 minutes to 1 hour. It also decreases the total amount of time that we will keep trying to reconnect to a peer before giving up from 7 days to 3 days.

EDIT by @kilrau : closes https://github.com/ExchangeUnion/xud/issues/1868