### PR TITLE
fix: listorders limit displays first orders instead of last

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -471,8 +471,8 @@ class Service {
       sellArray = sortOrders(sellArray, false);
 
       if (limit > 0) {
-        buyArray = buyArray.slice(0, limit);
-        sellArray = sellArray.slice(0, limit);
+        buyArray = buyArray.slice(-limit);
+        sellArray = sellArray.slice(-limit);
       }
 
       return {

--- a/test/jest/Service.spec.ts
+++ b/test/jest/Service.spec.ts
@@ -349,9 +349,9 @@ describe('Service', () => {
       const result = service.listOrders({ pairId: pairIds[0], owner: Owner.Both, limit: 2, includeAliases: false });
       expect(result.size).toEqual(1);
       expect(result.get(pairIds[0])!.buyArray.length).toEqual(2);
-      expect(result.get(pairIds[0])!.buyArray.some(val => val.price === 1)).toBeTruthy();
+      expect(result.get(pairIds[0])!.buyArray.some(val => val.price === 2)).toBeTruthy();
       expect(result.get(pairIds[0])!.sellArray.length).toEqual(2);
-      expect(result.get(pairIds[0])!.sellArray.some(val => val.price === 6)).toBeTruthy();
+      expect(result.get(pairIds[0])!.sellArray.some(val => val.price === 5)).toBeTruthy();
     });
 
   });


### PR DESCRIPTION
Fix of #1881, but need ACK from @kilrau that it is a bug :)

![Screenshot from 2020-09-09 22-08-37](https://user-images.githubusercontent.com/29906866/92642561-0dbccc00-f2e9-11ea-9066-eff11b36ac68.png)
