### PR TITLE
fix(connext): avoid scientific notation for amount

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -351,7 +351,7 @@ class ConnextClient extends SwapClient {
       let secret;
       if (deal.role === SwapRole.Maker) {
         // we are the maker paying the taker
-        amount = deal.takerUnits.toString();
+        amount = deal.takerUnits.toLocaleString('fullwide', { useGrouping: false });
         tokenAddress = this.tokenAddresses.get(deal.takerCurrency)!;
         const executeTransfer = this.executeHashLockTransfer({
           amount,
@@ -369,7 +369,7 @@ class ConnextClient extends SwapClient {
         secret = preimage;
       } else {
         // we are the taker paying the maker
-        amount = deal.makerUnits.toString();
+        amount = deal.makerUnits.toLocaleString('fullwide', { useGrouping: false });
         tokenAddress = this.tokenAddresses.get(deal.makerCurrency)!;
         lockTimeout = deal.makerCltvDelta!;
         secret = deal.rPreimage!;
@@ -668,7 +668,7 @@ class ConnextClient extends SwapClient {
     const assetId = this.getTokenAddress(currency);
     const depositResponse = await this.sendRequest('/deposit', 'POST', {
       assetId,
-      amount: units.toString(),
+      amount: units.toLocaleString('fullwide', { useGrouping: false }), // toLocaleString avoids scientific notation
     });
     const { txhash } = await parseResponseBody<ConnextDepositResponse>(depositResponse);
     const channelCollateralized$ = fromEvent(this, 'depositConfirmed').pipe(
@@ -706,7 +706,7 @@ class ConnextClient extends SwapClient {
 
     const withdrawResponse = await this.sendRequest('/withdraw', 'POST', {
       recipient: destination,
-      amount: amount.toString(),
+      amount: amount.toLocaleString('fullwide', { useGrouping: false }),
       assetId: this.tokenAddresses.get(currency),
     });
 
@@ -741,7 +741,7 @@ class ConnextClient extends SwapClient {
   ): Promise<void> => {
     await this.sendRequest('/hashlock-transfer', 'POST', {
       assetId,
-      amount: amount.toString(),
+      amount: amount.toLocaleString('fullwide', { useGrouping: false }),
     });
   }
 


### PR DESCRIPTION
This changes the way we convert numbers to strings when building requests to send to the Connext client by using `toLocaleString` instead of `toString` to avoid representing large numbers with scientific notation.

This should help with issues we've faced using toknes that deal with larger quantities like DAI.

An example of how `toLocaleString` compares with `toString` as well as `bigint`:

```typescript
const x = 1725000000000000000000; // 1725 DAI in wei units
const bigX = 1725000000000000000000n;

console.log(x.toString());                                          // 1.725e+21
console.log(x.toLocaleString('fullwide', { useGrouping: false }));  // 1725000000000000000000
console.log(bigX.toString());                                       // 1725000000000000000000

const y = x + 1;
console.log(y.toLocaleString('fullwide', { useGrouping: false }));  // 1725000000000000000000
// but we will never be making payments with wei-level precision, xud only uses up to 8 digits to right of decimal point
// the approach above gives us up to 16 digits of precision, which is on the order of 100 million + 8 decimal places of precision
```