### PR TITLE
fix(rpc): 0 remaining quantity on full remove 

### DIFF
--- a/lib/cli/commands/removeorder.ts
+++ b/lib/cli/commands/removeorder.ts
@@ -26,7 +26,7 @@ const displayOutput = (orderId: string, removeOrderResponse: RemoveOrderResponse
   } else {
     let message = `Order ${orderId} partially removed`;
     if (remainingQuantity) {
-      message += `, ${remainingQuantity} ${removedCurrency} remaining quantity`;
+      message += `, ${satsToCoinsStr(remainingQuantity)} ${removedCurrency} remaining quantity`;
     }
     if (quantityOnHold) {
       message += `, ${satsToCoinsStr(quantityOnHold)} ${removedCurrency} was on hold`;

--- a/lib/cli/commands/removeorder.ts
+++ b/lib/cli/commands/removeorder.ts
@@ -19,14 +19,19 @@ export const builder = (argv: Argv) => argv
   .example('$0 removeorder 79d2cd30-8a26-11ea-90cf-439fb244cf44 0.1', 'remove 0.1 quantity from an order by id');
 
 const displayOutput = (orderId: string, removeOrderResponse: RemoveOrderResponse.AsObject) => {
-  const removedCurrency = removeOrderResponse.pairId.split('/')[0];
-  if (removeOrderResponse.quantityOnHold === 0 && removeOrderResponse.remainingQuantity === 0) {
+  const { remainingQuantity, quantityOnHold, pairId } = removeOrderResponse;
+  const removedCurrency = pairId.split('/')[0];
+  if (quantityOnHold === 0 && remainingQuantity === 0) {
     console.log(`Order ${orderId} successfully removed.`);
   } else {
-    console.log(`
-Order ${orderId} partially removed, remaining quantity: \
-${satsToCoinsStr(removeOrderResponse.remainingQuantity)} ${removedCurrency}, \
-on hold: ${satsToCoinsStr(removeOrderResponse.quantityOnHold)} ${removedCurrency}`);
+    let message = `Order ${orderId} partially removed`;
+    if (remainingQuantity) {
+      message += `, ${remainingQuantity} ${removedCurrency} remaining quantity`;
+    }
+    if (quantityOnHold) {
+      message += `, ${satsToCoinsStr(quantityOnHold)} ${removedCurrency} was on hold`;
+    }
+    console.log(message);
   }
 };
 

--- a/lib/orderbook/OrderBook.ts
+++ b/lib/orderbook/OrderBook.ts
@@ -870,7 +870,9 @@ class OrderBook extends EventEmitter {
    * the order is on hold, an error will be thrown.
    * @param quantityToRemove the quantity to remove from the order, if undefined then the entire
    * order is removed.
-   * @returns any quantity of the order that was on hold and could not be immediately removed (if allowed).
+   * @returns an object summarizing the result of the order removal, including any quantity that
+   * was on hold and could not be immediately removed, the total quantity removed, and the quantity
+   * remaining on the order.
    */
   public removeOwnOrderByLocalId = (localId: string, allowAsyncRemoval?: boolean, quantityToRemove?: number) => {
     const order = this.getOwnOrderByLocalId(localId);

--- a/lib/orderbook/TradingPair.ts
+++ b/lib/orderbook/TradingPair.ts
@@ -262,6 +262,8 @@ class TradingPair extends EventEmitter {
     if (isOwnOrder(order)) {
       assert(order.hold === 0, 'cannot remove an order with a hold');
     }
+    const startingQuantity = order.quantity;
+    order.quantity = 0;
     const map = order.isBuy ? maps.buyMap : maps.sellMap;
     map.delete(order.id);
 
@@ -271,7 +273,7 @@ class TradingPair extends EventEmitter {
     }
 
     this.logger.trace(`order removed: ${orderId}`);
-    return { order: order as T, fullyRemoved: true };
+    return { order: { ...order, quantity: startingQuantity } as T, fullyRemoved: true };
   }
 
   private getOrderMap = (order: Order): OrderMap<Order> | undefined => {


### PR DESCRIPTION
This fixes a bug where fully removing an order via `RemoveOrder` would return the entire quantity of the order as the remaining quantity instead of zero. The problem was that when removing a quantity in full, we would simply delete it from our collection of orders but not modify its quantity, which is used (since #1986) for informational purposes on the rpc response.

It also tidies up the cli output a bit so as not to display zero amounts for holds or remaining quantity.

Fixes #2020