### PR TITLE
fix(connext): fix ethprovider network name

### DIFF
--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -66,7 +66,7 @@ const getRouterNodeIdentifier = (network: string): string => {
       return 'vector5yw6vEx4VJPWMC4Vf48WSfY4bzgfJxAt4EGGFGT1o1mmQnRz35';
     case 'testnet':
       // public key of our testnet router node
-      return 'vector6XKj2XPrVEYfTEdxEjgVVnFCtZVXa4RrfzQLiXpjfcj4GJMdpR';
+      return 'vector6Y5JHqC9z6HyZ6kD9SuPMiNrdRVts4un3ekMsdso21oJkZ9vHh';
     case 'mainnet':
       throw new Error('mainnet router node has not been created, yet');
     default:

--- a/lib/connextclient/ConnextClient.ts
+++ b/lib/connextclient/ConnextClient.ts
@@ -212,7 +212,7 @@ class ConnextClient extends SwapClient {
   // Related issue: https://github.com/ExchangeUnion/xud/issues/1494
   public setSeed = (seed: string) => {
     this.seed = seed;
-    this.ethProvider = getEthprovider(this.host, this.port, this.network, CHAIN_IDENTIFIERS[this.network], this.seed);
+    this.ethProvider = getEthprovider(this.host, this.port, CHAIN_IDENTIFIERS[this.network], this.seed);
   };
 
   public initConnextClient = async (seedMnemonic: string) => {

--- a/lib/connextclient/ethprovider.ts
+++ b/lib/connextclient/ethprovider.ts
@@ -6,9 +6,7 @@ import { mergeMap } from 'rxjs/operators';
 
 // gets the Ethereum provider object to read data from the chain
 const getProvider = (host: string, port: number, chainId: number): ethers.providers.JsonRpcProvider => {
-  return new ethers.providers.JsonRpcProvider(
-    { url: `http://${host}:${port}/ethprovider/${chainId}` },
-  );
+  return new ethers.providers.JsonRpcProvider({ url: `http://${host}:${port}/ethprovider/${chainId}` });
 };
 
 // gets the signer object necessary for write access (think unlock wallet)

--- a/lib/connextclient/ethprovider.ts
+++ b/lib/connextclient/ethprovider.ts
@@ -5,13 +5,9 @@ import { mergeMap } from 'rxjs/operators';
 // This file will be a separate module with the above dependencies.
 
 // gets the Ethereum provider object to read data from the chain
-const getProvider = (host: string, port: number, name: string, chainId: number): ethers.providers.JsonRpcProvider => {
+const getProvider = (host: string, port: number, chainId: number): ethers.providers.JsonRpcProvider => {
   return new ethers.providers.JsonRpcProvider(
     { url: `http://${host}:${port}/ethprovider/${chainId}` },
-    {
-      name,
-      chainId,
-    },
   );
 };
 
@@ -85,9 +81,9 @@ const getERC20Balance = curry(
 // This is the main function that has to be called before this package exposes more functions.
 // Think of it as a constructor where we create the interal state of the module before
 // we export more functionality to the consumer.
-const getEthprovider = (host: string, port: number, name: string, chainId: number, seed: string) => {
+const getEthprovider = (host: string, port: number, chainId: number, seed: string) => {
   // create the internal state
-  const provider = getProvider(host, port, name, chainId);
+  const provider = getProvider(host, port, chainId);
   const signer = getSigner(provider, seed);
   // because the functions below are curried we can only provide some of the arguments
   const getERC20BalanceWithSigner = getERC20Balance(signer.address);


### PR DESCRIPTION
This PR ensures that we pass in `rinkeby` as the network name when running in testnet mode. Otherwise `ethers.providers.JsonRpcProvider` would fail to initialize.

Can be tested using https://github.com/ExchangeUnion/xud-docker/pull/819