### PR TITLE
test(sim): connext collateralization with wait

### DIFF
--- a/test/simulation/custom-xud.patch
+++ b/test/simulation/custom-xud.patch
@@ -14,37 +14,6 @@ index 489a50a4..f9391527 100644
      try {
        if (!this.config.rpc.disable) {
          // start rpc server first, it will respond with UNAVAILABLE error
-diff --git a/lib/connextclient/ConnextClient.ts b/lib/connextclient/ConnextClient.ts
-index 7fe05a71..240ad137 100644
---- a/lib/connextclient/ConnextClient.ts
-+++ b/lib/connextclient/ConnextClient.ts
-@@ -309,24 +309,8 @@ class ConnextClient extends SwapClient {
-     }
-   }
- 
--  public setReservedInboundAmount = (reservedInboundAmount: number, currency: string) => {
--    const inboundCapacity = this._maxChannelInboundAmount.get(currency) || 0;
--    if (inboundCapacity < reservedInboundAmount) {
--      // we do not have enough inbound capacity to fill all open orders, so we will request more
--      this.logger.debug(`collateral of ${inboundCapacity} for ${currency} is insufficient for reserved order amount of ${reservedInboundAmount}`);
--
--      // we want to make a request for the current collateral plus the greater of any
--      // minimum request size for the currency or the capacity shortage + 3% buffer
--      const quantityToRequest = inboundCapacity + Math.max(
--        reservedInboundAmount * 1.03 - inboundCapacity,
--        ConnextClient.MIN_COLLATERAL_REQUEST_SIZES[currency] ?? 0,
--      );
--      const unitsToRequest = this.unitConverter.amountToUnits({ currency, amount: quantityToRequest });
--
--      // we don't await this request - instead we allow for "lazy collateralization" to complete since
--      // we don't expect all orders to be filled at once, we can be patient
--      this.requestCollateralInBackground(currency, unitsToRequest);
--    }
-+  public setReservedInboundAmount = (_reservedInboundAmount: number, _currency: string) => {
-+    // we don't request collateral for custom xud simulation tests
-   }
- 
-   protected updateCapacity = async () => {
 diff --git a/lib/swaps/SwapRecovery.ts b/lib/swaps/SwapRecovery.ts
 index 3759f6a3..4089dc94 100644
 --- a/lib/swaps/SwapRecovery.ts

--- a/test/simulation/tests-instability.go
+++ b/test/simulation/tests-instability.go
@@ -154,6 +154,9 @@ func testMakerCrashedDuringSwapConnextIn(net *xudtest.NetworkHarness, ht *harnes
 	}
 	ht.act.placeOrderAndBroadcast(net.Alice, net.Bob, aliceOrderReq)
 
+	// brief wait for collateralization to complete for Alice
+	time.Sleep(1 * time.Second)
+
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
 		OrderId:  "testMakerCrashedDuringSwapConnextIn",
@@ -286,6 +289,9 @@ func testMakerConnextClientCrashedBeforeSettlement(net *xudtest.NetworkHarness, 
 		Side:     xudrpc.OrderSide_SELL,
 	}
 	ht.act.placeOrderAndBroadcast(net.Alice, net.Bob, aliceOrderReq)
+
+	// brief wait for collateralization to complete for Alice
+	time.Sleep(1 * time.Second)
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{
@@ -518,6 +524,9 @@ func testMakerCrashedAfterSendDelayedSettlementConnextIn(net *xudtest.NetworkHar
 		Side:     xudrpc.OrderSide_SELL,
 	}
 	ht.act.placeOrderAndBroadcast(net.Alice, net.Bob, aliceOrderReq)
+
+	// brief wait for collateralization to complete for Alice
+	time.Sleep(1 * time.Second)
 
 	// Place a matching order on Bob.
 	bobOrderReq := &xudrpc.PlaceOrderRequest{


### PR DESCRIPTION
This restores the logic to request collateral in the custom xud builds used for instability tests by adding a one second wait after adding an order on the maker side (who then requests collateralization) but before placing a matching order on the taker side.

This appears to work around a brief, transient inability to send a connext payment to a node immediately after that node requests collateral.

Related PR #1916 - specifically the persistent simulation test failures that were eventually avoided by removing the collateral requests from custom-xud, which is being restored here.