### PR TITLE
feat(p2p): don't log empty order packets

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -798,14 +798,17 @@ class Pool extends EventEmitter {
       }
       case PacketType.Orders: {
         const receivedOrders = (packet as packets.OrdersPacket).body!;
-        this.logger.verbose(`received ${receivedOrders.length} orders from ${peer.label}`);
-        receivedOrders.forEach((order) => {
-          if (peer.isPairActive(order.pairId)) {
-            this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey! });
-          } else {
-            this.logger.debug(`received order ${order.id} for deactivated trading pair`);
-          }
-        });
+        if (receivedOrders.length > 0) {
+          this.logger.debug(`received ${receivedOrders.length} orders from ${peer.label}`);
+          receivedOrders.forEach((order) => {
+            if (peer.isPairActive(order.pairId)) {
+              this.emit('packet.order', { ...order, peerPubKey: peer.nodePubKey! });
+            } else {
+              this.logger.debug(`received order ${order.id} for deactivated trading pair`);
+            }
+          });
+        }
+
         break;
       }
       case PacketType.GetNodes: {


### PR DESCRIPTION
This skips the log statement that logs when a peer sends us zero orders for a given trading pair, as this is more or less a non-event and is currently logged fairly frequently. It also lowers the level of logging when we do get orders from `verbose` to `debug` as it is a common and not particularly important event.