### PR TITLE
fix(p2p): fix stall timer checks

### DIFF
--- a/lib/p2p/Peer.ts
+++ b/lib/p2p/Peer.ts
@@ -617,7 +617,7 @@ class Peer extends EventEmitter {
   }
 
   private initStall = (): void => {
-    if (this.status !== PeerStatus.Closed) {
+    if (this.status === PeerStatus.Closed) {
       return;
     }
     assert(!this.stallTimer);


### PR DESCRIPTION
This fixes a regression introduced in #1994 that prevents enabling the stall timer for peers that checks whether peers are not responding to our packets in a reasonable timeframe and disconnecting those that are not. Without these checks, peers that have gone offline may remain in the list of connected peers, resulting in unexpected behavior and also preventing those peers from establishing new connections with us once they come back online.

Closes #2010.

I'm also hoping, but can't say for sure, that this fixes the test flakiness case that arose recently described here https://github.com/ExchangeUnion/xud/issues/1771#issuecomment-732289609.