### PR TITLE
fix: use regtest instead of regnet arg

### DIFF
--- a/bin/xud
+++ b/bin/xud
@@ -42,8 +42,8 @@ const { argv } = require('yargs')
       type: 'boolean',
       default: undefined,
     },
-    regnet: {
-      describe: 'Whether to run XUD on regnet',
+    regtest: {
+      describe: 'Whether to run XUD on regtest',
       type: 'boolean',
       default: undefined,
     },


### PR DESCRIPTION
This fixes a bug where the xud flag to set the network was incorrectly configured as `regnet` when it should be `regtest` to match what xud expects.