### PR TITLE
fix:incorrect address conversion for connext currencies while adding currencies #1957

### DIFF
--- a/lib/cli/commands/addcurrency.ts
+++ b/lib/cli/commands/addcurrency.ts
@@ -29,6 +29,14 @@ export const builder = (argv: Argv) => argv
   .option('token_address', {
     description: 'the contract address for tokens such as ERC20',
     type: 'string',
+    coerce: (address) => {
+      if (address.startsWith('0x')) {
+        return address;
+      }
+      // yargs converts only number addresses into decimal, so we need to revert it to hexadecimal
+      const hexAddress = address.toString(16);
+      return `0x${hexAddress.padStart(41 - hexAddress.length, '0')}`;
+    },
   })
   .example('$0 addcurrency BTC Lnd', 'add BTC')
   .example('$0 addcurrency ETH Connext 18 0x0000000000000000000000000000000000000000', 'add ETH');


### PR DESCRIPTION
resolves #1957

This was a bug coming from yargs, it was converting only number connext addresses into decimals, instead of letting them stay as hexadecimal so I made a small check and fixed it on coerce method.

This was an easy fix but trickier to find. 