### PR TITLE
fix: handling insufficient balance errors for swap clients

### DIFF
--- a/lib/constants/enums.ts
+++ b/lib/constants/enums.ts
@@ -161,6 +161,8 @@ export enum SwapFailureReason {
   InvalidOrders = 15,
   /** Our payment to the peer was rejected, either deliberately or due to an error. */
   PaymentRejected = 16,
+  /** The swap failed due to insufficient balance. */
+  InsufficientBalance = 17,
 }
 
 export enum DisconnectionReason {

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -463,6 +463,7 @@ class GrpcService {
             // these cases suggest something went very wrong with our swap request
             code = status.INTERNAL;
             break;
+          case SwapFailureReason.InsufficientBalance:
           case SwapFailureReason.NoRouteFound:
           case SwapFailureReason.SendPaymentFailure:
           case SwapFailureReason.SwapClientNotSetup:

--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -854,6 +854,10 @@ class LndClient extends SwapClient {
       // QueryRoutes no longer returns more than one route
       route = (await this.queryRoutes(request)).getRoutesList()[0];
     } catch (err) {
+      if (typeof err.message === 'string' && err.message.includes('insufficient local balance')) {
+        throw swapErrors.INSUFFICIENT_BALANCE;
+      }
+
       if (typeof err.message !== 'string' || (
         !err.message.includes('unable to find a path to destination') &&
         !err.message.includes('target not found')

--- a/lib/swaps/Swaps.ts
+++ b/lib/swaps/Swaps.ts
@@ -335,6 +335,9 @@ class Swaps extends EventEmitter {
     try {
       route = await swapClient.getRoute(makerUnits, destination, makerCurrency);
     } catch (err) {
+      if (err === errors.INSUFFICIENT_BALANCE) {
+        throw SwapFailureReason.InsufficientBalance;
+      }
       throw SwapFailureReason.UnexpectedClientError;
     }
 
@@ -589,7 +592,7 @@ class Swaps extends EventEmitter {
         deal,
         peer,
         reqId,
-        failureReason: SwapFailureReason.UnexpectedClientError,
+        failureReason: (err === errors.INSUFFICIENT_BALANCE) ? SwapFailureReason.InsufficientBalance : SwapFailureReason.UnexpectedClientError,
         errorMessage: err.message,
         failedCurrency: deal.takerCurrency,
       });

--- a/lib/swaps/errors.ts
+++ b/lib/swaps/errors.ts
@@ -13,6 +13,7 @@ const errorCodes = {
   UNKNOWN_PAYMENT_ERROR: codesPrefix.concat('.9'),
   PAYMENT_PENDING: codesPrefix.concat('.10'),
   REMOTE_IDENTIFIER_MISSING: codesPrefix.concat('.11'),
+  INSUFFICIENT_BALANCE: codesPrefix.concat('.12'),
 };
 
 const errors = {
@@ -64,6 +65,10 @@ const errors = {
   REMOTE_IDENTIFIER_MISSING: {
     message: 'operation failed due to a missing remote identifier',
     code: errorCodes.REMOTE_IDENTIFIER_MISSING,
+  },
+  INSUFFICIENT_BALANCE: {
+    message: 'swap failed due to insufficient channel balance',
+    code: errorCodes.INSUFFICIENT_BALANCE,
   },
 };
 


### PR DESCRIPTION
attempts to resolve #1558 

This's a WIP (Work in Progress) PR, I'm currently having trouble with my local setup and @raladev is helping me with it, apart from that please let me know what else actually need to be done.

I suppose matched orders should return to the orderbook? @kilrau (I couldn't test this yet too)

@sangaman @raladev @kilrau  