### PR TITLE
docs: fix cli help typos

### DIFF
--- a/lib/cli/commands/closechannel.ts
+++ b/lib/cli/commands/closechannel.ts
@@ -3,7 +3,7 @@ import { CloseChannelRequest } from '../../proto/xudrpc_pb';
 import { callback, loadXudClient } from '../command';
 import { coinsToSats } from '../utils';
 
-export const command = 'closechannel <currency> [node_identifier ] [--force]';
+export const command = 'closechannel <currency> [node_identifier] [--force]';
 
 export const describe = 'close any payment channels with a peer';
 

--- a/lib/cli/commands/walletdeposit.ts
+++ b/lib/cli/commands/walletdeposit.ts
@@ -11,7 +11,7 @@ export const builder = (argv: Argv) => argv
     description: 'the ticker symbol of the currency to deposit.',
     type: 'string',
   })
-  .example('$0 deposit BTC', 'get a BTC deposit address');
+  .example('$0 walletdeposit BTC', 'get a BTC deposit address');
 
 export const handler = async (argv: Arguments<any>) => {
   const request = new DepositRequest();


### PR DESCRIPTION
1. removed redundant space in closechannel help `[node_identifier ]` -> `[node_identifier]`
2. fixed example in walletdeposit help `deposit BTC` -> `walletdeposit BTC`