### PR TITLE
feat: derive child seed for swap clients

### DIFF
--- a/lib/nodekey/NodeKey.ts
+++ b/lib/nodekey/NodeKey.ts
@@ -116,8 +116,9 @@ class NodeKey {
   }
 
   /**
-   * Derives a child seed from the private key for the swap client
+   * Derives a child mnemonic seed from the private key for the swap client.
    * @param swapClient the swap client to create the seed for
+   * @returns a BIP39 mnemonic
    */
   public childSeed = (swapClient: SwapClientType) => {
     const privKeyHex = this.privKey.toString('hex');

--- a/lib/utils/seedutil.ts
+++ b/lib/utils/seedutil.ts
@@ -53,6 +53,18 @@ async function decipher(mnemonic: string[]) {
   return Buffer.from(decipheredSeed, 'hex');
 }
 
+async function deriveChild(mnemonic: string[], clientType: string) {
+  const { stdout, stderr } = await exec(`${seedutilPath} derivechild -client ${clientType} ${mnemonic.join(' ')}`);
+
+  if (stderr) {
+    throw new Error(stderr);
+  }
+
+  const childMnenomic = stdout.trim().split(' ');
+  assert.equal(childMnenomic.length, 24, 'seedutil did not derive child mnemonic of exactly 24 words');
+  return childMnenomic;
+}
+
 async function generate() {
   const { stdout, stderr } = await exec(`${seedutilPath} generate`);
 
@@ -65,4 +77,4 @@ async function generate() {
   return mnemonic;
 }
 
-export { keystore, encipher, decipher, generate };
+export { keystore, encipher, decipher, deriveChild, generate };

--- a/seedutil/SeedUtil.spec.ts
+++ b/seedutil/SeedUtil.spec.ts
@@ -143,6 +143,36 @@ describe('SeedUtil generate', () => {
   });
 });
 
+describe('SeedUtil derivechild', () => {
+  test('it errors without a client type', async () => {
+    const cmd = `./seedutil/seedutil derivechild ${VALID_SEED.seedWords.slice(0, 24).join(' ')}`;
+    await expect(executeCommand(cmd))
+      .rejects.toThrow('client is required');
+  });
+
+  test('it errors with 23 words', async () => {
+    const cmd = `./seedutil/seedutil derivechild -client BTC ${VALID_SEED.seedWords.slice(0, 23).join(' ')}`;
+    await expect(executeCommand(cmd))
+      .rejects.toThrow(ERRORS.INVALID_ARGS_LENGTH);
+  });
+
+  test('it succeeds with 24 words, no aezeed password', async () => {
+    const cmd = `./seedutil/seedutil derivechild -client BTC ${VALID_SEED_NO_PASS.seedWords.join(' ')}`;
+    const result = await executeCommand(cmd);
+    // the mnemonic will change each time due to the salt, but the deciphered seed should stay the same
+    const decipherCmd = `./seedutil/seedutil decipher ${result}`;
+    await expect(executeCommand(decipherCmd)).resolves.toMatchSnapshot();
+  });
+
+  test('it succeeds with 24 words, valid aezeed password', async () => {
+    const cmd = `./seedutil/seedutil derivechild -aezeedpass=${VALID_SEED.seedPassword} -client BTC ${VALID_SEED.seedWords.join(' ')}`;
+    const result = await executeCommand(cmd);
+    // the mnemonic will change each time due to the salt, but the deciphered seed should stay the same
+    const decipherCmd = `./seedutil/seedutil decipher -aezeedpass=${VALID_SEED.seedPassword} ${result}`;
+    await expect(executeCommand(decipherCmd)).resolves.toMatchSnapshot();
+  });
+});
+
 describe('SeedUtil keystore', () => {
   beforeEach(async () => {
     await deleteDir(DEFAULT_KEYSTORE_PATH);

--- a/seedutil/__snapshots__/SeedUtil.spec.ts.snap
+++ b/seedutil/__snapshots__/SeedUtil.spec.ts.snap
@@ -10,6 +10,16 @@ exports[`SeedUtil decipher it succeeds with 24 words, valid aezeed password 1`] 
 "
 `;
 
+exports[`SeedUtil derivechild it succeeds with 24 words, no aezeed password 1`] = `
+"000f4b90d9f9720bfac78aaea09a5193b34811
+"
+`;
+
+exports[`SeedUtil derivechild it succeeds with 24 words, valid aezeed password 1`] = `
+"000ecdef333ecf9054ccb4fb843a3dbbf4ac6a
+"
+`;
+
 exports[`SeedUtil encipher it succeeds with 24 words, no aezeed password 1`] = `
 "00738860374692022c462027a35aaaef3c3289aa0a057e2600000000002cad2e2b
 "


### PR DESCRIPTION
This change uses separate mnemonics and seeds for each swap client that are unique to that client, rather than using a single seed and mnemonic across all clients. To accomplish this, a new method is added to the seedutil tool to derive a child mnemonic from a provided mnemonic. This is done by extracting the 16 bytes of entropy from the provided seed, concatenating the entropy with the name of the client (e.g. "LND-BTC") and then hashing the concatenation and taking 16 bytes from the resulting hash.

Closes #1576.