### PR TITLE
feat(connext): lazy collateralization

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -202,6 +202,10 @@ class LndClient extends SwapClient {
     return; // we do not currently check inbound capacities for lnd
   }
 
+  public setReservedInboundAmount = (_reservedInboundAmount: number) => {
+    return; // not currently used for lnd
+  }
+
   /** Lnd specific procedure to mark the client as locked. */
   private lock = () => {
     if (!this.walletUnlocker) {

--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -140,6 +140,7 @@ abstract class SwapClient extends EventEmitter {
    * and throws an error if there isn't, otherwise does nothing.
    */
   public abstract checkInboundCapacity(inboundAmount: number, currency?: string): void;
+  public abstract setReservedInboundAmount(reservedInboundAmount: number, currency?: string): void;
   protected abstract updateCapacity(): Promise<void>;
 
   public verifyConnectionWithTimeout = () => {

--- a/test/integration/OrderBook.spec.ts
+++ b/test/integration/OrderBook.spec.ts
@@ -36,6 +36,10 @@ const getMockSwaps = (sandbox: sinon.SinonSandbox) => {
   swaps.swapClientManager['swapClients'] = new Map<string, SwapClient>();
   swaps.swapClientManager['swapClients'].set('BTC', lndBTC);
   swaps.swapClientManager['swapClients'].set('LTC', lndLTC);
+  swaps.swapClientManager.addInboundReservedAmount = () => {};
+  swaps.swapClientManager.subtractInboundReservedAmount = () => {};
+  swaps.swapClientManager.addOutboundReservedAmount = () => {};
+  swaps.swapClientManager.subtractOutboundReservedAmount = () => {};
   swaps.swapClientManager.get = (currency: any) => {
     const client = swaps.swapClientManager['swapClients'].get(currency);
     if (!client) {

--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/Xud.ts b/lib/Xud.ts
-index 52ed8b5b..93c5029b 100644
+index 489a50a4..f9391527 100644
 --- a/lib/Xud.ts
 +++ b/lib/Xud.ts
 @@ -87,6 +87,11 @@ class Xud extends EventEmitter {
@@ -14,6 +14,37 @@ index 52ed8b5b..93c5029b 100644
      try {
        if (!this.config.rpc.disable) {
          // start rpc server first, it will respond with UNAVAILABLE error
+diff --git a/lib/connextclient/ConnextClient.ts b/lib/connextclient/ConnextClient.ts
+index 7fe05a71..240ad137 100644
+--- a/lib/connextclient/ConnextClient.ts
++++ b/lib/connextclient/ConnextClient.ts
+@@ -309,24 +309,8 @@ class ConnextClient extends SwapClient {
+     }
+   }
+ 
+-  public setReservedInboundAmount = (reservedInboundAmount: number, currency: string) => {
+-    const inboundCapacity = this._maxChannelInboundAmount.get(currency) || 0;
+-    if (inboundCapacity < reservedInboundAmount) {
+-      // we do not have enough inbound capacity to fill all open orders, so we will request more
+-      this.logger.debug(`collateral of ${inboundCapacity} for ${currency} is insufficient for reserved order amount of ${reservedInboundAmount}`);
+-
+-      // we want to make a request for the current collateral plus the greater of any
+-      // minimum request size for the currency or the capacity shortage + 3% buffer
+-      const quantityToRequest = inboundCapacity + Math.max(
+-        reservedInboundAmount * 1.03 - inboundCapacity,
+-        ConnextClient.MIN_COLLATERAL_REQUEST_SIZES[currency] ?? 0,
+-      );
+-      const unitsToRequest = this.unitConverter.amountToUnits({ currency, amount: quantityToRequest });
+-
+-      // we don't await this request - instead we allow for "lazy collateralization" to complete since
+-      // we don't expect all orders to be filled at once, we can be patient
+-      this.requestCollateralInBackground(currency, unitsToRequest);
+-    }
++  public setReservedInboundAmount = (_reservedInboundAmount: number, _currency: string) => {
++    // we don't request collateral for custom xud simulation tests
+   }
+ 
+   protected updateCapacity = async () => {
 diff --git a/lib/swaps/SwapRecovery.ts b/lib/swaps/SwapRecovery.ts
 index 3759f6a3..4089dc94 100644
 --- a/lib/swaps/SwapRecovery.ts
@@ -39,10 +70,10 @@ index 3759f6a3..4089dc94 100644
    }
  
 diff --git a/lib/swaps/Swaps.ts b/lib/swaps/Swaps.ts
-index 0018b386..388e1638 100644
+index 9648e02b..0e850119 100644
 --- a/lib/swaps/Swaps.ts
 +++ b/lib/swaps/Swaps.ts
-@@ -727,6 +727,24 @@ class Swaps extends EventEmitter {
+@@ -730,6 +730,24 @@ class Swaps extends EventEmitter {
      } else if (deal.state === SwapState.Active) {
        // we check that the deal is still active before we try to settle the invoice
        try {
@@ -67,7 +98,7 @@ index 0018b386..388e1638 100644
          await swapClient.settleInvoice(rHash, rPreimage, currency);
        } catch (err) {
          this.logger.error(`could not settle invoice for deal ${rHash}`, err);
-@@ -747,7 +765,9 @@ class Swaps extends EventEmitter {
+@@ -750,7 +768,9 @@ class Swaps extends EventEmitter {
                } catch (err) {
                  this.logger.error(`could not settle invoice for deal ${rHash}`, err);
                }
@@ -78,7 +109,7 @@ index 0018b386..388e1638 100644
            });
            await settleRetryPromise;
          } else {
-@@ -771,6 +791,16 @@ class Swaps extends EventEmitter {
+@@ -774,6 +794,16 @@ class Swaps extends EventEmitter {
     * accepted, initiates the swap.
     */
    private handleSwapAccepted = async (responsePacket: packets.SwapAcceptedPacket, peer: Peer) => {
@@ -95,7 +126,7 @@ index 0018b386..388e1638 100644
      assert(responsePacket.body, 'SwapAcceptedPacket does not contain a body');
      const { quantity, rHash, makerCltvDelta } = responsePacket.body;
      const deal = this.getDeal(rHash);
-@@ -858,6 +888,11 @@ class Swaps extends EventEmitter {
+@@ -861,6 +891,11 @@ class Swaps extends EventEmitter {
  
      try {
        await makerSwapClient.sendPayment(deal);
@@ -107,7 +138,7 @@ index 0018b386..388e1638 100644
      } catch (err) {
        // first we must handle the edge case where the maker has paid us but failed to claim our payment
        // in this case, we've already marked the swap as having been paid and completed
-@@ -1039,6 +1074,18 @@ class Swaps extends EventEmitter {
+@@ -1042,6 +1077,18 @@ class Swaps extends EventEmitter {
  
        this.logger.debug('Executing maker code to resolve hash');
  
@@ -126,7 +157,7 @@ index 0018b386..388e1638 100644
        const swapClient = this.swapClientManager.get(deal.takerCurrency)!;
  
        // we update the phase persist the deal to the database before we attempt to send payment
-@@ -1049,6 +1096,13 @@ class Swaps extends EventEmitter {
+@@ -1052,6 +1099,13 @@ class Swaps extends EventEmitter {
        assert(deal.state !== SwapState.Error, `cannot send payment for failed swap ${deal.rHash}`);
  
        try {
@@ -140,7 +171,7 @@ index 0018b386..388e1638 100644
          deal.rPreimage = await swapClient.sendPayment(deal);
        } catch (err) {
          this.logger.debug(`sendPayment in resolveHash for swap ${deal.rHash} failed due to ${err.message}`);
-@@ -1126,10 +1180,21 @@ class Swaps extends EventEmitter {
+@@ -1129,10 +1183,22 @@ class Swaps extends EventEmitter {
          }
        }
  
@@ -153,17 +184,18 @@ index 0018b386..388e1638 100644
        // to the database because we don't want to delay claiming the incoming payment
        // using the preimage we've just resolved
 -      this.setDealPhase(deal, SwapPhase.PreimageResolved).catch(this.logger.error);
-+      await this.setDealPhase(deal, SwapPhase.PreimageResolved).catch(this.logger.error);
++      this.setDealPhase(deal, SwapPhase.PreimageResolved).then(() => {
++        if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_AFTER_PREIMAGE_RESOLVED') {
++          this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
++          process.exit();
++        }
++      }).catch(this.logger.error);
 +
-+      if (process.env.CUSTOM_SCENARIO === 'INSTABILITY::MAKER_CRASH_AFTER_SEND_AFTER_PREIMAGE_RESOLVED') {
-+        this.logger.info(`CUSTOM_SCENARIO: ${process.env.CUSTOM_SCENARIO}`);
-+        process.exit();
-+      }
 +
        return deal.rPreimage;
      } else {
        // If we are here we are the taker
-@@ -1137,6 +1202,16 @@ class Swaps extends EventEmitter {
+@@ -1140,6 +1206,16 @@ class Swaps extends EventEmitter {
        assert(htlcCurrency === undefined || htlcCurrency === deal.takerCurrency, 'incoming htlc does not match expected deal currency');
        this.logger.debug('Executing taker code to resolve hash');
  
@@ -180,7 +212,7 @@ index 0018b386..388e1638 100644
        return deal.rPreimage;
      }
    }
-@@ -1305,8 +1380,11 @@ class Swaps extends EventEmitter {
+@@ -1308,8 +1384,11 @@ class Swaps extends EventEmitter {
          swapClient.removeInvoice(deal.rHash).catch(this.logger.error); // we don't need to await the remove invoice call
        }
      } else if (deal.phase === SwapPhase.SendingPayment) {
@@ -194,7 +226,7 @@ index 0018b386..388e1638 100644
      }
  
      this.logger.trace(`emitting swap.failed event for ${deal.rHash}`);
-@@ -1370,9 +1448,14 @@ class Swaps extends EventEmitter {
+@@ -1373,9 +1452,14 @@ class Swaps extends EventEmitter {
  
          if (deal.role === SwapRole.Maker) {
            // the maker begins execution of the swap upon accepting the deal

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -90,7 +90,7 @@ func testMakerCrashedDuringSwap(net *xudtest.NetworkHarness, ht *harnessTest, cu
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerCrashedDuringSwap",
 		Price:    0.02,
 		Quantity: uint64(ltcQuantity),
 		PairId:   "LTC/BTC",
@@ -100,7 +100,7 @@ func testMakerCrashedDuringSwap(net *xudtest.NetworkHarness, ht *harnessTest, cu
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerCrashedDuringSwap",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,
@@ -146,7 +146,7 @@ func testMakerCrashedDuringSwapConnextIn(net *xudtest.NetworkHarness, ht *harnes
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerCrashedDuringSwapConnextIn",
 		Price:    40,
 		Quantity: 100,
 		PairId:   "BTC/ETH",
@@ -156,7 +156,7 @@ func testMakerCrashedDuringSwapConnextIn(net *xudtest.NetworkHarness, ht *harnes
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerCrashedDuringSwapConnextIn",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,
@@ -206,7 +206,7 @@ func testMakerLndCrashedBeforeSettlement(net *xudtest.NetworkHarness, ht *harnes
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerLndCrashedBeforeSettlement",
 		Price:    0.02,
 		Quantity: uint64(ltcQuantity),
 		PairId:   "LTC/BTC",
@@ -216,7 +216,7 @@ func testMakerLndCrashedBeforeSettlement(net *xudtest.NetworkHarness, ht *harnes
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerLndCrashedBeforeSettlement",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,
@@ -279,7 +279,7 @@ func testMakerConnextClientCrashedBeforeSettlement(net *xudtest.NetworkHarness, 
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerConnextClientCrashedBeforeSettlement",
 		Price:    40,
 		Quantity: 100,
 		PairId:   "BTC/ETH",
@@ -289,7 +289,7 @@ func testMakerConnextClientCrashedBeforeSettlement(net *xudtest.NetworkHarness, 
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerConnextClientCrashedBeforeSettlement",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,
@@ -351,7 +351,7 @@ func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht 
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerCrashedAfterSendDelayedSettlement",
 		Price:    0.02,
 		Quantity: uint64(ltcQuantity),
 		PairId:   "LTC/BTC",
@@ -361,7 +361,7 @@ func testMakerCrashedAfterSendDelayedSettlement(net *xudtest.NetworkHarness, ht 
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerCrashedAfterSendDelayedSettlement",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,
@@ -423,7 +423,7 @@ func testMakerCrashedAfterSendDelayedSettlementConnextOut(net *xudtest.NetworkHa
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerCrashedAfterSendDelayedSettlementConnextOut",
 		Price:    40,
 		Quantity: 100,
 		PairId:   "BTC/ETH",
@@ -433,7 +433,7 @@ func testMakerCrashedAfterSendDelayedSettlementConnextOut(net *xudtest.NetworkHa
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerCrashedAfterSendDelayedSettlementConnextOut",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,
@@ -511,7 +511,7 @@ func testMakerCrashedAfterSendDelayedSettlementConnextIn(net *xudtest.NetworkHar
 
 	// Place an order on Alice.
 	aliceOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "maker_order_id",
+		OrderId:  "testMakerCrashedAfterSendDelayedSettlementConnextIn",
 		Price:    40,
 		Quantity: 100,
 		PairId:   "BTC/ETH",
@@ -521,7 +521,7 @@ func testMakerCrashedAfterSendDelayedSettlementConnextIn(net *xudtest.NetworkHar
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
-		OrderId:  "taker_order_id",
+		OrderId:  "testMakerCrashedAfterSendDelayedSettlementConnextIn",
 		Price:    aliceOrderReq.Price,
 		Quantity: aliceOrderReq.Quantity,
 		PairId:   aliceOrderReq.PairId,


### PR DESCRIPTION
Closes #1896. Branched off of and dependant on #1885. WIP for now but this adds functionality to track reserved outbound & inbound balances each time an own order is added to or removed from the order book. Every time an order is added (and reserved amount increases) we check if the inbound capacity for that currency is sufficient to cover all orders. In Connext's case, if it's not sufficient then we make a collateral request to cover all orders +3% (unless we already have a pending collateral request waiting). We don't do anything on the lnd side since lnd can't dynamically increase its inbound capacity (although we could consider doing something like logging a message).

Related to #1584, which can use the reserved amounts that are being tracked in this PR and expose them over rpc.

Tests still need to be updated to mock the new methods that track reserved amounts and/or add test cases for the reserved amount tracking logic.