### PR TITLE
fix(p2p): don't reconnect peers when pool closed

### DIFF
--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -431,6 +431,11 @@ class Pool extends EventEmitter {
       throw errors.ATTEMPTED_CONNECTION_TO_SELF;
     }
 
+    if (this.disconnecting || !this.connected) {
+      // if we are disconnected or disconnecting, don't make new connections to peers
+      throw errors.POOL_CLOSED;
+    }
+
     // check if we allow connections to tor addresses
     if (!this.config.tor && address.host.indexOf('.onion') !== -1) {
       throw errors.NODE_TOR_ADDRESS(nodePubKey, address);
@@ -972,14 +977,19 @@ class Pool extends EventEmitter {
     peer.active = false;
     this.emit('peer.close', peer.nodePubKey);
 
-    const shouldReconnect =
+    const doesDisconnectionReasonCallForReconnection =
       (peer.sentDisconnectionReason === undefined || peer.sentDisconnectionReason === DisconnectionReason.ResponseStalling) &&
       (peer.recvDisconnectionReason === undefined || peer.recvDisconnectionReason === DisconnectionReason.ResponseStalling ||
        peer.recvDisconnectionReason === DisconnectionReason.AlreadyConnected ||
        peer.recvDisconnectionReason === DisconnectionReason.Shutdown);
     const addresses = peer.addresses || [];
 
-    if (!peer.inbound && peer.nodePubKey && shouldReconnect && (addresses.length || peer.address)) {
+    if (doesDisconnectionReasonCallForReconnection
+      && !peer.inbound // we don't make reconnection attempts to peers that connected to use
+      && peer.nodePubKey // we only reconnect if we know the peer's node pubkey
+      && (addresses.length || peer.address) // we only reconnect if there's an address to connect to
+      && !this.disconnecting && this.connected // we don't reconnect if we're in the process of disconnecting or have disconnected the p2p pool
+    ) {
       this.logger.debug(`attempting to reconnect to a disconnected peer ${peer.label}`);
       const node = { addresses, lastAddress: peer.address, nodePubKey: peer.nodePubKey };
       await this.tryConnectNode(node, true);


### PR DESCRIPTION
This ensures that we don't attempt to reconnect to peers that have disconnected from us after we have started closing the p2p pool. This may help prevent scenarios where we unintentionally attempt to reconnect to peers after shutting down xud.