### PR TITLE
fix(lnd): don't calculate negative capacities

### DIFF
--- a/lib/lndclient/LndClient.ts
+++ b/lib/lndclient/LndClient.ts
@@ -740,13 +740,13 @@ class LndClient extends SwapClient {
     channels.toObject().channelsList.forEach((channel) => {
       if (channel.active) {
         balance += channel.localBalance;
-        const outbound = channel.localBalance - channel.localChanReserveSat;
+        const outbound = Math.max(0, channel.localBalance - channel.localChanReserveSat);
         totalOutboundAmount += outbound;
         if (maxOutbound < outbound) {
           maxOutbound = outbound;
         }
 
-        const inbound = channel.remoteBalance - channel.remoteChanReserveSat;
+        const inbound = Math.max(0, channel.remoteBalance - channel.remoteChanReserveSat);
         totalInboundAmount += inbound;
         if (maxInbound < inbound) {
           maxInbound = inbound;


### PR DESCRIPTION
This fixes a bug in the logic for calculating the inbound & outbound amount/capacity totals. We subtract the channel reserve amounts from the balances when determining how large a payment the channel could support, however we should not end up with a negative number.