### PR TITLE
feat(p2p): Track peers' connection failures and rank accordingly

### DIFF
--- a/lib/db/DB.ts
+++ b/lib/db/DB.ts
@@ -125,7 +125,7 @@ class DB {
   public sequelize: Sequelize;
   public models: Models;
 
-  private static VERSION = 1;
+  private static VERSION = 2;
 
   /**
    * @param storage the file path for the sqlite database file, if ':memory:' or not specified the db is stored in memory

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -20,8 +20,9 @@ migrations[0] = async (sequelize: Sequelize.Sequelize) => {
 };
 
 migrations[1] = async (sequelize: Sequelize.Sequelize) => {
-  await sequelize.getQueryInterface().addColumn('nodes',
-    'consecutiveConnFailures', { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 });
+  await sequelize
+    .getQueryInterface()
+    .addColumn('nodes', 'consecutiveConnFailures', { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 });
 };
 
 export default migrations;

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -19,4 +19,9 @@ migrations[0] = async (sequelize: Sequelize.Sequelize) => {
   });
 };
 
+migrations[1] = async (sequelize: Sequelize.Sequelize) => {
+  await sequelize.getQueryInterface().addColumn('nodes',
+    'consecutiveConnFailures', { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 });
+};
+
 export default migrations;

--- a/lib/db/models/Node.ts
+++ b/lib/db/models/Node.ts
@@ -34,6 +34,7 @@ export default function Node(sequelize: Sequelize) {
       },
     },
     banned: { type: DataTypes.BOOLEAN, allowNull: true },
+    consecutiveConnFailures: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
   };
 
   const indexes: IndexesOptions[] = [

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -83,6 +83,7 @@ export type NodeAttributes = NodeCreationAttributes & {
   addressesText: string;
   lastAddressText: string;
   lastAddress: Address;
+  consecutiveConnFailures: number;
 };
 
 export interface NodeInstance extends Model<NodeAttributes, NodeCreationAttributes>, NodeAttributes {

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -77,7 +77,7 @@ class NodeList extends EventEmitter {
     this.nodes.forEach(callback);
   };
 
-  public rank = (): { primary: NodeInstance[], secondary: NodeInstance[] } => {
+  public rank = (): { primary: NodeInstance[]; secondary: NodeInstance[] } => {
     const primary: NodeInstance[] = [];
     const secondary: NodeInstance[] = [];
 
@@ -93,7 +93,7 @@ class NodeList extends EventEmitter {
       return { primary: secondary, secondary: [] };
     }
     return { primary, secondary };
-  }
+  };
 
   /**
    * Get the internal node id for a given nodePubKey.
@@ -288,7 +288,7 @@ class NodeList extends EventEmitter {
       node.consecutiveConnFailures = node.consecutiveConnFailures + 1;
       await node.save();
     }
-  }
+  };
 
   public resetConsecutiveConnFailures = async (nodePubKey: string) => {
     const node = this.nodes.get(nodePubKey);
@@ -296,7 +296,7 @@ class NodeList extends EventEmitter {
       node.consecutiveConnFailures = 0;
       await node.save();
     }
-  }
+  };
 
   private setBanStatus = (node: NodeInstance, status: boolean) => {
     node.banned = status;

--- a/lib/p2p/NodeList.ts
+++ b/lib/p2p/NodeList.ts
@@ -43,6 +43,9 @@ class NodeList extends EventEmitter {
   private static readonly BAN_THRESHOLD = -50;
   private static readonly MAX_REPUTATION_SCORE = 100;
 
+  private static readonly PRIMARY_PEER_CONN_FAILURES_THRESHOLD = 200;
+  private static readonly SECONDARY_PEER_CONN_FAILURES_THRESHOLD = 1500;
+
   public get count() {
     return this.nodes.size;
   }
@@ -73,6 +76,24 @@ class NodeList extends EventEmitter {
   public forEach = (callback: (node: NodeInstance) => void) => {
     this.nodes.forEach(callback);
   };
+
+  public rank = (): { primary: NodeInstance[], secondary: NodeInstance[] } => {
+    const primary: NodeInstance[] = [];
+    const secondary: NodeInstance[] = [];
+
+    this.nodes.forEach((node) => {
+      if (node.consecutiveConnFailures < NodeList.PRIMARY_PEER_CONN_FAILURES_THRESHOLD) {
+        primary.push(node);
+      } else if (node.consecutiveConnFailures < NodeList.SECONDARY_PEER_CONN_FAILURES_THRESHOLD) {
+        secondary.push(node);
+      }
+    });
+
+    if (primary.length === 0) {
+      return { primary: secondary, secondary: [] };
+    }
+    return { primary, secondary };
+  }
 
   /**
    * Get the internal node id for a given nodePubKey.
@@ -260,6 +281,22 @@ class NodeList extends EventEmitter {
 
     return false;
   };
+
+  public incrementConsecutiveConnFailures = async (nodePubKey: string) => {
+    const node = this.nodes.get(nodePubKey);
+    if (node) {
+      node.consecutiveConnFailures = node.consecutiveConnFailures + 1;
+      await node.save();
+    }
+  }
+
+  public resetConsecutiveConnFailures = async (nodePubKey: string) => {
+    const node = this.nodes.get(nodePubKey);
+    if (node && node.consecutiveConnFailures > 0) {
+      node.consecutiveConnFailures = 0;
+      await node.save();
+    }
+  }
 
   private setBanStatus = (node: NodeInstance, status: boolean) => {
     node.banned = status;

--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -46,6 +46,8 @@ enum PeerStatus {
 }
 
 interface Peer {
+  on(event: 'connect', listener: () => void): this;
+  on(event: 'connFailure', listener: () => void): this;
   on(event: 'packet', listener: (packet: Packet) => void): this;
   on(event: 'reputation', listener: (event: ReputationEvent) => void): this;
   /** Adds a listener to be called when the peer's advertised but inactive pairs should be verified. */
@@ -55,6 +57,7 @@ interface Peer {
   on(event: 'nodeStateUpdate', listener: () => void): this;
   once(event: 'close', listener: () => void): this;
   emit(event: 'connect'): boolean;
+  emit(event: 'connFailure'): boolean;
   emit(event: 'reputation', reputationEvent: ReputationEvent): boolean;
   emit(event: 'close'): boolean;
   emit(event: 'packet', packet: Packet): boolean;
@@ -589,6 +592,8 @@ class Peer extends EventEmitter {
 
       const onError = async (err: Error) => {
         cleanup();
+
+        this.emit('connFailure');
 
         if (!retry) {
           await this.close();

--- a/lib/p2p/Pool.ts
+++ b/lib/p2p/Pool.ts
@@ -81,6 +81,7 @@ class Pool extends EventEmitter {
   /** A collection of known nodes on the XU network. */
   private nodes: NodeList;
   private loadingNodesPromise?: Promise<void>;
+  private secondaryPeersTimeout?: NodeJS.Timeout;
   /** A collection of opened, active peers. */
   private peers = new Map<string, Peer>();
   private server?: Server;
@@ -97,6 +98,9 @@ class Pool extends EventEmitter {
   private nodeKey: NodeKey;
   /** The minimum version of xud we accept for peers */
   private minCompatibleVersion: string;
+
+  /** Secondary peers connection attempt delay. */
+  private static readonly SECONDARY_PEERS_DELAY = 600000; // 10 min
 
   constructor({
     config,
@@ -199,19 +203,35 @@ class Pool extends EventEmitter {
     this.bindNodeList();
 
     this.loadingNodesPromise = this.nodes.load();
-    this.loadingNodesPromise
-      .then(async () => {
-        if (this.nodes.count > 0 && !this.disconnecting) {
-          this.logger.info('Connecting to known / previously connected peers');
-          await this.connectNodes(this.nodes, true, true);
-          this.logger.info('Completed start-up connections to known peers');
-        }
+    this.loadingNodesPromise.then(async () => {
+      if (this.disconnecting) {
         this.loadingNodesPromise = undefined;
-      })
-      .catch((reason) => {
-        this.logger.error('Unexpected error connecting to known peers on startup', reason);
-        this.loadingNodesPromise = undefined;
-      });
+        return;
+      }
+
+      const { primary, secondary } = this.nodes.rank();
+
+      // delay connection attempts to secondary peers - whom we've had trouble connecting to in the past -
+      // to prevent overwhelming xud at startup
+      if (secondary.length > 0) {
+        this.secondaryPeersTimeout = setTimeout(async () => {
+          this.logger.info('Connecting to secondary known / previously connected peers');
+          await this.connectNodes(secondary, true, true);
+          this.logger.info('Completed start-up connections to secondary known peers');
+        }, Pool.SECONDARY_PEERS_DELAY);
+      }
+
+      if (primary.length > 0) {
+        this.logger.info('Connecting to known / previously connected peers');
+        await this.connectNodes(primary, true, true);
+        this.logger.info('Completed start-up connections to known peers');
+      }
+
+      this.loadingNodesPromise = undefined;
+    }).catch((reason) => {
+      this.logger.error('Unexpected error connecting to known peers on startup', reason);
+      this.loadingNodesPromise = undefined;
+    });
 
     this.verifyReachability();
     this.connected = true;
@@ -293,6 +313,11 @@ class Pool extends EventEmitter {
   public disconnect = async (): Promise<void> => {
     if (!this.connected) {
       return;
+    }
+
+    if (this.secondaryPeersTimeout) {
+      clearTimeout(this.secondaryPeersTimeout);
+      this.secondaryPeersTimeout = undefined;
     }
 
     this.disconnecting = true;
@@ -1034,6 +1059,14 @@ class Pool extends EventEmitter {
       if (peer.nodePubKey) {
         await this.addReputationEvent(peer.nodePubKey, event);
       }
+    });
+
+    peer.on('connFailure', async () => {
+      await this.nodes.incrementConsecutiveConnFailures(peer.expectedNodePubKey!);
+    });
+
+    peer.on('connect', async () => {
+      await this.nodes.resetConsecutiveConnFailures(peer.expectedNodePubKey!);
     });
   };
 


### PR DESCRIPTION
Closing https://github.com/ExchangeUnion/xud/issues/1970.

Few remarks:
* The `offline`/`dead` terminology wasn't used. Instead, `consecutiveConnFailure` counter was added to known nodes, and a ranking function which works in accordance with some thresholds. 
* Peer session can fail even if raw connection was successful (in handshake or validation). These failures suppose to affect the peer's reputation. The current ranking function doesn't consider that, but rather only the `consecutiveConnFailure` counter (it's possible to change that).
* `consecutiveConnFailure` cannot be correlated to time, so simpler thresholds (200 & 1500) than what was specified in https://github.com/ExchangeUnion/xud/issues/1970#issuecomment-733626904 were used.
* If no potential peers found in the first threshold (200) group, the second's (1500) group is used. A more sophisticated adjustments can be made, but I just went with the simplest. 
