### PR TITLE
fix(connext): not enough balance for closechannel

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -768,7 +768,12 @@ class ConnextClient extends SwapClient {
     if (!currency) {
       throw errors.CURRENCY_MISSING;
     }
-    const amount = units || (await this.getBalance(currency)).freeBalanceOffChain;
+    const { freeBalanceOffChain } = await this.getBalance(currency);
+    const availableUnits = Number(freeBalanceOffChain);
+    if (units && availableUnits < units) {
+      throw errors.INSUFFICIENT_BALANCE;
+    }
+    const amount = units || freeBalanceOffChain;
 
     const withdrawResponse = await this.sendRequest('/withdraw', 'POST', {
       recipient: destination,


### PR DESCRIPTION
This introduces better error handling for Connext when using `closeChannel` to remove funds from a Connext channel and specifying an amount to remove that is greater than the available balance.