### PR TITLE
fix: implemented showing all pairs instead of active ones for listpeers

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -179,7 +179,7 @@ class Peer extends EventEmitter {
       alias: this.alias,
       nodePubKey: this.nodePubKey,
       inbound: this.inbound,
-      pairs: Array.from(this.activePairs),
+      pairs: this.nodeState ? this.nodeState.pairs : [],
       xudVersion: this.version,
       secondsConnected: Math.round((Date.now() - this.connectTime) / 1000),
       lndPubKeys: this.nodeState ? this.nodeState.lndPubKeys : undefined,


### PR DESCRIPTION
attempts to resolve #1801 

This should be as simple as this change as per comments on the issue, could you please check @sangaman @raladev @kilrau 
![image](https://user-images.githubusercontent.com/3640368/93203725-8f837e00-f75d-11ea-9c39-3f8f4d4603ee.png)
