### PR TITLE
fix: connext status shouldn't show Ready unless connection verified

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -786,13 +786,15 @@ class ConnextClient extends SwapClient {
   public getInfo = async (): Promise<ConnextInfo> => {
     let address: string | undefined;
     let version: string | undefined;
-    let status = errors.CONNEXT_CLIENT_NOT_INITIALIZED.message;
+    let status: string;
     if (this.isDisabled()) {
       status = errors.CONNEXT_IS_DISABLED.message;
-    } else {
+    } else if (this.isConnected()) {
       status = 'Ready';
       version = 'TODO: Not exposed, yet';
       address = this.channelAddress || 'Waiting for channel';
+    } else {
+      status = ClientStatus[this.status];
     }
 
     return { status, address, version };


### PR DESCRIPTION
resolves #2038 

- I'm still unable to access connext and it was still showing ready, so since it's not really much to do to fix this, I decided to take this one.

Can you please check?