### PR TITLE
fix: don't activate unsupported pairs with peers

### DIFF
--- a/lib/swaps/SwapClientManager.ts
+++ b/lib/swaps/SwapClientManager.ts
@@ -247,6 +247,15 @@ class SwapClientManager extends EventEmitter {
     return this.swapClients.get(currency);
   }
 
+  /**
+   * Returns whether the swap client manager has a client for a given currency.
+   * @param currency the currency that the swap client is linked to.
+   * @returns `true` if a swap client exists, false otherwise.
+   */
+  public has = (currency: string): boolean => {
+    return this.swapClients.has(currency);
+  }
+
   /** Gets the type of swap client for a given currency. */
   public getType = (currency: string) => {
     return this.swapClients.get(currency)?.type;

--- a/test/jest/Orderbook.spec.ts
+++ b/test/jest/Orderbook.spec.ts
@@ -175,13 +175,11 @@ describe('OrderBook', () => {
   test('nosanityswaps enabled adds pairs and requests orders', async () => {
     orderbook['nosanityswaps'] = true;
     await orderbook['verifyPeerPairs'](peer);
-    expect(mockActivateCurrency).toHaveBeenCalledTimes(3);
+    expect(mockActivateCurrency).toHaveBeenCalledTimes(2);
     expect(mockActivateCurrency).toHaveBeenCalledWith('BTC');
     expect(mockActivateCurrency).toHaveBeenCalledWith('LTC');
-    expect(mockActivateCurrency).toHaveBeenCalledWith('WETH');
-    expect(mockActivatePair).toHaveBeenCalledTimes(2);
+    expect(mockActivatePair).toHaveBeenCalledTimes(1);
     expect(mockActivatePair).toHaveBeenCalledWith(advertisedPairs[0]);
-    expect(mockActivatePair).toHaveBeenCalledWith(advertisedPairs[1]);
   });
 
   test('isPeerCurrencySupported returns true for a known currency with matching identifiers', async () => {


### PR DESCRIPTION
This ensures that, even when not running in strict mode, we only activate trading pairs with peers when we support both currencies of the pair locally. Previously we would activate every trading pair, like
BTC/LTC when we don't have a swap client for LTC, resulting in us requesting and receiving order updates for trading pairs that are irrelevent to us.

Related https://github.com/ExchangeUnion/xud/pull/1864#issuecomment-687140868:

> after adding new pair, the peer with new pair sends packet update to his peers. And after that these peers send GetOrders packet to this peer even if they have no this pair. It would be good to not ask orders if we have no this new pair.