### PR TITLE
fix(orderbook): don't remove 0 quantity w/ hold

### DIFF
--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -860,12 +860,15 @@ class OrderBook extends EventEmitter {
         throw errors.QUANTITY_ON_HOLD(localId, order.hold);
       }
 
-      this.removeOwnOrder({
-        orderId: order.id,
-        pairId: order.pairId,
-        quantityToRemove: removableQuantity,
-      });
-      remainingQuantityToRemove -= removableQuantity;
+      if (removableQuantity > 0) {
+        // we can remove any portion of the order that's not on hold up front
+        this.removeOwnOrder({
+          orderId: order.id,
+          pairId: order.pairId,
+          quantityToRemove: removableQuantity,
+        });
+        remainingQuantityToRemove -= removableQuantity;
+      }
 
       const failedHandler = (deal: SwapDeal) => {
         if (deal.orderId === order.id) {


### PR DESCRIPTION
This fixes a bug whereby attempting to remove an order that is entirely on hold would throw an error due to trying to remove zero quantity from an order. Instead, if the entire order is on hold we skip removing any portion that is not on hold (since there is none) and wait for the hold to be lifted and remove any quantity.