### PR TITLE
fix(lnd): handling hold invoice check errors

### DIFF
--- a/lib/swaps/SwapClient.ts
+++ b/lib/swaps/SwapClient.ts
@@ -206,7 +206,7 @@ abstract class SwapClient extends EventEmitter {
       case ClientStatus.WaitingUnlock:
       case ClientStatus.OutOfSync:
       case ClientStatus.NoHoldInvoiceSupport:
-        // these statuses can only be set on an operational, initalized client
+        // these statuses can only be set on an operational, initialized client
         validStatusTransition = this.isOperational();
         break;
       case ClientStatus.NotInitialized:
@@ -349,7 +349,7 @@ abstract class SwapClient extends EventEmitter {
    * Returns `true` if the client is enabled and configured properly.
    */
   public isOperational(): boolean {
-    return !this.isDisabled() && !this.isMisconfigured() && !this.isNotInitialized() && !this.hasNoInvoiceSupport();
+    return !this.isDisabled() && !this.isMisconfigured() && !this.isNotInitialized();
   }
   public isDisconnected(): boolean {
     return this.status === ClientStatus.Disconnected;


### PR DESCRIPTION
This adds better error handling for when the test calls to verify lnd hold invoices are available fail due to connectivity reasons. Previously any error that occurred at this step would cause us to set lnd's status to `NoHoldInvoiceSupport` including connection issues. There was also a bug that caused us to try to set the status to connected even when a hold invoice status check failed.

This could result in the unusual behavior of status going to `Disconnected` upon a call failing due to the grpc `UNAVAILABLE` error status, then being set to `NoHoldInvoiceSupport` and then to `ConnectionVerified`. Now we only set `NoHoldInvoiceSupport` when the test calls fail for a reason other than `UNAVAILABLE`, and we only set the status to `ConnectionVerified` when the hold invoice calls succeed.

Closes #1968.