### PR TITLE
feat(cli): case insensitive choices

### DIFF
--- a/lib/cli/commands/addcurrency.ts
+++ b/lib/cli/commands/addcurrency.ts
@@ -16,6 +16,10 @@ export const builder = (argv: Argv) => argv
     description: 'the payment channel network client for swaps',
     type: 'string',
     choices: ['Lnd', 'Connext'],
+    coerce: (swapClientStr: string) => {
+      const swapClientLower = swapClientStr.toLowerCase();
+      return swapClientLower.charAt(0).toUpperCase() + swapClientLower.slice(1);
+    },
   })
   .option('decimal_places', {
     description: 'the places to the right of the decimal point of the smallest subunit (e.g. satoshi)',
@@ -33,6 +37,7 @@ export const handler = async (argv: Arguments<any>) => {
   if (isNaN(argv.decimal_places) || argv.decimal_places >= 100 || argv.decimal_places < 0) {
     throw 'decimal_places must be a number between 0 and 100';
   }
+
   const request = new Currency();
   request.setCurrency(argv.currency.toUpperCase());
   request.setSwapClient(Number(SwapClientType[argv.swap_client]));

--- a/lib/cli/commands/listorders.ts
+++ b/lib/cli/commands/listorders.ts
@@ -91,6 +91,10 @@ export const builder = (argv: Argv) => argv
     describe: 'whether to include own, peer or both orders',
     type: 'string',
     choices: ['Both', 'Own', 'Peer'],
+    coerce: (ownerStr: string) => {
+      const ownerLower = ownerStr.toLowerCase();
+      return ownerLower.charAt(0).toUpperCase() + ownerLower.slice(1);
+    },
     default: 'Both',
   })
   .option('limit', {


### PR DESCRIPTION
This makes commands that have enumerated choices - such as `swap_client` which accepts either `Lnd` or `Connext` - case insensitive in regards to those choices. Previously a value of `lnd` in the example above would throw an error due to an invalid value.